### PR TITLE
M1: Task post-report raw capture (#1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,31 +1,45 @@
 # ══════════════════════════════════════════════════════════════
-# Agent Zero + Docker 환경 변수 설정
+#  Agent Zero + Docker 환경 변수
 # ══════════════════════════════════════════════════════════════
-# 사용할 LLM 프로바이더에 따라 아래 섹션 중 하나를 선택하세요.
-# settings.json 의 provider 설정과 반드시 일치해야 합니다.
+#  사용법: 이 파일을 `.env` 로 복사 후, 아래 3개 섹션을 채우세요.
+#    1) LLM 프로바이더 — A/B/C 중 하나 선택해서 주석 해제
+#    2) Git           — GitHub 푸시 자동화 (필수)
+#    3) Telegram      — 양방향 알림/지시 (필수)
+# ══════════════════════════════════════════════════════════════
 
 
-# ── Option A: Anthropic API (권장) ──────────────────────────
-# 공식 API. 프롬프트 캐싱 자동 적용, 약관 리스크 없음.
-# settings.json: "chat_model_provider": "anthropic"
+# ══════════════════════════════════════════════════════════════
+#  1) LLM 프로바이더  (A · B · C 중 택 1)
+# ══════════════════════════════════════════════════════════════
+#  선택한 옵션과 settings.json 의 "chat_model_provider" 값이
+#  반드시 일치해야 합니다.
+
+
+# ── Option A: Anthropic API  ★ 권장 ─────────────────────────
+#   공식 API · 프롬프트 캐싱 자동 적용 · 약관 리스크 없음
+#   settings.json → "chat_model_provider": "anthropic"
 #
 # ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
 #
-# 비용 참고 (2026-04 기준):
-#   Claude Sonnet 4:  입력 $3/M, 출력 $15/M, 캐시읽기 $0.30/M (90% 할인)
-#   Claude Haiku 3.5: 입력 $0.80/M, 출력 $4/M, 캐시읽기 $0.08/M (90% 할인)
-#   → 프롬프트 캐싱으로 반복 호출 시 입력 비용 대폭 절감
+#   비용 (2026-04 기준, 단위: per 1M tokens)
+#   ┌──────────────────┬────────┬────────┬──────────────┐
+#   │ 모델             │ 입력   │ 출력   │ 캐시읽기(-90%)│
+#   ├──────────────────┼────────┼────────┼──────────────┤
+#   │ Claude Sonnet 4  │ $3.00  │ $15.00 │ $0.30        │
+#   │ Claude Haiku 3.5 │ $0.80  │ $ 4.00 │ $0.08        │
+#   └──────────────────┴────────┴────────┴──────────────┘
+#   → 반복 호출 시 프롬프트 캐싱으로 입력 비용 대폭 절감
 
 
 # ── Option B: OpenAI API ────────────────────────────────────
-# settings.json: "chat_model_provider": "openai"
+#   settings.json → "chat_model_provider": "openai"
 #
 # OPENAI_API_KEY=sk-your-openai-key-here
 
 
-# ── Option C: CLIProxy (구독 우회) ──────────────────────────
-# ⚠️ 약관 위반 리스크. 테스트/개인용으로만 사용 권장.
-# settings.json: "chat_model_provider": "other"
+# ── Option C: CLIProxy (구독 우회)  ⚠️ 비권장 ───────────────
+#   약관 위반 리스크 · 테스트/개인용으로만 사용
+#   settings.json → "chat_model_provider": "other"
 #
 # OPENAI_API_KEY=sk-placeholder
 # CHAT_MODEL_BASE_URL=http://cliproxy:8317/v1
@@ -34,11 +48,23 @@
 # UTILITY_API_KEY=sk-placeholder
 
 
-# ── Git Configuration (Agent Zero 컨테이너 내 git push 자동화) ──
+# ══════════════════════════════════════════════════════════════
+#  2) Git  (필수)
+# ══════════════════════════════════════════════════════════════
+#  Agent Zero 컨테이너 내부에서 git commit/push 에 사용됩니다.
+#  GITHUB_TOKEN 은 repo 스코프의 Personal Access Token.
+
 GIT_USER_NAME=your-github-username
 GIT_USER_EMAIL=your-email@example.com
 GITHUB_TOKEN=ghp_your_personal_access_token
 
-# ── Telegram Bot (알림 + 양방향 지시) ──
+
+# ══════════════════════════════════════════════════════════════
+#  3) Telegram  (필수)
+# ══════════════════════════════════════════════════════════════
+#  양방향 알림 + 원격 지시용 봇 설정입니다.
+#  BOT_TOKEN  : @BotFather 에서 발급
+#  CHAT_ID    : 본인 계정 또는 그룹 ID
+
 TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 TELEGRAM_CHAT_ID=123456789

--- a/agent-zero/extensions/python/chat_model_call_after/_50_task_report_llm.py
+++ b/agent-zero/extensions/python/chat_model_call_after/_50_task_report_llm.py
@@ -1,0 +1,12 @@
+"""
+Record an LLM call (model, tokens, cache reads) after each chat completion.
+See agent-zero/lib/task_report.py and issue #1.
+"""
+
+from helpers.extension import Extension
+from helpers.task_report import llm_call
+
+
+class TaskReportLLM(Extension):
+    async def execute(self, call_data=None, response=None, **kwargs):
+        llm_call(self.agent, call_data, response)

--- a/agent-zero/extensions/python/message_loop_start/_50_task_report_iter.py
+++ b/agent-zero/extensions/python/message_loop_start/_50_task_report_iter.py
@@ -1,0 +1,14 @@
+"""
+Update iteration count on each message_loop_start tick.
+See agent-zero/lib/task_report.py and issue #1.
+"""
+
+from helpers.extension import Extension
+from helpers.task_report import record_iteration
+
+
+class TaskReportIter(Extension):
+    async def execute(self, loop_data=None, **kwargs):
+        if loop_data is None:
+            return
+        record_iteration(self.agent, getattr(loop_data, "iteration", 0))

--- a/agent-zero/extensions/python/monologue_end/_50_task_report_finish.py
+++ b/agent-zero/extensions/python/monologue_end/_50_task_report_finish.py
@@ -1,0 +1,15 @@
+"""
+Finalize the task report and write JSON to /a0/logs/tasks/<task_id>.json.
+
+NOTE: monologue_end is skipped on cancel/kill — a fallback via the implicit
+@extensible hook (_functions/agent/Agent/monologue/end) is left for a
+follow-up. See issue #1.
+"""
+
+from helpers.extension import Extension
+from helpers.task_report import finish_task
+
+
+class TaskReportFinish(Extension):
+    async def execute(self, **kwargs):
+        finish_task(self.agent)

--- a/agent-zero/extensions/python/monologue_start/_50_task_report_begin.py
+++ b/agent-zero/extensions/python/monologue_start/_50_task_report_begin.py
@@ -1,0 +1,12 @@
+"""
+Begin a task report on monologue_start.
+See agent-zero/lib/task_report.py and issue #1.
+"""
+
+from helpers.extension import Extension
+from helpers.task_report import begin_task
+
+
+class TaskReportBegin(Extension):
+    async def execute(self, **kwargs):
+        begin_task(self.agent)

--- a/agent-zero/extensions/python/tool_execute_after/_50_task_report_tool_end.py
+++ b/agent-zero/extensions/python/tool_execute_after/_50_task_report_tool_end.py
@@ -1,0 +1,12 @@
+"""
+Record tool call duration, result size, and break_loop after tool.execute().
+See agent-zero/lib/task_report.py and issue #1.
+"""
+
+from helpers.extension import Extension
+from helpers.task_report import tool_end
+
+
+class TaskReportToolEnd(Extension):
+    async def execute(self, tool_name="", response=None, **kwargs):
+        tool_end(self.agent, tool_name, response)

--- a/agent-zero/extensions/python/tool_execute_before/_50_task_report_tool_start.py
+++ b/agent-zero/extensions/python/tool_execute_before/_50_task_report_tool_start.py
@@ -1,0 +1,12 @@
+"""
+Stash tool call start time and args hash before tool.execute().
+See agent-zero/lib/task_report.py and issue #1.
+"""
+
+from helpers.extension import Extension
+from helpers.task_report import tool_start
+
+
+class TaskReportToolStart(Extension):
+    async def execute(self, tool_name="", tool_args=None, **kwargs):
+        tool_start(self.agent, tool_name, tool_args or {})

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -1,0 +1,185 @@
+"""
+Task-level instrumentation for Agent Zero monologues.
+
+Captures profile, skills, tool calls, LLM calls, and iterations during a
+single monologue() invocation, then writes a JSON file to
+/a0/logs/tasks/<task_id>.json on monologue_end.
+
+This is M1 of the task post-report system — raw capture only, no analysis
+or reporting yet. See https://github.com/devyoon91/az-cliproxy-docker/issues/1
+
+Mounted into the container at /a0/python/helpers/task_report.py so that
+extension files can `from helpers.task_report import ...`.
+"""
+
+import hashlib
+import json
+import logging
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+TASKS_DIR = Path("/a0/logs/tasks")
+DATA_KEY = "task_report"
+PENDING_TOOL_KEY = "task_report_pending_tools"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_task_id() -> str:
+    return f"task-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:6]}"
+
+
+def _args_hash(args) -> str:
+    try:
+        canon = json.dumps(args, sort_keys=True, default=str, ensure_ascii=False)
+    except Exception:
+        canon = repr(args)
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()[:12]
+
+
+def _preview(args, max_len: int = 120) -> str:
+    try:
+        s = json.dumps(args, ensure_ascii=False, default=str)
+    except Exception:
+        s = repr(args)
+    return s if len(s) <= max_len else s[:max_len] + "…"
+
+
+def begin_task(agent) -> dict:
+    """Initialize a fresh report blob on agent.data. Called from monologue_start."""
+    skills = agent.data.get("loaded_skills") or []
+    profile = getattr(getattr(agent, "config", None), "profile", None)
+    report = {
+        "task_id": _new_task_id(),
+        "started_at": _now_iso(),
+        "started_ts": time.time(),
+        "agent_name": getattr(agent, "agent_name", None),
+        "agent_number": getattr(agent, "number", None),
+        "profile": profile,
+        "skills_loaded": list(skills),
+        "iterations": 0,
+        "llm_calls": [],
+        "tool_calls": [],
+    }
+    agent.data[DATA_KEY] = report
+    agent.data[PENDING_TOOL_KEY] = {}
+    logger.info(
+        f"[task_report] begin {report['task_id']} profile={profile} skills={len(skills)}"
+    )
+    return report
+
+
+def get_report(agent):
+    return agent.data.get(DATA_KEY)
+
+
+def record_iteration(agent, iteration) -> None:
+    r = get_report(agent)
+    if r is None:
+        return
+    try:
+        r["iterations"] = max(r["iterations"], int(iteration or 0))
+    except (TypeError, ValueError):
+        pass
+
+
+def tool_start(agent, tool_name: str, tool_args) -> None:
+    pending = agent.data.get(PENDING_TOOL_KEY)
+    if pending is None:
+        return
+    pending[tool_name] = {
+        "name": tool_name,
+        "args_hash": _args_hash(tool_args),
+        "args_preview": _preview(tool_args),
+        "started_at": _now_iso(),
+        "_started_ts": time.time(),
+    }
+
+
+def tool_end(agent, tool_name: str, response) -> None:
+    r = get_report(agent)
+    pending = agent.data.get(PENDING_TOOL_KEY)
+    if r is None or pending is None:
+        return
+    entry = pending.pop(tool_name, None) or {"name": tool_name}
+    end_ts = time.time()
+    msg = getattr(response, "message", "") if response is not None else ""
+    if not isinstance(msg, str):
+        msg = str(msg) if msg is not None else ""
+    started_ts = entry.pop("_started_ts", end_ts)
+    entry.update({
+        "ended_at": _now_iso(),
+        "duration_ms": round((end_ts - started_ts) * 1000, 1),
+        "result_size": len(msg),
+        "break_loop": bool(getattr(response, "break_loop", False)) if response is not None else False,
+    })
+    r["tool_calls"].append(entry)
+
+
+def llm_call(agent, call_data, response) -> None:
+    r = get_report(agent)
+    if r is None:
+        return
+    model = None
+    if isinstance(call_data, dict):
+        model = call_data.get("model")
+    usage = getattr(response, "usage", None) if response is not None else None
+    input_tokens = 0
+    output_tokens = 0
+    cache_read = 0
+    if usage is not None:
+        input_tokens = getattr(usage, "prompt_tokens", 0) or 0
+        output_tokens = getattr(usage, "completion_tokens", 0) or 0
+        details = getattr(usage, "prompt_tokens_details", None)
+        if details is not None:
+            cache_read = getattr(details, "cached_tokens", 0) or 0
+    r["llm_calls"].append({
+        "at": _now_iso(),
+        "model": model,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_read_tokens": cache_read,
+    })
+
+
+def finish_task(agent) -> dict | None:
+    """Finalize report and write to disk. Called from monologue_end.
+
+    NOTE: monologue_end is skipped on cancel/kill. A fallback via the implicit
+    @extensible hook (_functions/agent/Agent/monologue/end) is left for a
+    follow-up — see issue #1.
+    """
+    r = get_report(agent)
+    if r is None:
+        return None
+    r["ended_at"] = _now_iso()
+    started_ts = r.pop("started_ts", time.time())
+    r["elapsed_sec"] = round(time.time() - started_ts, 3)
+    r["totals"] = {
+        "tool_calls": len(r["tool_calls"]),
+        "llm_calls": len(r["llm_calls"]),
+        "input_tokens": sum(c["input_tokens"] for c in r["llm_calls"]),
+        "output_tokens": sum(c["output_tokens"] for c in r["llm_calls"]),
+        "cache_read_tokens": sum(c["cache_read_tokens"] for c in r["llm_calls"]),
+    }
+    try:
+        TASKS_DIR.mkdir(parents=True, exist_ok=True)
+        path = TASKS_DIR / f"{r['task_id']}.json"
+        path.write_text(json.dumps(r, ensure_ascii=False, indent=2), encoding="utf-8")
+        logger.info(
+            f"[task_report] wrote {path} "
+            f"(tools={r['totals']['tool_calls']} llm={r['totals']['llm_calls']} "
+            f"iter={r['iterations']} elapsed={r['elapsed_sec']}s)"
+        )
+    except Exception as e:
+        logger.warning(f"[task_report] write failed: {e}")
+    finally:
+        agent.data.pop(DATA_KEY, None)
+        agent.data.pop(PENDING_TOOL_KEY, None)
+    return r

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,14 @@ services:
       - ./agent-zero/prompts:/a0/prompts
       - ./agent-zero/git-init.sh:/a0/git-init.sh:ro
       - ./agent-zero/extensions/python/agent_init/_90_usage_tracker.py:/a0/extensions/python/agent_init/_90_usage_tracker.py:ro
+      # Task post-report system (M1: raw capture) — issue #1
+      - ./agent-zero/lib/task_report.py:/a0/python/helpers/task_report.py:ro
+      - ./agent-zero/extensions/python/monologue_start/_50_task_report_begin.py:/a0/extensions/python/monologue_start/_50_task_report_begin.py:ro
+      - ./agent-zero/extensions/python/message_loop_start/_50_task_report_iter.py:/a0/extensions/python/message_loop_start/_50_task_report_iter.py:ro
+      - ./agent-zero/extensions/python/tool_execute_before/_50_task_report_tool_start.py:/a0/extensions/python/tool_execute_before/_50_task_report_tool_start.py:ro
+      - ./agent-zero/extensions/python/tool_execute_after/_50_task_report_tool_end.py:/a0/extensions/python/tool_execute_after/_50_task_report_tool_end.py:ro
+      - ./agent-zero/extensions/python/chat_model_call_after/_50_task_report_llm.py:/a0/extensions/python/chat_model_call_after/_50_task_report_llm.py:ro
+      - ./agent-zero/extensions/python/monologue_end/_50_task_report_finish.py:/a0/extensions/python/monologue_end/_50_task_report_finish.py:ro
       - ./agent-zero/settings.json:/a0/tmp/settings.json
     entrypoint: ["/bin/sh", "-c", "sh /a0/git-init.sh && exec /exe/initialize.sh ${BRANCH:-main}"]
     depends_on:


### PR DESCRIPTION
Closes part of #1 — **M1 마일스톤 (raw 캡처)**.

## 요약

Agent Zero monologue 단위로 사후 분석할 수 있는 raw 데이터 수집 인프라를
넣었습니다. 6개 lifecycle hook + 1개 공유 헬퍼 모듈로 구성.

분석/보고서/Loop 감지는 다음 마일스톤(M2~M3)에서 진행합니다.

## 변경

| 파일 | 역할 |
|---|---|
| `agent-zero/lib/task_report.py` | 공유 헬퍼 — 캡처/저장 로직 |
| `extensions/python/monologue_start/_50_task_report_begin.py` | task_id 발급, profile/skills 스냅샷 |
| `extensions/python/message_loop_start/_50_task_report_iter.py` | iteration 카운트 |
| `extensions/python/tool_execute_before/_50_task_report_tool_start.py` | tool 호출 시작 시각/args hash |
| `extensions/python/tool_execute_after/_50_task_report_tool_end.py` | duration, result_size, break_loop |
| `extensions/python/chat_model_call_after/_50_task_report_llm.py` | model, in/out/cache_read 토큰 |
| `extensions/python/monologue_end/_50_task_report_finish.py` | totals 집계 + JSON 저장 |
| `docker-compose.yml` | 위 7개 파일을 컨테이너에 마운트 |

## 출력 형식

`/a0/logs/tasks/<task_id>.json` (호스트: `agent-zero/logs/tasks/`):

```json
{
  "task_id": "task-20260417-153012-a1b2c3",
  "started_at": "2026-04-17T...",
  "ended_at": "2026-04-17T...",
  "elapsed_sec": 12.345,
  "profile": "researcher",
  "skills_loaded": ["claude-api", "schedule"],
  "iterations": 4,
  "llm_calls": [{"model": "...", "input_tokens": 1234, "output_tokens": 56, "cache_read_tokens": 1000}],
  "tool_calls": [{"name": "code_execution", "args_hash": "abc123", "duration_ms": 234.5, "result_size": 1024, "break_loop": false}],
  "totals": {"tool_calls": 5, "llm_calls": 4, "input_tokens": 5000, "output_tokens": 200, "cache_read_tokens": 4000}
}
```

## 결정한 것 (이슈 미정 사항 중)

- **task_id 형식**: `task-YYYYMMDD-HHMMSS-{6-hex}` — 사람이 읽고 정렬 가능
- **저장 위치**: `agent-zero/logs/tasks/` (이미 `.gitignore`에 `agent-zero/logs/` 포함됨)
- **비용 데이터**: M1에서는 토큰만 수집. 비용 계산은 M3에서 litellm.completion_cost 사용 검토

## 알려진 갭 (M2+ 또는 별도 이슈)

- `monologue_end`는 cancel/kill 시 skip됨 → `_functions/agent/Agent/monologue/end` 암시적 훅 fallback 필요
- 보관 기간/로테이션 정책 미정
- Telegram 푸시 끄기 옵션 미구현 (M3에서 함께)

## 테스트 계획

- [ ] `docker-compose up -d` 후 컨테이너 재시작
- [ ] `agent-zero/logs/agent-zero.log`에서 `[task_report] begin ...` 로그 확인
- [ ] Agent Zero에 간단한 task 한 번 던지고 `agent-zero/logs/tasks/` 디렉토리에 JSON 생성 확인
- [ ] JSON 내용에 profile/skills/tool_calls/llm_calls 필드 채워졌는지 확인
- [ ] task 중간에 cancel 했을 때 동작 (skip 확인 후 M2 fallback 작업으로 연결)

🤖 Generated with [Claude Code](https://claude.com/claude-code)