### PR TITLE
fix(compose): M1 task_report.py mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - ./agent-zero/git-init.sh:/a0/git-init.sh:ro
       - ./agent-zero/extensions/python/agent_init/_90_usage_tracker.py:/a0/extensions/python/agent_init/_90_usage_tracker.py:ro
       # Task post-report system (M1: raw capture) — issue #1
-      - ./agent-zero/lib/task_report.py:/a0/python/helpers/task_report.py:ro
+      - ./agent-zero/lib/task_report.py:/a0/helpers/task_report.py:ro
       - ./agent-zero/extensions/python/monologue_start/_50_task_report_begin.py:/a0/extensions/python/monologue_start/_50_task_report_begin.py:ro
       - ./agent-zero/extensions/python/message_loop_start/_50_task_report_iter.py:/a0/extensions/python/message_loop_start/_50_task_report_iter.py:ro
       - ./agent-zero/extensions/python/tool_execute_before/_50_task_report_tool_start.py:/a0/extensions/python/tool_execute_before/_50_task_report_tool_start.py:ro


### PR DESCRIPTION
Closes #6.

## 요약

M1 에서 `task_report.py` 를 `/a0/python/helpers/` 로 마운트했는데 Agent Zero 의 helpers 패키지는 `/a0/helpers/` 아래 있음. `from helpers.task_report import ...` 전부 `ModuleNotFoundError`로 터져서 M1 raw capture 가 **M1 머지 이후 한 번도 동작하지 않았음**.

## 변경

1줄:

```diff
- - ./agent-zero/lib/task_report.py:/a0/python/helpers/task_report.py:ro
+ - ./agent-zero/lib/task_report.py:/a0/helpers/task_report.py:ro
```

## 검증

머지 후:
```bash
docker-compose down && docker-compose up -d
docker exec agent-zero /opt/venv-a0/bin/python -c "from helpers.task_report import begin_task; print('OK')"
```
`OK` 찍히면 완료. 그 다음 UI 에서 task 던지면 `agent-zero/logs/tasks/*.json` 생성됨.