### PR TITLE
chore: add missing skills.relevant.md prompt template

### DIFF
--- a/agent-zero/prompts/agent.system.skills.relevant.md
+++ b/agent-zero/prompts/agent.system.skills.relevant.md
@@ -1,0 +1,5 @@
+# relevant skills
+- the following skills matched the user's current request by lexical search, including trigger phrases
+- use `skills_tool:load` to load one before following it
+
+{{skills}}


### PR DESCRIPTION
## 요약

Agent Zero v1.9는 `agent.system.skills.md` / `.loaded.md` / `.relevant.md` 세 파일 세트로 스킬 프롬프트를 구성합니다. `.relevant.md` 만 추적 안 되고 있어 런타임에 Agent Zero가 파일을 못 찾고 폴백 → 렉시컬 스킬 매칭 출력이 비어 있었음.

## 변경

[agent-zero/prompts/agent.system.skills.relevant.md](agent-zero/prompts/agent.system.skills.relevant.md) — 5-line Jinja 템플릿 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)