### PR TITLE
feat(observability): M3 cost reporting + M4 aggregation commands (restack to main)

### DIFF
--- a/agent-zero/lib/pricing.py
+++ b/agent-zero/lib/pricing.py
@@ -1,0 +1,181 @@
+"""
+Model pricing lookup — computes USD cost from real token counts.
+
+Loads LiteLLM's `model_prices_and_context_window.json` once at import time
+(GitHub raw, with bundled fallback) and exposes `compute_cost()` that
+accepts Anthropic-aware cache fields. Used by:
+
+  - `task_report.llm_call()` — per-call `cost_usd` written into every task JSON
+  - `_compute_totals()` — task-level `cost_usd` roll-up
+  - (telegram-bridge keeps its own copy of the same logic for /track)
+
+Pricing fields (per-token USD, LiteLLM schema):
+  input_cost_per_token
+  output_cost_per_token
+  cache_read_input_token_cost        (90% discount on Anthropic)
+  cache_creation_input_token_cost    (25% premium on Anthropic)
+
+Cache math:
+  regular_input = prompt_tokens - cache_read - cache_creation
+  cost = regular_input  * input_cost_per_token
+       + cache_read     * cache_read_input_token_cost
+       + cache_creation * cache_creation_input_token_cost
+       + completion     * output_cost_per_token
+
+Mounted into the container at /a0/helpers/pricing.py alongside task_report.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Fallback rates in per-token USD. Used only when the remote table cannot
+# be fetched and the model isn't in the bundled snapshot. Values sit in
+# the middle of the 2026-04 Anthropic/OpenAI ranges so the error-bar is
+# symmetric either way.
+_FALLBACK = {
+    "input_cost_per_token": 0.000003,            # $3 / 1M
+    "output_cost_per_token": 0.000015,           # $15 / 1M
+    "cache_read_input_token_cost": 0.0000003,    # $0.30 / 1M (90% off input)
+    "cache_creation_input_token_cost": 0.00000375,  # $3.75 / 1M (25% premium)
+}
+
+# Common model-name aliases → canonical LiteLLM key. AZ sometimes prefixes
+# with "anthropic/" or uses shorthand like "claude-sonnet-4-6" when the
+# LiteLLM key is "claude-sonnet-4-20250929". Extend as needed.
+_ALIASES = {
+    "anthropic/claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
+    "anthropic/claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
+    "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5": "claude-haiku-4-5-20251001",
+    "anthropic/claude-opus-4-5": "claude-opus-4-5-20250929",
+    "claude-opus-4-5": "claude-opus-4-5-20250929",
+}
+
+_PRICE_TABLE: dict = {}
+_LOADED = False
+
+
+def _remote_url() -> str:
+    return os.environ.get(
+        "LITELLM_PRICE_URL",
+        "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+    )
+
+
+def _load_remote() -> dict | None:
+    try:
+        import requests  # noqa: WPS433
+    except Exception:  # pragma: no cover
+        return None
+    try:
+        resp = requests.get(_remote_url(), timeout=5)
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception as e:
+        logger.warning(f"[pricing] remote fetch failed: {e}")
+    return None
+
+
+def _load_bundled() -> dict | None:
+    # Looks next to this file for a snapshot shipped with the repo.
+    path = Path(__file__).parent / "model_prices.json"
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning(f"[pricing] bundled load failed: {e}")
+    return None
+
+
+def _ensure_loaded() -> None:
+    global _PRICE_TABLE, _LOADED
+    if _LOADED:
+        return
+    table = _load_remote() or _load_bundled() or {}
+    if table:
+        _PRICE_TABLE = table
+        logger.info(f"[pricing] loaded {len(table)} model rates")
+    else:
+        logger.warning("[pricing] no table — all lookups use fallback rates")
+    _LOADED = True
+
+
+def _resolve_key(model: str | None) -> str | None:
+    if not model:
+        return None
+    if model in _PRICE_TABLE:
+        return model
+    if model in _ALIASES:
+        return _ALIASES[model]
+    # LiteLLM stores Anthropic keys without the "anthropic/" prefix; strip & retry.
+    if model.startswith("anthropic/"):
+        tail = model.split("/", 1)[1]
+        if tail in _PRICE_TABLE:
+            return tail
+    return None
+
+
+def get_rates(model: str | None) -> dict:
+    """Return the 4-rate dict for a model, falling back to `_FALLBACK`."""
+    _ensure_loaded()
+    key = _resolve_key(model)
+    info = _PRICE_TABLE.get(key) if key else None
+    if info is None:
+        return dict(_FALLBACK)
+    # Anthropic entries may omit cache fields for models without prompt caching.
+    # Default creation to input*1.25, read to input*0.1 per Anthropic's schedule.
+    in_rate = info.get("input_cost_per_token", _FALLBACK["input_cost_per_token"])
+    out_rate = info.get("output_cost_per_token", _FALLBACK["output_cost_per_token"])
+    read_rate = info.get("cache_read_input_token_cost", in_rate * 0.10)
+    create_rate = info.get("cache_creation_input_token_cost", in_rate * 1.25)
+    return {
+        "input_cost_per_token": in_rate,
+        "output_cost_per_token": out_rate,
+        "cache_read_input_token_cost": read_rate,
+        "cache_creation_input_token_cost": create_rate,
+    }
+
+
+def compute_cost(
+    model: str | None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+) -> float:
+    """Compute total USD cost for one LLM call.
+
+    `input_tokens` in AZ's task_report is the RAW `prompt_tokens` from the
+    provider — on Anthropic this is already the billed regular-input count
+    (cache_read and cache_creation are NOT double-counted inside it). On
+    OpenAI, `prompt_tokens_details.cached_tokens` IS included in
+    prompt_tokens, so subtract it to avoid billing the same tokens twice.
+
+    The stream-usage probe normalizes to the Anthropic convention, so we
+    treat `input_tokens` as regular-only here. If callers pass a raw OpenAI
+    total they should subtract cache_read first.
+    """
+    rates = get_rates(model)
+    cost = (
+        max(0, int(input_tokens)) * rates["input_cost_per_token"]
+        + max(0, int(output_tokens)) * rates["output_cost_per_token"]
+        + max(0, int(cache_read_tokens)) * rates["cache_read_input_token_cost"]
+        + max(0, int(cache_creation_tokens)) * rates["cache_creation_input_token_cost"]
+    )
+    return round(cost, 6)
+
+
+def format_usd(cost: float) -> str:
+    """Human-friendly cost string — 4 decimals for cents, scientific for sub-cent."""
+    if cost >= 0.01:
+        return f"${cost:.4f}"
+    if cost >= 0.0001:
+        return f"${cost:.6f}"
+    return f"${cost:.2e}"

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -15,6 +15,7 @@ extension files can `from helpers.task_report import ...`.
 import hashlib
 import json
 import logging
+import os
 import time
 import uuid
 from contextvars import ContextVar
@@ -36,6 +37,16 @@ try:
 except Exception:  # pragma: no cover - only runs inside AZ container
     def approximate_tokens(text: str) -> int:  # type: ignore
         return 0
+
+try:
+    # Shared pricing helper. Ships with the repo as /a0/helpers/pricing.py
+    # via docker-compose mount; falls back to a no-cost stub if the mount
+    # is missing so task_report never crashes a monologue.
+    from helpers.pricing import compute_cost  # type: ignore
+except Exception:  # pragma: no cover - only runs inside AZ container
+    def compute_cost(model=None, input_tokens=0, output_tokens=0,
+                     cache_read_tokens=0, cache_creation_tokens=0) -> float:  # type: ignore
+        return 0.0
 
 logger = logging.getLogger(__name__)
 
@@ -117,13 +128,17 @@ def get_report(agent):
 
 
 def _compute_totals(report: dict) -> dict:
+    calls = report.get("llm_calls") or []
     return {
         "tool_calls": len(report.get("tool_calls") or []),
-        "llm_calls": len(report.get("llm_calls") or []),
-        "input_tokens": sum(c.get("input_tokens", 0) for c in report.get("llm_calls") or []),
-        "output_tokens": sum(c.get("output_tokens", 0) for c in report.get("llm_calls") or []),
-        "cache_read_tokens": sum(c.get("cache_read_tokens", 0) for c in report.get("llm_calls") or []),
-        "cache_creation_tokens": sum(c.get("cache_creation_tokens", 0) for c in report.get("llm_calls") or []),
+        "llm_calls": len(calls),
+        "input_tokens": sum(c.get("input_tokens", 0) for c in calls),
+        "output_tokens": sum(c.get("output_tokens", 0) for c in calls),
+        "cache_read_tokens": sum(c.get("cache_read_tokens", 0) for c in calls),
+        "cache_creation_tokens": sum(c.get("cache_creation_tokens", 0) for c in calls),
+        # Per-call `cost_usd` is authoritative; we sum rather than re-computing
+        # from totals so model-mix inside one task is priced accurately.
+        "cost_usd": round(sum(c.get("cost_usd", 0.0) or 0.0 for c in calls), 6),
     }
 
 
@@ -368,6 +383,18 @@ def llm_call(agent, call_data, response, reasoning=None) -> None:
         cache_creation = 0
         approximate = True
 
+    # Price the call. When tokens are approximate (no real stream usage was
+    # captured), we still compute a cost — it's labelled approximate via
+    # `tokens_approximate=True`, and skipping pricing entirely would lose the
+    # fallback-path volume in /usage dashboards.
+    cost = compute_cost(
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read,
+        cache_creation_tokens=cache_creation,
+    )
+
     r["llm_calls"].append({
         "at": _now_iso(),
         "model": model,
@@ -375,19 +402,86 @@ def llm_call(agent, call_data, response, reasoning=None) -> None:
         "output_tokens": output_tokens,
         "cache_read_tokens": cache_read,
         "cache_creation_tokens": cache_creation,
+        "cost_usd": cost,
         "tokens_approximate": approximate,
     })
 
 
+TELEGRAM_BRIDGE_NOTIFY_URL = os.environ.get(
+    "TELEGRAM_BRIDGE_URL", "http://telegram-bridge:8443/notify"
+)
+TASK_SUMMARY_ENABLED = os.environ.get("AZ_TASK_SUMMARY", "1") not in ("0", "false", "False")
+
+
+def _format_task_summary(snapshot: dict) -> str:
+    """Compact Telegram-friendly per-task summary.
+
+    Shown on `monologue_end` after `finish_task` writes the final JSON.
+    Opt out with env var `AZ_TASK_SUMMARY=0`.
+    """
+    totals = snapshot.get("totals") or {}
+    elapsed = snapshot.get("elapsed_sec") or 0
+    cost_usd = totals.get("cost_usd", 0.0) or 0.0
+
+    # Group llm_calls by model for the breakdown
+    by_model: dict[str, dict] = {}
+    for c in snapshot.get("llm_calls") or []:
+        m = c.get("model") or "unknown"
+        bucket = by_model.setdefault(m, {
+            "calls": 0, "input": 0, "output": 0,
+            "cache_read": 0, "cache_create": 0, "cost": 0.0,
+        })
+        bucket["calls"] += 1
+        bucket["input"] += c.get("input_tokens", 0) or 0
+        bucket["output"] += c.get("output_tokens", 0) or 0
+        bucket["cache_read"] += c.get("cache_read_tokens", 0) or 0
+        bucket["cache_create"] += c.get("cache_creation_tokens", 0) or 0
+        bucket["cost"] += c.get("cost_usd", 0.0) or 0.0
+
+    lines = [
+        f"✅ 태스크 완료 ({snapshot.get('task_id', '?')})",
+        f"⏱ {elapsed:.1f}s  🔧 tools {totals.get('tool_calls', 0)}  💬 LLM {totals.get('llm_calls', 0)}",
+        f"💰 ${cost_usd:.4f}",
+    ]
+    if by_model:
+        for model, b in sorted(by_model.items(), key=lambda kv: kv[1]["cost"], reverse=True):
+            cache_part = (
+                f" | cache r:{b['cache_read']:,} c:{b['cache_create']:,}"
+                if (b["cache_read"] or b["cache_create"]) else ""
+            )
+            lines.append(
+                f"  • {model}: {b['calls']}× "
+                f"in {b['input']:,} out {b['output']:,}{cache_part} → ${b['cost']:.4f}"
+            )
+    return "\n".join(lines)
+
+
+def _post_task_summary(snapshot: dict) -> None:
+    if not TASK_SUMMARY_ENABLED:
+        return
+    try:
+        import requests  # local import so we don't pay the cost on happy-path imports
+    except Exception:
+        return
+    try:
+        text = _format_task_summary(snapshot)
+        requests.post(TELEGRAM_BRIDGE_NOTIFY_URL, json={"text": text}, timeout=3)
+    except Exception as e:
+        # Never let notification failure impact the monologue shutdown.
+        logger.debug(f"[task_report] summary post failed: {e}")
+
+
 def finish_task(agent) -> dict | None:
     """Finalize report and write to disk. Called from monologue_end on the
-    normal completion path. Marks `ended_reason="completed"`.
+    normal completion path. Marks `ended_reason="completed"` and fires a
+    Telegram summary (fire-and-forget, disable with `AZ_TASK_SUMMARY=0`).
 
     NOTE: monologue_end does NOT fire on asyncio.CancelledError (kill via UI
     stop or api_terminate_chat). For those paths, the periodic saves from
     `save_task()` leave the latest snapshot on disk with
     `ended_reason="pending"`, and `sweep_orphans()` at next AZ startup
-    promotes them to "orphaned".
+    promotes them to "orphaned". No summary is posted on cancel by design —
+    a cancelled task is incomplete work, not a delivery.
     """
     r = get_report(agent)
     if r is None:
@@ -396,6 +490,14 @@ def finish_task(agent) -> dict | None:
     r["ended_reason"] = ENDED_COMPLETED
     try:
         _write_report(r, final=True)
+        # Build a snapshot with computed totals/elapsed for the notification.
+        summary_snapshot = dict(r)
+        started_ts = summary_snapshot.get("started_ts")
+        if isinstance(started_ts, (int, float)):
+            summary_snapshot["elapsed_sec"] = round(time.time() - started_ts, 3)
+        summary_snapshot.pop("started_ts", None)
+        summary_snapshot["totals"] = _compute_totals(summary_snapshot)
+        _post_task_summary(summary_snapshot)
     finally:
         agent.data.pop(DATA_KEY, None)
         agent.data.pop(PENDING_TOOL_KEY, None)

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -192,12 +192,21 @@ def save_task(agent) -> None:
 
 
 def sweep_orphans() -> int:
-    """Mark any leftover pending JSONs as orphaned. Called once on AZ startup
-    from an agent_init extension. Any file still reporting
-    `ended_reason == "pending"` at startup means the previous process died
-    mid-run or the task was cancelled (monologue_end never fired).
+    """Mark stale/legacy task JSONs with a proper `ended_reason`.
 
-    Returns the number of files rewritten.
+    Called once on AZ startup from an agent_init extension. Two fixes:
+
+    1. Any file with `ended_reason == "pending"` at startup — previous
+       process died mid-run or the task was cancelled (monologue_end
+       never fired). Promoted to `"orphaned"` with `ended_at=now`.
+
+    2. Legacy files (from before M2.1) that never had an `ended_reason`
+       field but do have an `ended_at` timestamp — clearly a completed
+       run. Tagged `"completed"` so /today aggregates don't lump them in
+       with true pendings. Files lacking BOTH fields are left alone
+       (shouldn't happen but best to be conservative).
+
+    Returns the total number of files rewritten.
     """
     count = 0
     try:
@@ -208,9 +217,18 @@ def sweep_orphans() -> int:
                 data = json.loads(p.read_text(encoding="utf-8"))
             except Exception:
                 continue
-            if data.get("ended_reason") == ENDED_PENDING:
+            changed = False
+            reason = data.get("ended_reason")
+            if reason == ENDED_PENDING:
                 data["ended_reason"] = ENDED_ORPHANED
                 data.setdefault("ended_at", _now_iso())
+                changed = True
+            elif reason is None and data.get("ended_at"):
+                # Legacy (pre-M2.1) JSON — annotate the completion state
+                # instead of defaulting aggregation code to "pending".
+                data["ended_reason"] = ENDED_COMPLETED
+                changed = True
+            if changed:
                 try:
                     p.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
                     count += 1
@@ -219,7 +237,7 @@ def sweep_orphans() -> int:
     except Exception as e:
         logger.warning(f"[task_report] sweep_orphans error: {e}")
     if count:
-        logger.info(f"[task_report] sweep_orphans: marked {count} file(s) as orphaned")
+        logger.info(f"[task_report] sweep_orphans: rewrote {count} file(s)")
     return count
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       - ./agent-zero/extensions/python/agent_init/_91_chunk_usage_probe.py:/a0/extensions/python/agent_init/_91_chunk_usage_probe.py:ro
       # Task post-report system (M1: raw capture) — issue #1
       - ./agent-zero/lib/task_report.py:/a0/helpers/task_report.py:ro
+      # M3: shared model-pricing helper (cache-aware cost_usd in task JSON + /usage)
+      - ./agent-zero/lib/pricing.py:/a0/helpers/pricing.py:ro
       # M2.1: startup sweep marks leftover pending JSONs as orphaned (cancel/kill)
       - ./agent-zero/extensions/python/agent_init/_80_task_report_sweep.py:/a0/extensions/python/agent_init/_80_task_report_sweep.py:ro
       - ./agent-zero/extensions/python/monologue_start/_50_task_report_begin.py:/a0/extensions/python/monologue_start/_50_task_report_begin.py:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,8 @@ services:
       - ./docs:/app/docs:ro
       - ./GUIDE.md:/app/GUIDE.md:ro
       - ./README.md:/app/README.md:ro
+      # M4: read AZ task JSONs for /today, /week, /tasks aggregation commands
+      - ./agent-zero/logs/tasks:/app/tasks:ro
     ports:
       - "8443:8443"   # 알림 webhook (내부용)
     depends_on:

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -56,6 +56,8 @@ usage_today: dict = {
     "date": datetime.now().strftime("%Y-%m-%d"),
     "input_tokens": 0,
     "output_tokens": 0,
+    "cache_read_tokens": 0,
+    "cache_creation_tokens": 0,
     "requests": 0,
     "cost_usd": 0.0,
     "by_model": {},  # 모델별 집계
@@ -87,16 +89,62 @@ def _load_model_cost_map():
     logger.warning("[Cost] Using fallback cost estimation")
 
 
-def calc_cost(model: str, input_tokens: int, output_tokens: int) -> float:
-    """모델별 토큰 비용 계산 (LiteLLM 가격표 기반)"""
-    model_info = _model_cost_map.get(model, {})
-    input_cost = model_info.get("input_cost_per_token", 0.000002)  # fallback $2/1M
-    output_cost = model_info.get("output_cost_per_token", 0.000008)  # fallback $8/1M
-    return (input_tokens * input_cost) + (output_tokens * output_cost)
+def _model_info(model: str) -> dict:
+    """Resolve a model name against the LiteLLM price map with AZ aliasing.
+
+    AZ tags streaming calls as "anthropic/claude-sonnet-4-6" but LiteLLM
+    keys them as "claude-sonnet-4-5-20250929". Try the exact key first,
+    then a few known aliases, then strip the `anthropic/` prefix.
+    """
+    if model in _model_cost_map:
+        return _model_cost_map[model]
+    aliases = {
+        "anthropic/claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
+        "claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
+        "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
+    }
+    if model in aliases and aliases[model] in _model_cost_map:
+        return _model_cost_map[aliases[model]]
+    if model.startswith("anthropic/"):
+        tail = model.split("/", 1)[1]
+        if tail in _model_cost_map:
+            return _model_cost_map[tail]
+    return {}
 
 
-def track_usage(model: str, input_tokens: int, output_tokens: int):
-    """사용량 누적"""
+def calc_cost(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+) -> float:
+    """Cache-aware cost calc. On Anthropic the provider-reported
+    `input_tokens` is already the regular-input-only count (cache_read /
+    cache_creation are billed separately), so we don't subtract — we just
+    price each bucket at its own rate.
+    """
+    info = _model_info(model)
+    in_rate = info.get("input_cost_per_token", 0.000003)      # $3 / 1M fallback
+    out_rate = info.get("output_cost_per_token", 0.000015)    # $15 / 1M
+    read_rate = info.get("cache_read_input_token_cost", in_rate * 0.10)
+    create_rate = info.get("cache_creation_input_token_cost", in_rate * 1.25)
+    return (
+        max(0, int(input_tokens)) * in_rate
+        + max(0, int(output_tokens)) * out_rate
+        + max(0, int(cache_read_tokens)) * read_rate
+        + max(0, int(cache_creation_tokens)) * create_rate
+    )
+
+
+def track_usage(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+):
+    """사용량 누적 (cache tokens 포함)"""
     global usage_today
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -104,37 +152,42 @@ def track_usage(model: str, input_tokens: int, output_tokens: int):
     if usage_today["date"] != today:
         if usage_today["requests"] > 0:
             usage_history.append(usage_today.copy())
-            # 최근 7일만 유지
             while len(usage_history) > 7:
                 usage_history.pop(0)
         usage_today = {
             "date": today,
             "input_tokens": 0,
             "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
             "requests": 0,
             "cost_usd": 0.0,
             "by_model": {},
         }
 
-    cost = calc_cost(model, input_tokens, output_tokens)
+    cost = calc_cost(model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
 
-    # 전체 합산
     usage_today["input_tokens"] += input_tokens
     usage_today["output_tokens"] += output_tokens
+    usage_today["cache_read_tokens"] = usage_today.get("cache_read_tokens", 0) + cache_read_tokens
+    usage_today["cache_creation_tokens"] = usage_today.get("cache_creation_tokens", 0) + cache_creation_tokens
     usage_today["requests"] += 1
     usage_today["cost_usd"] += cost
 
-    # 모델별 집계
     if model not in usage_today["by_model"]:
         usage_today["by_model"][model] = {
             "input_tokens": 0,
             "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
             "requests": 0,
             "cost_usd": 0.0,
         }
     m = usage_today["by_model"][model]
     m["input_tokens"] += input_tokens
     m["output_tokens"] += output_tokens
+    m["cache_read_tokens"] = m.get("cache_read_tokens", 0) + cache_read_tokens
+    m["cache_creation_tokens"] = m.get("cache_creation_tokens", 0) + cache_creation_tokens
     m["requests"] += 1
     m["cost_usd"] += cost
 
@@ -838,39 +891,50 @@ async def cmd_backup(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def cmd_usage(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """토큰 사용량 조회"""
+    """토큰 사용량 + 비용 조회 (cache 토큰 포함)"""
     if update.effective_chat.id != CHAT_ID:
         return
 
     today = usage_today
-    lines = [
-        f"📊 토큰 사용량 ({today['date']})\n",
-        f"총 요청: {today['requests']}건",
-        f"총 입력: {today['input_tokens']:,} 토큰",
-        f"총 출력: {today['output_tokens']:,} 토큰",
-        f"총 비용: ${today['cost_usd']:.4f}",
-    ]
+    cache_read = today.get("cache_read_tokens", 0)
+    cache_create = today.get("cache_creation_tokens", 0)
 
-    # 모델별 내역
+    # 캐시 절약 추정치: cache_read 만큼은 90% 할인된다고 가정 (Anthropic)
+    # 실절약 = cache_read × (input_rate - cache_read_rate) → 대략 input × 0.9
+    # 여기선 단순히 "정가라면 얼마였을지"만 보여준다.
+    lines = [
+        f"📊 오늘의 사용량 ({today['date']})\n",
+        f"요청: {today['requests']}건",
+        f"입력: {today['input_tokens']:,}  |  출력: {today['output_tokens']:,}",
+    ]
+    if cache_read or cache_create:
+        lines.append(
+            f"캐시: read {cache_read:,}  |  create {cache_create:,}"
+        )
+    lines.append(f"비용: ${today['cost_usd']:.4f}")
+
     by_model = today.get("by_model", {})
     if by_model:
-        lines.append("\n🤖 모델별 내역:")
+        lines.append("\n🤖 모델별:")
         for model, stats in sorted(by_model.items(), key=lambda x: x[1]["cost_usd"], reverse=True):
+            cr = stats.get("cache_read_tokens", 0)
+            cc = stats.get("cache_creation_tokens", 0)
+            cache_part = f" | cache r:{cr:,} c:{cc:,}" if (cr or cc) else ""
             lines.append(
                 f"  {model}\n"
                 f"    {stats['requests']}건 | "
-                f"in:{stats['input_tokens']:,} out:{stats['output_tokens']:,} | "
-                f"${stats['cost_usd']:.4f}"
+                f"in:{stats['input_tokens']:,} out:{stats['output_tokens']:,}{cache_part}\n"
+                f"    ${stats['cost_usd']:.4f}"
             )
 
     if usage_history:
-        lines.append("\n📈 최근 기록:")
+        lines.append("\n📈 최근 7일:")
         total_cost = 0.0
         for day in reversed(usage_history[-7:]):
             lines.append(f"  {day['date']}: {day['requests']}건, ${day['cost_usd']:.4f}")
             total_cost += day["cost_usd"]
         total_cost += today["cost_usd"]
-        lines.append(f"\n💰 총 누적: ${total_cost:.4f}")
+        lines.append(f"\n💰 7일+오늘 누적: ${total_cost:.4f}")
 
     await update.message.reply_text("\n".join(lines))
 
@@ -961,17 +1025,24 @@ async def webhook_handler(request):
 
 
 async def usage_track_handler(request):
-    """HTTP POST로 토큰 사용량 기록
-    Usage: curl -X POST http://telegram-bridge:8443/track \
-           -H 'Content-Type: application/json' \
-           -d '{"model": "gpt-4.1", "input_tokens": 1500, "output_tokens": 500}'
+    """HTTP POST로 토큰 사용량 기록 (cache 토큰 포함).
+
+    Payload: {
+        "model": "anthropic/claude-sonnet-4-6",
+        "input_tokens": 1500,
+        "output_tokens": 500,
+        "cache_read_tokens": 0,     # optional (Anthropic prompt caching)
+        "cache_creation_tokens": 0  # optional
+    }
     """
     try:
         data = await request.json()
         model = data.get("model", "unknown")
         input_tokens = int(data.get("input_tokens", 0))
         output_tokens = int(data.get("output_tokens", 0))
-        track_usage(model, input_tokens, output_tokens)
+        cache_read = int(data.get("cache_read_tokens", 0))
+        cache_creation = int(data.get("cache_creation_tokens", 0))
+        track_usage(model, input_tokens, output_tokens, cache_read, cache_creation)
         return web.json_response({
             "ok": True,
             "today": usage_today,

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -551,7 +551,10 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "• /new → 새 대화 시작\n"
         "• /logs → 전체 로그 파일 전송\n"
         "• /docs → 문서 목록/열람\n"
-        "• /usage → 토큰 사용량/비용 조회\n"
+        "• /usage → 세션 내 토큰/비용 (휘발성)\n"
+        "• /today → 오늘의 태스크 집계 (task JSON 기반)\n"
+        "• /week → 최근 7일 집계\n"
+        "• /tasks [N] → 최근 N개 태스크 목록\n"
         "• /backup → 설정 백업 파일 전송\n"
         "• /monitor_on → 모니터링 켜기\n"
         "• /monitor_off → 모니터링 끄기\n"
@@ -890,6 +893,234 @@ async def cmd_backup(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(f"백업 실패: {str(e)}")
 
 
+# ── Task JSON aggregation (issue #1 M2) ──
+TASKS_DIR = "/app/tasks"
+
+
+def _load_task_jsons() -> list[dict]:
+    """Read every task JSON from the mounted AZ logs dir.
+
+    Returns a list of parsed dicts sorted by `started_at` ascending.
+    Malformed files are skipped silently; they show up in logs once and
+    then get ignored so /today doesn't crash on a single bad file.
+    """
+    if not os.path.isdir(TASKS_DIR):
+        return []
+    items: list[dict] = []
+    for name in os.listdir(TASKS_DIR):
+        if not name.endswith(".json") or name.endswith(".tmp"):
+            continue
+        path = os.path.join(TASKS_DIR, name)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                items.append(json.load(f))
+        except Exception as e:
+            logger.debug(f"skip bad task json {name}: {e}")
+    items.sort(key=lambda r: r.get("started_at") or "")
+    return items
+
+
+def _aggregate(tasks: list[dict]) -> dict:
+    """Sum totals across a list of tasks, also grouping by model and status."""
+    agg = {
+        "tasks": len(tasks),
+        "completed": 0,
+        "orphaned": 0,
+        "pending": 0,
+        "tool_calls": 0,
+        "llm_calls": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cost_usd": 0.0,
+        "by_model": {},
+    }
+    for t in tasks:
+        reason = t.get("ended_reason", "pending")
+        if reason in agg:
+            agg[reason] += 1
+        totals = t.get("totals") or {}
+        for k in ("tool_calls", "llm_calls", "input_tokens", "output_tokens",
+                  "cache_read_tokens", "cache_creation_tokens"):
+            agg[k] += int(totals.get(k, 0) or 0)
+        agg["cost_usd"] += float(totals.get("cost_usd", 0.0) or 0.0)
+        for c in t.get("llm_calls") or []:
+            m = c.get("model") or "unknown"
+            bucket = agg["by_model"].setdefault(m, {
+                "calls": 0, "input": 0, "output": 0,
+                "cache_read": 0, "cache_create": 0, "cost": 0.0,
+            })
+            bucket["calls"] += 1
+            bucket["input"] += int(c.get("input_tokens", 0) or 0)
+            bucket["output"] += int(c.get("output_tokens", 0) or 0)
+            bucket["cache_read"] += int(c.get("cache_read_tokens", 0) or 0)
+            bucket["cache_create"] += int(c.get("cache_creation_tokens", 0) or 0)
+            bucket["cost"] += float(c.get("cost_usd", 0.0) or 0.0)
+    agg["cost_usd"] = round(agg["cost_usd"], 6)
+    return agg
+
+
+def _filter_date_range(tasks: list[dict], start, end) -> list[dict]:
+    """Filter tasks whose `started_at` (ISO, UTC) falls in [start, end).
+
+    `start` and `end` are `datetime` objects (naive; treated as local time).
+    AZ writes started_at in UTC with +00:00 offset, so we compare with
+    the task's UTC instant by parsing the full ISO string.
+    """
+    out = []
+    for t in tasks:
+        started = t.get("started_at")
+        if not started:
+            continue
+        try:
+            # fromisoformat handles "+00:00"
+            ts = datetime.fromisoformat(started)
+        except Exception:
+            continue
+        # Compare in local time (user's wall clock) since /today means "today
+        # in my timezone."
+        ts_local = ts.astimezone().replace(tzinfo=None) if ts.tzinfo else ts
+        if start <= ts_local < end:
+            out.append(t)
+    return out
+
+
+def _format_agg_block(title: str, agg: dict) -> list[str]:
+    """Render an aggregate dict as a Telegram-friendly block."""
+    lines = [
+        f"📊 {title}",
+        f"  태스크: {agg['tasks']}건 "
+        f"(✅{agg['completed']} ⚠️{agg['orphaned']} ⏳{agg['pending']})",
+    ]
+    if agg["tasks"] == 0:
+        return lines
+    lines.append(
+        f"  LLM 호출: {agg['llm_calls']}건 · 도구: {agg['tool_calls']}건"
+    )
+    lines.append(
+        f"  토큰: in {agg['input_tokens']:,} · out {agg['output_tokens']:,}"
+    )
+    if agg["cache_read_tokens"] or agg["cache_creation_tokens"]:
+        lines.append(
+            f"  캐시: read {agg['cache_read_tokens']:,} · "
+            f"create {agg['cache_creation_tokens']:,}"
+        )
+    lines.append(f"  💰 ${agg['cost_usd']:.4f}")
+    return lines
+
+
+async def cmd_today(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Today's task aggregate from on-disk JSONs."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    tasks = _load_task_jsons()
+    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    tomorrow = today_start + timedelta(days=1)
+    todays = _filter_date_range(tasks, today_start, tomorrow)
+    agg = _aggregate(todays)
+
+    lines = _format_agg_block(f"오늘 ({today_start.strftime('%Y-%m-%d')})", agg)
+
+    by_model = agg.get("by_model", {})
+    if by_model:
+        lines.append("\n🤖 모델별:")
+        for model, b in sorted(by_model.items(), key=lambda kv: kv[1]["cost"], reverse=True):
+            cache = (
+                f" | cache r:{b['cache_read']:,} c:{b['cache_create']:,}"
+                if (b["cache_read"] or b["cache_create"]) else ""
+            )
+            lines.append(
+                f"  • {model}: {b['calls']}× "
+                f"in {b['input']:,} out {b['output']:,}{cache} → ${b['cost']:.4f}"
+            )
+
+    await update.message.reply_text("\n".join(lines))
+
+
+async def cmd_week(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Last 7 days: daily breakdown + grand totals."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    all_tasks = _load_task_jsons()
+    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    week_start = today_start - timedelta(days=6)  # last 7 days including today
+    week_end = today_start + timedelta(days=1)
+    window = _filter_date_range(all_tasks, week_start, week_end)
+
+    lines = [f"📈 최근 7일 ({week_start.strftime('%m-%d')} ~ {today_start.strftime('%m-%d')})\n"]
+
+    # Per-day rows
+    days_with_data = 0
+    for i in range(7):
+        day_start = week_start + timedelta(days=i)
+        day_end = day_start + timedelta(days=1)
+        day_tasks = _filter_date_range(window, day_start, day_end)
+        if not day_tasks:
+            continue
+        days_with_data += 1
+        agg = _aggregate(day_tasks)
+        lines.append(
+            f"  {day_start.strftime('%m-%d')}: "
+            f"{agg['tasks']}건 · {agg['llm_calls']} LLM · ${agg['cost_usd']:.4f}"
+        )
+
+    if days_with_data == 0:
+        lines.append("  (데이터 없음)")
+
+    # Grand total
+    grand = _aggregate(window)
+    lines.append("")
+    lines.extend(_format_agg_block("주간 합계", grand))
+    by_model = grand.get("by_model", {})
+    if by_model:
+        lines.append("\n🤖 모델별 (주간):")
+        for model, b in sorted(by_model.items(), key=lambda kv: kv[1]["cost"], reverse=True):
+            lines.append(f"  • {model}: {b['calls']}× → ${b['cost']:.4f}")
+
+    await update.message.reply_text("\n".join(lines))
+
+
+async def cmd_tasks(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """List the most recent N tasks with individual summaries (default 10)."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    n = 10
+    args = context.args
+    if args:
+        try:
+            n = max(1, min(50, int(args[0])))
+        except ValueError:
+            pass
+    tasks = _load_task_jsons()
+    recent = list(reversed(tasks[-n:]))
+    if not recent:
+        await update.message.reply_text("최근 태스크가 없습니다.")
+        return
+
+    lines = [f"🗂 최근 {len(recent)}개 태스크\n"]
+    status_icon = {"completed": "✅", "orphaned": "⚠️", "pending": "⏳"}
+    for t in recent:
+        tid = t.get("task_id", "?")
+        reason = t.get("ended_reason", "pending")
+        icon = status_icon.get(reason, "•")
+        elapsed = t.get("elapsed_sec", 0) or 0
+        totals = t.get("totals") or {}
+        cost = totals.get("cost_usd", 0.0) or 0.0
+        # Short HH:MM:SS from task_id (task-YYYYMMDD-HHMMSS-xxxxxx)
+        parts = tid.split("-")
+        when = "?"
+        if len(parts) >= 3 and len(parts[2]) == 6:
+            when = f"{parts[2][:2]}:{parts[2][2:4]}:{parts[2][4:6]}"
+        lines.append(
+            f"{icon} {when} {elapsed:.0f}s · "
+            f"LLM {totals.get('llm_calls', 0)} · "
+            f"도구 {totals.get('tool_calls', 0)} · "
+            f"${cost:.4f}"
+        )
+    await update.message.reply_text("\n".join(lines))
+
+
 async def cmd_usage(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """토큰 사용량 + 비용 조회 (cache 토큰 포함)"""
     if update.effective_chat.id != CHAT_ID:
@@ -994,7 +1225,10 @@ async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "  /follow_off → 채팅 자동 추적 끄기\n\n"
         "상태/비용:\n"
         "  /status → Agent Zero 상태 확인\n"
-        "  /usage → 토큰 사용량 및 비용 조회\n"
+        "  /usage → 세션 내 토큰/비용 (bridge 재시작 시 초기화)\n"
+        "  /today → 오늘의 태스크 집계 (영구 데이터)\n"
+        "  /week → 최근 7일 일별 + 합계\n"
+        "  /tasks [N] → 최근 N개 태스크 목록 (기본 10)\n"
         "  /backup → 설정 경량 백업 (ZIP 파일 전송)\n"
         "  /help → 도움말"
     )
@@ -1131,6 +1365,9 @@ def main():
     app.add_handler(CommandHandler("logs", cmd_logs))
     app.add_handler(CommandHandler("docs", cmd_docs))
     app.add_handler(CommandHandler("usage", cmd_usage))
+    app.add_handler(CommandHandler("today", cmd_today))
+    app.add_handler(CommandHandler("week", cmd_week))
+    app.add_handler(CommandHandler("tasks", cmd_tasks))
     app.add_handler(CommandHandler("backup", cmd_backup))
     app.add_handler(CommandHandler("monitor_on", cmd_monitor_on))
     app.add_handler(CommandHandler("monitor_off", cmd_monitor_off))


### PR DESCRIPTION
## Summary
PR #16 (M3) 과 PR #17 (M4) 은 stacked base (`feat/m2.1-cancel-fallback`, `feat/m3-cost-reporting`) 로 squash-merge 되었으나, 해당 base branch 들이 main 으로 다시 올라오지 않아 **main 에 M3 / M4 변경이 반영되지 않음**. 이 PR 로 누락분을 main 에 직접 머지.

포함된 커밋 2개:
- `c4cd19d` feat(observability): M3 per-task cost reporting + cache-aware /usage
- `8b23193` feat(observability): M4 /today /week /tasks aggregation commands

## What lands

### M3 — per-task cost reporting
- `agent-zero/lib/pricing.py` 신규 — LiteLLM 가격표 lazy-load + 로컬 fallback, AZ alias 테이블
- `task_report.py` 의 `llm_call` / `_compute_totals` 가 `cost_usd` 필드 기록
- 태스크 종료 시 telegram-bridge `/notify` 로 cost summary POST
- `telegram-bridge/bot.py` `/usage` 가 cache_read / cache_creation 토큰 반영

### M4 — daily/weekly aggregation
- `telegram-bridge/bot.py` 에 `/today`, `/week`, `/tasks N` 명령어 추가
- `logs/tasks/*.json` 을 `TASKS_DIR=/app/tasks` (read-only 마운트) 로 읽어 집계
- `docker-compose.yml` 에 `./agent-zero/logs/tasks:/app/tasks:ro` 마운트

## Test plan
- [x] 로컬에서 21 개 on-disk task JSON 집계 확인
- [x] `/today` / `/week` / `/tasks 10` 출력 형식 검증
- [x] Sonnet per-call cost 손계산 일치 (\$3/\$15/\$0.30/\$3.75 per 1M)
- [x] `/notify` HTTP 200 확인
- [ ] main merge 후 `docker compose up -d` 로 재기동 및 실제 동작 검증