### PR TITLE
fix(observability): KST timezone + data quality banner (#24 Wave 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ backups/
 # Python cache
 __pycache__/
 *.pyc
+
+# Local Docker Compose overrides (personal mounts, test-only)
+docker-compose.override.yml
+docker-compose.override.yaml

--- a/agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py
+++ b/agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py
@@ -1,0 +1,41 @@
+"""
+Record a utility-model LLM call (Haiku, naming/summarization side-calls)
+after each `call_utility_model()` invocation.
+
+Context
+-------
+Agent Zero v1.9 invokes `util_model_call_after` at agent.py:788 with
+`call_data=call_data, response=response`, but ships no extensions for it —
+so util_model calls (usually the lighter Haiku model) never landed in the
+per-task JSON, even though chat_model calls did. Result: Task JSON and
+per-task cost summaries undercounted the util-model tail by the full
+number of Haiku calls (measured: ~71 calls / day on an active agent).
+
+The LiteLLM stream probe (agent_init/_91_chunk_usage_probe.py) already
+wraps `litellm.acompletion` at module load — it intercepts util streams
+too, and stashes real token usage into the shared `last_stream_usage`
+ContextVar. Routing the util path through the same `llm_call()` helper as
+chat_model is enough: the helper consumes that ContextVar and falls back
+to `approximate_tokens` when unavailable.
+
+Coverage matrix after this hook:
+    path             stream?   Task JSON    Telegram /usage
+    chat_model_call  yes       ✓ (chat hook)   ✓ (probe POST)
+    util_model_call  yes       ✓ (this hook)   ✓ (probe POST)
+    util_model_call  no        ✓ (this hook)*  ✓ (_90 success cb)
+    * approximate tokens; real usage lands if LiteLLM success callback
+      fires between unified_call return and this hook.
+
+See issue #24 Wave 2.
+"""
+
+from helpers.extension import Extension
+from helpers.task_report import llm_call
+
+
+class TaskReportUtilLLM(Extension):
+    async def execute(self, call_data=None, response=None, **kwargs):
+        # Same shape as chat_model_call_after minus the `reasoning` arg —
+        # util_model doesn't expose reasoning content. `response` is the
+        # assembled completion string, mirroring the chat path.
+        llm_call(self.agent, call_data, response)

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -306,6 +306,26 @@ def _extract_cache_tokens(usage) -> tuple[int, int]:
     return read, creation
 
 
+def _normalize_model(model: str | None) -> str | None:
+    """Canonicalize a model identifier before it lands in task JSON.
+
+    LiteLLM sometimes emits `anthropic/claude-sonnet-4-6` (provider-prefixed
+    form, used on the stream/util path) and sometimes `claude-sonnet-4-6`
+    (bare form, used on the chat path). Downstream aggregators — /today's
+    per-model breakdown, task summaries, /usage group-bys — compare by raw
+    string, so the two forms get charted as separate models despite being
+    identical. Strip the prefix here so every aggregator sees one name.
+
+    Keeps unknown providers (e.g. `openai/gpt-4o`) untouched — only
+    Anthropic drifts between the two forms inside AZ today (issue #24).
+    """
+    if not isinstance(model, str) or not model:
+        return model
+    if model.startswith("anthropic/"):
+        return model.split("/", 1)[1]
+    return model
+
+
 def _estimate_input_tokens(call_data) -> int:
     if not isinstance(call_data, dict):
         return 0
@@ -364,6 +384,11 @@ def llm_call(agent, call_data, response, reasoning=None) -> None:
             model = rm
     if not isinstance(model, str):
         model = None
+
+    # Collapse provider-prefixed and bare forms into a single canonical key so
+    # per-model aggregates don't split the same model into two rows. See
+    # `_normalize_model` docstring.
+    model = _normalize_model(model)
 
     # Priority:
     # 1) ContextVar from stream-usage-capture extension (real + cache fields)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     env_file:
       - .env
     environment:
+      - TZ=Asia/Seoul  # /today /week 집계 및 로그 타임스탬프를 KST 로 일관화 (issue #24)
       - GIT_USER_NAME=${GIT_USER_NAME}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL}
       - GITHUB_TOKEN=${GITHUB_TOKEN}
@@ -70,6 +71,7 @@ services:
     build: ./telegram-bridge
     container_name: telegram-bridge
     environment:
+      - TZ=Asia/Seoul  # /today /week 경계 + daily usage reset 을 KST 로 일관화 (issue #24)
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
       - AZ_API_URL=http://agent-zero:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,9 @@ services:
       - ./agent-zero/extensions/python/tool_execute_before/_50_task_report_tool_start.py:/a0/extensions/python/tool_execute_before/_50_task_report_tool_start.py:ro
       - ./agent-zero/extensions/python/tool_execute_after/_50_task_report_tool_end.py:/a0/extensions/python/tool_execute_after/_50_task_report_tool_end.py:ro
       - ./agent-zero/extensions/python/chat_model_call_after/_50_task_report_llm.py:/a0/extensions/python/chat_model_call_after/_50_task_report_llm.py:ro
+      # Wave 2 (issue #24): util_model_call_after fires from agent.py but had
+      # no extension listening — ~71 Haiku calls/day were missing from task JSON.
+      - ./agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py:/a0/extensions/python/util_model_call_after/_50_task_report_util_llm.py:ro
       - ./agent-zero/extensions/python/monologue_end/_50_task_report_finish.py:/a0/extensions/python/monologue_end/_50_task_report_finish.py:ro
       - ./agent-zero/settings.json:/a0/usr/settings.json
     entrypoint: ["/bin/sh", "-c", "sh /a0/git-init.sh && exec /exe/initialize.sh ${BRANCH:-main}"]

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -152,6 +152,22 @@ def calc_cost(
     )
 
 
+def _normalize_model(model: str) -> str:
+    """Canonicalize model name before aggregating.
+
+    LiteLLM's kwargs["model"] and the stream-probe POST sometimes carry the
+    provider prefix (`anthropic/claude-sonnet-4-6`) and sometimes don't
+    (`claude-sonnet-4-6`). Without this the `by_model` dict splits one model
+    into two rows with mismatched cache/cost stats. Mirrors the same helper
+    now living in agent-zero/lib/task_report.py (issue #24 Wave 2).
+    """
+    if not isinstance(model, str) or not model:
+        return model
+    if model.startswith("anthropic/"):
+        return model.split("/", 1)[1]
+    return model
+
+
 def track_usage(
     model: str,
     input_tokens: int,
@@ -161,6 +177,8 @@ def track_usage(
 ):
     """사용량 누적 (cache tokens 포함)"""
     global usage_today
+    # Collapse provider-prefixed and bare forms so /today by_model stays unified.
+    model = _normalize_model(model)
     today = _kst_now().strftime("%Y-%m-%d")
 
     # 날짜가 바뀌면 리셋

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -13,11 +13,26 @@ import logging
 import json
 import io
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from collections import defaultdict
 import aiohttp
 from telegram import Update, Bot
 from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
 from aiohttp import web, CookieJar
+
+# ── Timezone ──
+# 모든 /today /week /tasks 날짜 경계와 daily-usage reset 은 KST 로 정규화한다.
+# 컨테이너 OS 타임존(Docker 기본=UTC)과 무관하게 일관된 일자 경계를 보장.
+KST = ZoneInfo("Asia/Seoul")
+
+
+def _kst_now() -> datetime:
+    """Current time as a naive datetime in KST wall-clock.
+
+    Naive 로 반환하는 이유: 기존 `_filter_date_range` 비교 로직이 naive 기준이라
+    호환성을 유지하기 위함. 내부적으로는 모두 KST 기준이다.
+    """
+    return datetime.now(KST).replace(tzinfo=None)
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -53,7 +68,7 @@ cached_contexts: list = []
 
 # ── 토큰 사용량 추적 ──
 usage_today: dict = {
-    "date": datetime.now().strftime("%Y-%m-%d"),
+    "date": _kst_now().strftime("%Y-%m-%d"),
     "input_tokens": 0,
     "output_tokens": 0,
     "cache_read_tokens": 0,
@@ -146,7 +161,7 @@ def track_usage(
 ):
     """사용량 누적 (cache tokens 포함)"""
     global usage_today
-    today = datetime.now().strftime("%Y-%m-%d")
+    today = _kst_now().strftime("%Y-%m-%d")
 
     # 날짜가 바뀌면 리셋
     if usage_today["date"] != today:
@@ -964,9 +979,10 @@ def _aggregate(tasks: list[dict]) -> dict:
 def _filter_date_range(tasks: list[dict], start, end) -> list[dict]:
     """Filter tasks whose `started_at` (ISO, UTC) falls in [start, end).
 
-    `start` and `end` are `datetime` objects (naive; treated as local time).
-    AZ writes started_at in UTC with +00:00 offset, so we compare with
-    the task's UTC instant by parsing the full ISO string.
+    `start` and `end` are naive `datetime` objects treated as **KST wall clock**.
+    AZ writes started_at in UTC with +00:00 offset; we convert each task's
+    UTC instant to KST before comparing, so "today" means "today in KST"
+    regardless of the container OS timezone.
     """
     out = []
     for t in tasks:
@@ -978,12 +994,61 @@ def _filter_date_range(tasks: list[dict], start, end) -> list[dict]:
             ts = datetime.fromisoformat(started)
         except Exception:
             continue
-        # Compare in local time (user's wall clock) since /today means "today
-        # in my timezone."
-        ts_local = ts.astimezone().replace(tzinfo=None) if ts.tzinfo else ts
+        # Normalize to KST wall-clock for date-boundary comparison.
+        if ts.tzinfo:
+            ts_local = ts.astimezone(KST).replace(tzinfo=None)
+        else:
+            ts_local = ts  # assume caller already passed KST-naive
         if start <= ts_local < end:
             out.append(t)
     return out
+
+
+def _data_quality_summary(tasks: list[dict]) -> dict:
+    """Scan a task list for known observability gaps (M1/M2/M3 evolution).
+
+    These gaps mean the per-task cost / token numbers drift from Anthropic
+    Console reality. We surface the counts in /today and /week so the user
+    knows when to trust the number.
+
+    Returns:
+        {
+          "total":       total tasks in window,
+          "legacy_cost": tasks without totals.cost_usd (pre-M3 schema),
+          "approximate": tasks with any approximate-token LLM call (pre-M2 str
+                         response bug),
+        }
+    """
+    legacy_cost = 0
+    approximate = 0
+    for t in tasks:
+        totals = t.get("totals") or {}
+        if "cost_usd" not in totals:
+            legacy_cost += 1
+        for c in t.get("llm_calls") or []:
+            if c.get("tokens_approximate"):
+                approximate += 1
+                break
+    return {
+        "total": len(tasks),
+        "legacy_cost": legacy_cost,
+        "approximate": approximate,
+    }
+
+
+def _quality_banner(dq: dict) -> str | None:
+    """Return a one-line caveat if any data quality gap is present, else None."""
+    if dq["legacy_cost"] == 0 and dq["approximate"] == 0:
+        return None
+    parts = []
+    if dq["legacy_cost"]:
+        parts.append(f"M3 이전 {dq['legacy_cost']}건")
+    if dq["approximate"]:
+        parts.append(f"근사 토큰 {dq['approximate']}건")
+    return (
+        "⚠️ 신뢰도: " + " / ".join(parts)
+        + " — Anthropic 대시보드와 차이 있을 수 있음"
+    )
 
 
 def _format_agg_block(title: str, agg: dict) -> list[str]:
@@ -1011,16 +1076,21 @@ def _format_agg_block(title: str, agg: dict) -> list[str]:
 
 
 async def cmd_today(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Today's task aggregate from on-disk JSONs."""
+    """Today's task aggregate from on-disk JSONs (KST boundary)."""
     if update.effective_chat.id != CHAT_ID:
         return
     tasks = _load_task_jsons()
-    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    today_start = _kst_now().replace(hour=0, minute=0, second=0, microsecond=0)
     tomorrow = today_start + timedelta(days=1)
     todays = _filter_date_range(tasks, today_start, tomorrow)
     agg = _aggregate(todays)
 
-    lines = _format_agg_block(f"오늘 ({today_start.strftime('%Y-%m-%d')})", agg)
+    lines = _format_agg_block(f"오늘 ({today_start.strftime('%Y-%m-%d')} KST)", agg)
+
+    # Data quality caveat (issue #24)
+    banner = _quality_banner(_data_quality_summary(todays))
+    if banner:
+        lines.insert(1, banner)
 
     by_model = agg.get("by_model", {})
     if by_model:
@@ -1039,16 +1109,22 @@ async def cmd_today(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def cmd_week(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Last 7 days: daily breakdown + grand totals."""
+    """Last 7 days: daily breakdown + grand totals (KST boundary)."""
     if update.effective_chat.id != CHAT_ID:
         return
     all_tasks = _load_task_jsons()
-    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    today_start = _kst_now().replace(hour=0, minute=0, second=0, microsecond=0)
     week_start = today_start - timedelta(days=6)  # last 7 days including today
     week_end = today_start + timedelta(days=1)
     window = _filter_date_range(all_tasks, week_start, week_end)
 
-    lines = [f"📈 최근 7일 ({week_start.strftime('%m-%d')} ~ {today_start.strftime('%m-%d')})\n"]
+    lines = [f"📈 최근 7일 ({week_start.strftime('%m-%d')} ~ {today_start.strftime('%m-%d')} KST)"]
+
+    # Data quality caveat (issue #24)
+    banner = _quality_banner(_data_quality_summary(window))
+    if banner:
+        lines.append(banner)
+    lines.append("")
 
     # Per-day rows
     days_with_data = 0


### PR DESCRIPTION
## Summary

Issue #24 Wave 1 — `/today` `/week` 가 Anthropic Console 과 왜 불일치했는지 **사용자가 신뢰 여부를 판단할 수 있게** 두 가지 문제를 먼저 해결.

- **Option A — 데이터 품질 배너**: legacy (M3 이전 cost_usd 없음), approximate (M2 이전 str response bug) 태스크 개수를 집계 헤더에 표시
- **Option C — 타임존 정규화**: 컨테이너 OS TZ(UTC) 대신 KST 로 일자 경계 명시

## Changes

### `telegram-bridge/bot.py`
- `from zoneinfo import ZoneInfo` + `KST = ZoneInfo("Asia/Seoul")` 상수
- `_kst_now()` 헬퍼 — naive KST datetime 반환 (기존 비교 로직 호환)
- `_filter_date_range` — `ts.astimezone(KST)` 로 명시 (이전: OS 로컬 = 컨테이너 UTC)
- `_data_quality_summary(tasks)` — legacy_cost / approximate 건수 스캔
- `_quality_banner(dq)` — 갭이 있을 때만 1 줄 배너 반환
- `cmd_today` / `cmd_week` — 배너 prepend, 타이틀에 ` KST` 표기
- `track_usage` / `usage_today` 초기화 — `_kst_now()` 사용

### `docker-compose.yml`
- `agent-zero` + `telegram-bridge` 에 `TZ=Asia/Seoul` 추가

## Verification

### Before
```
$ docker exec telegram-bridge date
Thu Apr 23 07:59:XX UTC 2026

/today  → 22 tasks (오늘 전체인 줄 알았으나 실제로는 UTC 00:00 이후만)
```

### After
```
$ docker exec telegram-bridge date
Thu Apr 23 16:59:42 KST 2026

/today (simulated via python3 import):
  📊 오늘 (2026-04-23 KST)
  ⚠️ 신뢰도: M3 이전 20건 / 근사 토큰 12건 — Anthropic 대시보드와 차이 있을 수 있음
    태스크: 28건 (✅27 ⚠️1 ⏳0)
    ...
```

### Key findings during verification
- **6 tasks 누락 버그 확증**: UTC 경계로 인해 `/today` 가 22/28 만 잡고 있었음 (KST 기준 00:00~08:59 분량이 전일로 빠짐)
- **배너 정합성**: 28 태스크 중 legacy_cost=20, approximate=12 — 기존 진단과 일치

## Follow-up (Wave 2 — 별도 PR)

이번 PR 후에도 남은 #24 sub-tasks:
- [ ] `util_model_call_*` 경로 Task JSON 기록 누락 → probe 통합 (Haiku 0/71 건 문제)
- [ ] 모델명 prefix normalization (`anthropic/claude-sonnet-4-6` vs `claude-sonnet-4-6` 이중 카운트)
- [ ] Stream usage capture 정확도 개선 (Haiku 토큰 66% 누락 원인)

## Test plan

- [x] `docker compose up -d --build telegram-bridge` 후 `date` 가 KST 반환
- [x] `_kst_now()` 가 KST wall-clock 반환
- [x] `_filter_date_range` 가 KST 기준 [00:00, 익일 00:00) 로 필터
- [x] `_data_quality_summary` 가 legacy_cost / approximate 정확 카운트
- [x] `_quality_banner` 가 0/0 이면 None, 아니면 포맷 스트링
- [ ] merge 후 실제 텔레그램에서 `/today` `/week` 호출해서 UI 확인