### PR TITLE
feat(observability): M1 tracker captures Anthropic cache tokens (#1)

### DIFF
--- a/agent-zero/extensions/python/agent_init/_90_usage_tracker.py
+++ b/agent-zero/extensions/python/agent_init/_90_usage_tracker.py
@@ -35,16 +35,29 @@ class UsageLogger(CustomLogger):
             if usage:
                 input_tokens = getattr(usage, "prompt_tokens", 0) or 0
                 output_tokens = getattr(usage, "completion_tokens", 0) or 0
+                # Anthropic cache fields (passed through by LiteLLM)
+                cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
+                cache_creation = getattr(usage, "cache_creation_input_tokens", 0) or 0
+                # OpenAI cache field (fallback)
+                details = getattr(usage, "prompt_tokens_details", None)
+                if details is not None:
+                    cache_read += getattr(details, "cached_tokens", 0) or 0
             else:
                 input_tokens = 0
                 output_tokens = 0
+                cache_read = 0
+                cache_creation = 0
 
             if input_tokens == 0 and output_tokens == 0:
                 return
 
-            logger.info(f"[UsageTracker] {model}: in={input_tokens}, out={output_tokens}")
+            logger.info(
+                f"[UsageTracker] {model}: in={input_tokens}, out={output_tokens}, "
+                f"cache_read={cache_read}, cache_creation={cache_creation}"
+            )
 
             # webhook 전송 (fire-and-forget, 실패해도 에이전트에 영향 없음)
+            # 신규 필드(cache_read/creation)는 기존 receiver가 무시해도 호환됨.
             try:
                 requests.post(
                     TELEGRAM_BRIDGE_URL,
@@ -52,6 +65,8 @@ class UsageLogger(CustomLogger):
                         "model": model,
                         "input_tokens": input_tokens,
                         "output_tokens": output_tokens,
+                        "cache_read_tokens": cache_read,
+                        "cache_creation_tokens": cache_creation,
                     },
                     timeout=3,
                 )

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -122,6 +122,28 @@ def tool_end(agent, tool_name: str, response) -> None:
     r["tool_calls"].append(entry)
 
 
+def _extract_cache_tokens(usage) -> tuple[int, int]:
+    """Extract (cache_read, cache_creation) from LiteLLM-normalized usage.
+
+    Supports both formats:
+    - OpenAI: prompt_tokens_details.cached_tokens
+    - Anthropic: cache_read_input_tokens / cache_creation_input_tokens
+      (LiteLLM passes through)
+    """
+    read = 0
+    creation = 0
+    if usage is None:
+        return read, creation
+    # Anthropic fields (passed through by LiteLLM)
+    read += getattr(usage, "cache_read_input_tokens", 0) or 0
+    creation += getattr(usage, "cache_creation_input_tokens", 0) or 0
+    # OpenAI fields
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details is not None:
+        read += getattr(details, "cached_tokens", 0) or 0
+    return read, creation
+
+
 def llm_call(agent, call_data, response) -> None:
     r = get_report(agent)
     if r is None:
@@ -132,19 +154,17 @@ def llm_call(agent, call_data, response) -> None:
     usage = getattr(response, "usage", None) if response is not None else None
     input_tokens = 0
     output_tokens = 0
-    cache_read = 0
     if usage is not None:
         input_tokens = getattr(usage, "prompt_tokens", 0) or 0
         output_tokens = getattr(usage, "completion_tokens", 0) or 0
-        details = getattr(usage, "prompt_tokens_details", None)
-        if details is not None:
-            cache_read = getattr(details, "cached_tokens", 0) or 0
+    cache_read, cache_creation = _extract_cache_tokens(usage)
     r["llm_calls"].append({
         "at": _now_iso(),
         "model": model,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "cache_read_tokens": cache_read,
+        "cache_creation_tokens": cache_creation,
     })
 
 
@@ -167,6 +187,7 @@ def finish_task(agent) -> dict | None:
         "input_tokens": sum(c["input_tokens"] for c in r["llm_calls"]),
         "output_tokens": sum(c["output_tokens"] for c in r["llm_calls"]),
         "cache_read_tokens": sum(c["cache_read_tokens"] for c in r["llm_calls"]),
+        "cache_creation_tokens": sum(c.get("cache_creation_tokens", 0) for c in r["llm_calls"]),
     }
     try:
         TASKS_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Relates to #1 — [M1 보강 제안 코멘트](https://github.com/devyoon91/az-cliproxy-docker/issues/1#issuecomment-4300742309).

## 요약

M1 tracker가 **OpenAI format 캐시 필드만 읽고 Anthropic format 은 놓치고 있었음**. Phase 1 검증의 핵심 지표(프롬프트 캐싱 동작 여부)가 raw 데이터에서 사라지고 있었던 상태.

## 배경

Anthropic 직접 호출 시 usage 구조:
```python
usage.cache_read_input_tokens      # 캐시 히트 (읽기)
usage.cache_creation_input_tokens  # 캐시 생성 (첫 호출)
```

LiteLLM 1.79.3 이 pass-through 해주는 필드임. 기존 tracker 는 `prompt_tokens_details.cached_tokens` (OpenAI) 만 읽어서 이 두 필드를 무시했음.

## 변경

### [task_report.py](agent-zero/lib/task_report.py)

- `_extract_cache_tokens()` 헬퍼 신규 — Anthropic + OpenAI 양쪽 포맷 처리
- `llm_calls[]` 엔트리에 `cache_creation_tokens` 필드 추가
- `totals` 집계에도 포함

### [_90_usage_tracker.py](agent-zero/extensions/python/agent_init/_90_usage_tracker.py)

- 동일 로직으로 cache_read/creation 수집
- 로그 포맷 확장: `in=..., out=..., cache_read=..., cache_creation=...`
- Telegram `/track` webhook payload 에 신규 필드 추가 (receiver 가 무시해도 호환)

## 출력 예시

```json
"llm_calls": [
  {
    "model": "claude-sonnet-4-6",
    "input_tokens": 500,
    "output_tokens": 50,
    "cache_read_tokens": 0,
    "cache_creation_tokens": 15000     // 첫 호출
  },
  {
    "model": "claude-sonnet-4-6",
    "input_tokens": 800,
    "output_tokens": 60,
    "cache_read_tokens": 15000,        // 두번째 호출부터 hit
    "cache_creation_tokens": 0
  }
]
```

## 검증 계획

병합 후 컨테이너 재기동 → Agent Zero UI 에서 **같은 질문 5분 내 2회 연속** 실행 → `agent-zero/logs/tasks/*.json` 열어서:
- 1번째 task: `cache_creation_tokens > 0`, `cache_read_tokens == 0`
- 2번째 task: `cache_read_tokens > 0` (hit 발생)

둘 다 0 이면 시스템 프롬프트가 호출마다 변하고 있는 것 → 다음 진단 단계 (prompt stability 검증) 필요.

## 호환성

- 기존 JSON consumer: 신규 필드 무시해도 동작 (추가만, 기존 필드 유지)
- Telegram bridge `/track`: 신규 필드 무시해도 동작. 나중에 bridge도 집계 추가 가능 (별도 PR)
- 기존 task 로그: 소급 적용 안됨. 병합 후 신규 task 부터 capture.