### PR TITLE
fix(observability): task_report JSON serialization for model object (#1)

### DIFF
--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -148,9 +148,17 @@ def llm_call(agent, call_data, response) -> None:
     r = get_report(agent)
     if r is None:
         return
+    # Resolve model name as a string.
+    # - response.model is the LiteLLM-normalized string (preferred)
+    # - call_data["model"] is Agent Zero's model *object*, not serializable
     model = None
-    if isinstance(call_data, dict):
-        model = call_data.get("model")
+    if response is not None:
+        model = getattr(response, "model", None)
+    if not isinstance(model, str) and isinstance(call_data, dict):
+        m = call_data.get("model")
+        model = getattr(m, "model_name", None) or getattr(m, "name", None)
+    if not isinstance(model, str):
+        model = None
     usage = getattr(response, "usage", None) if response is not None else None
     input_tokens = 0
     output_tokens = 0


### PR DESCRIPTION
Hotfix on top of #10.

## 증상

질문 던질 때마다 컨테이너 로그:
```
[task_report] write failed:
Object of type LiteLLMChatWrapper is not JSON serializable
```

PR #10 머지 후에도 `agent-zero/logs/tasks/` 비어있음 — capture 는 돌았지만 저장 실패로 JSON 안 나옴.

## 근본 원인

`task_report.py` 의 `llm_call()` 이 `call_data["model"]` 을 그대로 llm_calls[].model 에 박았는데, 이건 Agent Zero 의 **LiteLLMChatWrapper 객체**지 문자열이 아님. `json.dumps` 실패.

M1 초기 구현(PR #2) 부터 내재한 버그. chat_model_call_after hook 의 call_data 구조를 잘못 이해함.

## 수정

우선순위 체인:
1. `response.model` — LiteLLM이 정규화한 모델 문자열
2. `call_data["model"].model_name` 또는 `.name` — wrapper 의 속성
3. `None` — 실패 시 안전 기본값

모두 string 아니면 None으로 정규화 → 항상 JSON-safe.

## 검증

머지 후:
```bash
git checkout main && git pull
docker-compose down && docker-compose up -d
# Agent Zero 에 task 1개 던지고
ls -lt agent-zero/logs/tasks/
# JSON 파일이 생기면 성공
```