### PR TITLE
feat(observability): M4 /today /week /tasks aggregation commands

### DIFF
--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -192,12 +192,21 @@ def save_task(agent) -> None:
 
 
 def sweep_orphans() -> int:
-    """Mark any leftover pending JSONs as orphaned. Called once on AZ startup
-    from an agent_init extension. Any file still reporting
-    `ended_reason == "pending"` at startup means the previous process died
-    mid-run or the task was cancelled (monologue_end never fired).
+    """Mark stale/legacy task JSONs with a proper `ended_reason`.
 
-    Returns the number of files rewritten.
+    Called once on AZ startup from an agent_init extension. Two fixes:
+
+    1. Any file with `ended_reason == "pending"` at startup — previous
+       process died mid-run or the task was cancelled (monologue_end
+       never fired). Promoted to `"orphaned"` with `ended_at=now`.
+
+    2. Legacy files (from before M2.1) that never had an `ended_reason`
+       field but do have an `ended_at` timestamp — clearly a completed
+       run. Tagged `"completed"` so /today aggregates don't lump them in
+       with true pendings. Files lacking BOTH fields are left alone
+       (shouldn't happen but best to be conservative).
+
+    Returns the total number of files rewritten.
     """
     count = 0
     try:
@@ -208,9 +217,18 @@ def sweep_orphans() -> int:
                 data = json.loads(p.read_text(encoding="utf-8"))
             except Exception:
                 continue
-            if data.get("ended_reason") == ENDED_PENDING:
+            changed = False
+            reason = data.get("ended_reason")
+            if reason == ENDED_PENDING:
                 data["ended_reason"] = ENDED_ORPHANED
                 data.setdefault("ended_at", _now_iso())
+                changed = True
+            elif reason is None and data.get("ended_at"):
+                # Legacy (pre-M2.1) JSON — annotate the completion state
+                # instead of defaulting aggregation code to "pending".
+                data["ended_reason"] = ENDED_COMPLETED
+                changed = True
+            if changed:
                 try:
                     p.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
                     count += 1
@@ -219,7 +237,7 @@ def sweep_orphans() -> int:
     except Exception as e:
         logger.warning(f"[task_report] sweep_orphans error: {e}")
     if count:
-        logger.info(f"[task_report] sweep_orphans: marked {count} file(s) as orphaned")
+        logger.info(f"[task_report] sweep_orphans: rewrote {count} file(s)")
     return count
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,8 @@ services:
       - ./docs:/app/docs:ro
       - ./GUIDE.md:/app/GUIDE.md:ro
       - ./README.md:/app/README.md:ro
+      # M4: read AZ task JSONs for /today, /week, /tasks aggregation commands
+      - ./agent-zero/logs/tasks:/app/tasks:ro
     ports:
       - "8443:8443"   # 알림 webhook (내부용)
     depends_on:

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -551,7 +551,10 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "• /new → 새 대화 시작\n"
         "• /logs → 전체 로그 파일 전송\n"
         "• /docs → 문서 목록/열람\n"
-        "• /usage → 토큰 사용량/비용 조회\n"
+        "• /usage → 세션 내 토큰/비용 (휘발성)\n"
+        "• /today → 오늘의 태스크 집계 (task JSON 기반)\n"
+        "• /week → 최근 7일 집계\n"
+        "• /tasks [N] → 최근 N개 태스크 목록\n"
         "• /backup → 설정 백업 파일 전송\n"
         "• /monitor_on → 모니터링 켜기\n"
         "• /monitor_off → 모니터링 끄기\n"
@@ -890,6 +893,234 @@ async def cmd_backup(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(f"백업 실패: {str(e)}")
 
 
+# ── Task JSON aggregation (issue #1 M2) ──
+TASKS_DIR = "/app/tasks"
+
+
+def _load_task_jsons() -> list[dict]:
+    """Read every task JSON from the mounted AZ logs dir.
+
+    Returns a list of parsed dicts sorted by `started_at` ascending.
+    Malformed files are skipped silently; they show up in logs once and
+    then get ignored so /today doesn't crash on a single bad file.
+    """
+    if not os.path.isdir(TASKS_DIR):
+        return []
+    items: list[dict] = []
+    for name in os.listdir(TASKS_DIR):
+        if not name.endswith(".json") or name.endswith(".tmp"):
+            continue
+        path = os.path.join(TASKS_DIR, name)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                items.append(json.load(f))
+        except Exception as e:
+            logger.debug(f"skip bad task json {name}: {e}")
+    items.sort(key=lambda r: r.get("started_at") or "")
+    return items
+
+
+def _aggregate(tasks: list[dict]) -> dict:
+    """Sum totals across a list of tasks, also grouping by model and status."""
+    agg = {
+        "tasks": len(tasks),
+        "completed": 0,
+        "orphaned": 0,
+        "pending": 0,
+        "tool_calls": 0,
+        "llm_calls": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cost_usd": 0.0,
+        "by_model": {},
+    }
+    for t in tasks:
+        reason = t.get("ended_reason", "pending")
+        if reason in agg:
+            agg[reason] += 1
+        totals = t.get("totals") or {}
+        for k in ("tool_calls", "llm_calls", "input_tokens", "output_tokens",
+                  "cache_read_tokens", "cache_creation_tokens"):
+            agg[k] += int(totals.get(k, 0) or 0)
+        agg["cost_usd"] += float(totals.get("cost_usd", 0.0) or 0.0)
+        for c in t.get("llm_calls") or []:
+            m = c.get("model") or "unknown"
+            bucket = agg["by_model"].setdefault(m, {
+                "calls": 0, "input": 0, "output": 0,
+                "cache_read": 0, "cache_create": 0, "cost": 0.0,
+            })
+            bucket["calls"] += 1
+            bucket["input"] += int(c.get("input_tokens", 0) or 0)
+            bucket["output"] += int(c.get("output_tokens", 0) or 0)
+            bucket["cache_read"] += int(c.get("cache_read_tokens", 0) or 0)
+            bucket["cache_create"] += int(c.get("cache_creation_tokens", 0) or 0)
+            bucket["cost"] += float(c.get("cost_usd", 0.0) or 0.0)
+    agg["cost_usd"] = round(agg["cost_usd"], 6)
+    return agg
+
+
+def _filter_date_range(tasks: list[dict], start, end) -> list[dict]:
+    """Filter tasks whose `started_at` (ISO, UTC) falls in [start, end).
+
+    `start` and `end` are `datetime` objects (naive; treated as local time).
+    AZ writes started_at in UTC with +00:00 offset, so we compare with
+    the task's UTC instant by parsing the full ISO string.
+    """
+    out = []
+    for t in tasks:
+        started = t.get("started_at")
+        if not started:
+            continue
+        try:
+            # fromisoformat handles "+00:00"
+            ts = datetime.fromisoformat(started)
+        except Exception:
+            continue
+        # Compare in local time (user's wall clock) since /today means "today
+        # in my timezone."
+        ts_local = ts.astimezone().replace(tzinfo=None) if ts.tzinfo else ts
+        if start <= ts_local < end:
+            out.append(t)
+    return out
+
+
+def _format_agg_block(title: str, agg: dict) -> list[str]:
+    """Render an aggregate dict as a Telegram-friendly block."""
+    lines = [
+        f"📊 {title}",
+        f"  태스크: {agg['tasks']}건 "
+        f"(✅{agg['completed']} ⚠️{agg['orphaned']} ⏳{agg['pending']})",
+    ]
+    if agg["tasks"] == 0:
+        return lines
+    lines.append(
+        f"  LLM 호출: {agg['llm_calls']}건 · 도구: {agg['tool_calls']}건"
+    )
+    lines.append(
+        f"  토큰: in {agg['input_tokens']:,} · out {agg['output_tokens']:,}"
+    )
+    if agg["cache_read_tokens"] or agg["cache_creation_tokens"]:
+        lines.append(
+            f"  캐시: read {agg['cache_read_tokens']:,} · "
+            f"create {agg['cache_creation_tokens']:,}"
+        )
+    lines.append(f"  💰 ${agg['cost_usd']:.4f}")
+    return lines
+
+
+async def cmd_today(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Today's task aggregate from on-disk JSONs."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    tasks = _load_task_jsons()
+    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    tomorrow = today_start + timedelta(days=1)
+    todays = _filter_date_range(tasks, today_start, tomorrow)
+    agg = _aggregate(todays)
+
+    lines = _format_agg_block(f"오늘 ({today_start.strftime('%Y-%m-%d')})", agg)
+
+    by_model = agg.get("by_model", {})
+    if by_model:
+        lines.append("\n🤖 모델별:")
+        for model, b in sorted(by_model.items(), key=lambda kv: kv[1]["cost"], reverse=True):
+            cache = (
+                f" | cache r:{b['cache_read']:,} c:{b['cache_create']:,}"
+                if (b["cache_read"] or b["cache_create"]) else ""
+            )
+            lines.append(
+                f"  • {model}: {b['calls']}× "
+                f"in {b['input']:,} out {b['output']:,}{cache} → ${b['cost']:.4f}"
+            )
+
+    await update.message.reply_text("\n".join(lines))
+
+
+async def cmd_week(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Last 7 days: daily breakdown + grand totals."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    all_tasks = _load_task_jsons()
+    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    week_start = today_start - timedelta(days=6)  # last 7 days including today
+    week_end = today_start + timedelta(days=1)
+    window = _filter_date_range(all_tasks, week_start, week_end)
+
+    lines = [f"📈 최근 7일 ({week_start.strftime('%m-%d')} ~ {today_start.strftime('%m-%d')})\n"]
+
+    # Per-day rows
+    days_with_data = 0
+    for i in range(7):
+        day_start = week_start + timedelta(days=i)
+        day_end = day_start + timedelta(days=1)
+        day_tasks = _filter_date_range(window, day_start, day_end)
+        if not day_tasks:
+            continue
+        days_with_data += 1
+        agg = _aggregate(day_tasks)
+        lines.append(
+            f"  {day_start.strftime('%m-%d')}: "
+            f"{agg['tasks']}건 · {agg['llm_calls']} LLM · ${agg['cost_usd']:.4f}"
+        )
+
+    if days_with_data == 0:
+        lines.append("  (데이터 없음)")
+
+    # Grand total
+    grand = _aggregate(window)
+    lines.append("")
+    lines.extend(_format_agg_block("주간 합계", grand))
+    by_model = grand.get("by_model", {})
+    if by_model:
+        lines.append("\n🤖 모델별 (주간):")
+        for model, b in sorted(by_model.items(), key=lambda kv: kv[1]["cost"], reverse=True):
+            lines.append(f"  • {model}: {b['calls']}× → ${b['cost']:.4f}")
+
+    await update.message.reply_text("\n".join(lines))
+
+
+async def cmd_tasks(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """List the most recent N tasks with individual summaries (default 10)."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    n = 10
+    args = context.args
+    if args:
+        try:
+            n = max(1, min(50, int(args[0])))
+        except ValueError:
+            pass
+    tasks = _load_task_jsons()
+    recent = list(reversed(tasks[-n:]))
+    if not recent:
+        await update.message.reply_text("최근 태스크가 없습니다.")
+        return
+
+    lines = [f"🗂 최근 {len(recent)}개 태스크\n"]
+    status_icon = {"completed": "✅", "orphaned": "⚠️", "pending": "⏳"}
+    for t in recent:
+        tid = t.get("task_id", "?")
+        reason = t.get("ended_reason", "pending")
+        icon = status_icon.get(reason, "•")
+        elapsed = t.get("elapsed_sec", 0) or 0
+        totals = t.get("totals") or {}
+        cost = totals.get("cost_usd", 0.0) or 0.0
+        # Short HH:MM:SS from task_id (task-YYYYMMDD-HHMMSS-xxxxxx)
+        parts = tid.split("-")
+        when = "?"
+        if len(parts) >= 3 and len(parts[2]) == 6:
+            when = f"{parts[2][:2]}:{parts[2][2:4]}:{parts[2][4:6]}"
+        lines.append(
+            f"{icon} {when} {elapsed:.0f}s · "
+            f"LLM {totals.get('llm_calls', 0)} · "
+            f"도구 {totals.get('tool_calls', 0)} · "
+            f"${cost:.4f}"
+        )
+    await update.message.reply_text("\n".join(lines))
+
+
 async def cmd_usage(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """토큰 사용량 + 비용 조회 (cache 토큰 포함)"""
     if update.effective_chat.id != CHAT_ID:
@@ -994,7 +1225,10 @@ async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "  /follow_off → 채팅 자동 추적 끄기\n\n"
         "상태/비용:\n"
         "  /status → Agent Zero 상태 확인\n"
-        "  /usage → 토큰 사용량 및 비용 조회\n"
+        "  /usage → 세션 내 토큰/비용 (bridge 재시작 시 초기화)\n"
+        "  /today → 오늘의 태스크 집계 (영구 데이터)\n"
+        "  /week → 최근 7일 일별 + 합계\n"
+        "  /tasks [N] → 최근 N개 태스크 목록 (기본 10)\n"
         "  /backup → 설정 경량 백업 (ZIP 파일 전송)\n"
         "  /help → 도움말"
     )
@@ -1131,6 +1365,9 @@ def main():
     app.add_handler(CommandHandler("logs", cmd_logs))
     app.add_handler(CommandHandler("docs", cmd_docs))
     app.add_handler(CommandHandler("usage", cmd_usage))
+    app.add_handler(CommandHandler("today", cmd_today))
+    app.add_handler(CommandHandler("week", cmd_week))
+    app.add_handler(CommandHandler("tasks", cmd_tasks))
     app.add_handler(CommandHandler("backup", cmd_backup))
     app.add_handler(CommandHandler("monitor_on", cmd_monitor_on))
     app.add_handler(CommandHandler("monitor_off", cmd_monitor_off))


### PR DESCRIPTION
## Summary
- Three new Telegram commands query on-disk task JSONs directly — survive bridge restart, include cache tokens, see true per-task cost
- Legacy pre-M2.1 JSONs get promoted to `ended_reason="completed"` at startup so status breakdowns aren't dominated by false-pendings

**⚠️ Stacked on #16 (M3)** — needs the `cost_usd` field each task JSON entry carries. Rebase onto `main` after #15 + #16 merge.

## Why not extend the existing in-memory `usage_today`?
The existing `/usage` command reads a dict that lives inside the telegram-bridge process. It resets on every container restart, misses cache tokens (before #16), and has no concept of task boundaries. Task JSONs on `/a0/logs/tasks/` are the canonical durable store — this PR just gives the bridge read access.

## Commands

### `/today`
```
📊 오늘 (2026-04-23)
  태스크: 21건 (✅20 ⚠️1 ⏳0)
  LLM 호출: 22건 · 도구: 20건
  토큰: in 243,383 · out 14,855
  캐시: read 115,333 · create 30,391
  💰 $0.0140

🤖 모델별:
  • anthropic/claude-sonnet-4-6: 22× in 243,383 out 14,855 → $0.0140
```

### `/week`
Per-day line + aggregated totals block + per-model weekly breakdown.

### `/tasks [N]`
Recent N tasks (default 10, max 50) with status icon, time, elapsed, LLM/tool counts, and cost.

## Wiring
- `docker-compose.yml`: mount `agent-zero/logs/tasks` into bridge at `/app/tasks:ro`
- `bot.py`: `_load_task_jsons()` + `_aggregate()` + `_filter_date_range()` + `_format_agg_block()` — shared helpers

## Legacy migration (task_report.py)
`sweep_orphans()` now also tags pre-M2.1 JSONs (missing `ended_reason`, has `ended_at`) as `"completed"`. Before migration the sample data showed 3 completed + 17 false-pending; after, 20 completed + 0 pending.

## Test plan
- [x] `/today` aggregates real 21 on-disk tasks correctly
- [x] `/week` renders per-day rows + grand totals
- [x] `/tasks` lists 10 most recent with correct elapsed and cost
- [x] Legacy migration promotes 17 old JSONs without double-counting
- [ ] Smoke: invoke `/today`, `/week`, `/tasks` from actual Telegram client

## Follow-ups
- Old tasks show $0.0000 because M3 pricing is forward-only (no backfill). New tasks will carry real `cost_usd`.
- M5 candidate: budget alerts (`AZ_COST_BUDGET_USD` env + Telegram nudge when daily crosses it), filter `/today` by model