### PR TITLE
fix(compose): mount settings.json at v1.9 location /a0/usr/

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - ./agent-zero/extensions/python/tool_execute_after/_50_task_report_tool_end.py:/a0/extensions/python/tool_execute_after/_50_task_report_tool_end.py:ro
       - ./agent-zero/extensions/python/chat_model_call_after/_50_task_report_llm.py:/a0/extensions/python/chat_model_call_after/_50_task_report_llm.py:ro
       - ./agent-zero/extensions/python/monologue_end/_50_task_report_finish.py:/a0/extensions/python/monologue_end/_50_task_report_finish.py:ro
-      - ./agent-zero/settings.json:/a0/tmp/settings.json
+      - ./agent-zero/settings.json:/a0/usr/settings.json
     entrypoint: ["/bin/sh", "-c", "sh /a0/git-init.sh && exec /exe/initialize.sh ${BRANCH:-main}"]
     depends_on:
       cliproxy:


### PR DESCRIPTION
## 요약

Agent Zero v1.9가 settings 경로를 `/a0/tmp/` → `/a0/usr/` 로 옮겼는데, migration이 bind mount된 파일을 `os.rename()` 하려다 **"Device or resource busy"** 로 크래시합니다. 마운트 대상을 새 위치로 직접 바꾸면 migration이 소스 파일을 못 찾고 스킵.

## 배경

이 fix는 **원래 PR #2 (M1) 에 포함돼 있던 커밋 `3a94e4c`** 였으나, 머지 과정에서 빠져 main에 반영되지 않았습니다. 동일 패턴의 선행 fix가 [`8eea7dd`](https://github.com/devyoon91/az-cliproxy-docker/commit/8eea7dd) (profile 경로) 에 있었음.

현재 상태에서는 settings.json이 호스트에 실제 파일로 존재해서 첫 기동은 되지만, **`docker-compose down` → `up` 사이클에서 migration 재실행 시 다시 크래시** 위험이 있음.

## 변경

[docker-compose.yml](docker-compose.yml) 1줄:

```diff
- - ./agent-zero/settings.json:/a0/tmp/settings.json
+ - ./agent-zero/settings.json:/a0/usr/settings.json
```

## 검증

병합 후:
```bash
docker-compose down
docker-compose up -d
docker-compose logs agent-zero | grep -iE "migration|traceback"
```
크래시 없이 정상 기동되면 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)