### PR TITLE
fix(observability): approximate tokens since response is str in v1.9

### DIFF
--- a/agent-zero/extensions/python/chat_model_call_after/_50_task_report_llm.py
+++ b/agent-zero/extensions/python/chat_model_call_after/_50_task_report_llm.py
@@ -8,5 +8,7 @@ from helpers.task_report import llm_call
 
 
 class TaskReportLLM(Extension):
-    async def execute(self, call_data=None, response=None, **kwargs):
-        llm_call(self.agent, call_data, response)
+    async def execute(self, call_data=None, response=None, reasoning=None, **kwargs):
+        # Agent Zero v1.9 passes `response` as str (the assembled completion
+        # text) and `reasoning` as str. See agent.py:832 invocation site.
+        llm_call(self.agent, call_data, response, reasoning)

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -20,6 +20,14 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+try:
+    # Agent Zero ships this helper; same function it uses internally in
+    # models.py to size cache-history chunks. Graceful fallback if absent.
+    from helpers.tokens import approximate_tokens  # type: ignore
+except Exception:  # pragma: no cover - only runs inside AZ container
+    def approximate_tokens(text: str) -> int:  # type: ignore
+        return 0
+
 logger = logging.getLogger(__name__)
 
 TASKS_DIR = Path("/a0/logs/tasks")
@@ -144,28 +152,79 @@ def _extract_cache_tokens(usage) -> tuple[int, int]:
     return read, creation
 
 
-def llm_call(agent, call_data, response) -> None:
+def _estimate_input_tokens(call_data) -> int:
+    if not isinstance(call_data, dict):
+        return 0
+    messages = call_data.get("messages") or []
+    try:
+        text = json.dumps(messages, ensure_ascii=False, default=str)
+    except Exception:
+        text = str(messages)
+    try:
+        return int(approximate_tokens(text) or 0)
+    except Exception:
+        return 0
+
+
+def _estimate_output_tokens(response, reasoning) -> int:
+    parts = []
+    if isinstance(response, str) and response:
+        parts.append(response)
+    if isinstance(reasoning, str) and reasoning:
+        parts.append(reasoning)
+    if not parts:
+        return 0
+    try:
+        return int(approximate_tokens("\n".join(parts)) or 0)
+    except Exception:
+        return 0
+
+
+def llm_call(agent, call_data, response, reasoning=None) -> None:
+    """Record an LLM call.
+
+    Agent Zero v1.9 note: the `chat_model_call_after` hook receives `response`
+    as a *string* (the assembled completion text), not a LiteLLM
+    `ModelResponse`. `_parse_chunk` in /a0/models.py strips `usage` from
+    streaming chunks, so real token counts and Anthropic cache fields are
+    unreachable from this hook.
+
+    As a stopgap we approximate input/output via `helpers.tokens.approximate_tokens`
+    (same function Agent Zero uses itself) and mark the entry with
+    `tokens_approximate=True`. Real cache tokens require bridging from the
+    LiteLLM callback layer (`_90_usage_tracker.py`) — tracked separately.
+    """
     r = get_report(agent)
     if r is None:
         return
-    # Resolve model name as a string.
-    # - response.model is the LiteLLM-normalized string (preferred)
-    # - call_data["model"] is Agent Zero's model *object*, not serializable
+    # Resolve model name as a string. In v1.9, `response` is a str, so fall
+    # back to call_data["model"].model_name (LiteLLMChatWrapper attribute).
     model = None
-    if response is not None:
-        model = getattr(response, "model", None)
-    if not isinstance(model, str) and isinstance(call_data, dict):
+    if isinstance(call_data, dict):
         m = call_data.get("model")
         model = getattr(m, "model_name", None) or getattr(m, "name", None)
+    # Belt-and-suspenders: if a future version ever passes a ModelResponse.
+    if not isinstance(model, str) and response is not None:
+        rm = getattr(response, "model", None)
+        if isinstance(rm, str):
+            model = rm
     if not isinstance(model, str):
         model = None
+
+    # Prefer real usage if it ever becomes available (future-proof).
     usage = getattr(response, "usage", None) if response is not None else None
-    input_tokens = 0
-    output_tokens = 0
     if usage is not None:
         input_tokens = getattr(usage, "prompt_tokens", 0) or 0
         output_tokens = getattr(usage, "completion_tokens", 0) or 0
-    cache_read, cache_creation = _extract_cache_tokens(usage)
+        cache_read, cache_creation = _extract_cache_tokens(usage)
+        approximate = False
+    else:
+        input_tokens = _estimate_input_tokens(call_data)
+        output_tokens = _estimate_output_tokens(response, reasoning)
+        cache_read = 0
+        cache_creation = 0
+        approximate = True
+
     r["llm_calls"].append({
         "at": _now_iso(),
         "model": model,
@@ -173,6 +232,7 @@ def llm_call(agent, call_data, response) -> None:
         "output_tokens": output_tokens,
         "cache_read_tokens": cache_read,
         "cache_creation_tokens": cache_creation,
+        "tokens_approximate": approximate,
     })
 
 


### PR DESCRIPTION
## 문제

PR #10/#11 머지 후 테스트 질문을 날려보니 `input_tokens`/`output_tokens`가 모두 **0**으로 찍혔다.

```json
"llm_calls": [{ "model": "anthropic/claude-sonnet-4-6",
                "input_tokens": 0, "output_tokens": 0,
                "cache_read_tokens": 0, "cache_creation_tokens": 0 }]
```

실제로는 응답(2474 bytes)이 정상 생성됐기 때문에 **우리 계측 쪽의 버그**.

## 근본 원인 (Agent Zero v1.9 소스 직접 확인)

- `agent.py:832` — hook 호출부:
  ```python
  extension.call_extensions_async(
      "chat_model_call_after", self,
      call_data=call_data, response=response, reasoning=reasoning
  )
  ```
- `models.py:473` `unified_call() -> Tuple[str, str]` — **`response`는 `str`** (누적된 응답 텍스트), `reasoning`도 `str`. LiteLLM `ModelResponse`가 아님.
- `models.py:736` `_parse_chunk` — 스트리밍 청크에서 `content`/`reasoning_content`만 추출하고 **`usage`를 통째로 버린다**.
- 즉 이 훅 경로에서는 원천적으로 실 토큰/Anthropic cache 필드를 얻을 수 없다. `response.usage` 접근은 항상 `AttributeError` → None → 0.

## 수정

`helpers.tokens.approximate_tokens` (Agent Zero 자신도 `models.py:541-562`에서 쓰는 tiktoken `cl100k_base` × 1.1 버퍼 함수) 로 근사:

- `input_tokens` ← `call_data["messages"]` 직렬화 후 토큰 카운트
- `output_tokens` ← `response + reasoning` 문자열 토큰 카운트
- 엔트리에 `tokens_approximate: true` 마커 추가 (downstream이 실값/근사값 구분 가능)
- 미래 버전이 실 `ModelResponse`를 넘길 경우 `response.usage` 경로가 먼저 타도록 fallback 구조 유지

## 검증

수정 후 재기동 → UI에서 질문 1회:

```json
"llm_calls": [{ "model": "anthropic/claude-sonnet-4-6",
                "input_tokens": 14496, "output_tokens": 1377,
                "cache_read_tokens": 0, "cache_creation_tokens": 0,
                "tokens_approximate": true }]
```

input 14.5K / output 1.4K로 정상 측정. 이후 `/a0` 내부 `approximate_tokens` import도 확인 (`tokens=6` for `'hello world this is a test'`).

## 남은 제한 사항

`cache_read_tokens` / `cache_creation_tokens`는 **여전히 0**. 이 경로에선 `_parse_chunk`가 usage를 버려서 불가능. 진짜 cache 토큰을 원하면 `_90_usage_tracker.py`의 LiteLLM callback 레이어(`response_obj.usage` 실값 보유)와 task_report를 모듈 레벨 레지스트리로 브리지해야 한다 → **별도 follow-up 이슈로 분리**.

Refs #1