### PR TITLE
fix(settings): util_model_name 오타 — claude-haiku-3.5-sonnet → claude-haiku-4-5

### DIFF
--- a/agent-zero/settings.example.json
+++ b/agent-zero/settings.example.json
@@ -15,7 +15,7 @@
     "chat_model_rl_input": 0,
     "chat_model_rl_output": 0,
     "util_model_provider": "anthropic",
-    "util_model_name": "claude-haiku-3.5-sonnet",
+    "util_model_name": "claude-haiku-4-5",
     "util_model_api_base": "",
     "util_model_ctx_length": 100000,
     "util_model_ctx_input": 0.7,


### PR DESCRIPTION
Closes #7.

## 요약

`settings.example.json` 의 `util_model_name` 이 `claude-haiku-3.5-sonnet` 로 되어 있었음. 두 가지 오타:
1. `.` → `-` 이어야 함 (Anthropic 모델 ID 는 하이픈 구분)
2. `-sonnet` 접미사가 Haiku 모델에 붙을 수 없음 (별도 패밀리)

CLIProxy 경유 땐 느슨히 무시됐지만 Anthropic 직접 호출 모드로 전환하면서 util model 호출 (memorize_memories, rename_chat 등) 전부 `NotFoundError` 로 터짐.

## 변경

```diff
- "util_model_name": "claude-haiku-3.5-sonnet",
+ "util_model_name": "claude-haiku-4-5",
```

chat_model 이 `claude-sonnet-4-6` 이니 같은 세대 Haiku 4.5 로 정렬.

## 기존 사용자 대응

`settings.json` 은 gitignored — 이 PR 자동으로 전파 안됨. 각자 수동 업데이트 필요. README/GUIDE 의 관련 섹션에도 같은 변경 있는지 별도 확인 권장.

## 비고

Anthropic 공식 문서상 Haiku 4.5 는 **prompt caching 최소 임계 4096 토큰** (Sonnet 4.6 은 2048). util model 호출의 system prompt 가 4096 미만이면 캐싱 불가 — 이슈 #1 보강 작업에서 함께 검토 예정.