### PR TITLE
fix(observability): util_model hook + model-name normalization (#24 Wave 2)

### DIFF
--- a/agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py
+++ b/agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py
@@ -1,0 +1,41 @@
+"""
+Record a utility-model LLM call (Haiku, naming/summarization side-calls)
+after each `call_utility_model()` invocation.
+
+Context
+-------
+Agent Zero v1.9 invokes `util_model_call_after` at agent.py:788 with
+`call_data=call_data, response=response`, but ships no extensions for it —
+so util_model calls (usually the lighter Haiku model) never landed in the
+per-task JSON, even though chat_model calls did. Result: Task JSON and
+per-task cost summaries undercounted the util-model tail by the full
+number of Haiku calls (measured: ~71 calls / day on an active agent).
+
+The LiteLLM stream probe (agent_init/_91_chunk_usage_probe.py) already
+wraps `litellm.acompletion` at module load — it intercepts util streams
+too, and stashes real token usage into the shared `last_stream_usage`
+ContextVar. Routing the util path through the same `llm_call()` helper as
+chat_model is enough: the helper consumes that ContextVar and falls back
+to `approximate_tokens` when unavailable.
+
+Coverage matrix after this hook:
+    path             stream?   Task JSON    Telegram /usage
+    chat_model_call  yes       ✓ (chat hook)   ✓ (probe POST)
+    util_model_call  yes       ✓ (this hook)   ✓ (probe POST)
+    util_model_call  no        ✓ (this hook)*  ✓ (_90 success cb)
+    * approximate tokens; real usage lands if LiteLLM success callback
+      fires between unified_call return and this hook.
+
+See issue #24 Wave 2.
+"""
+
+from helpers.extension import Extension
+from helpers.task_report import llm_call
+
+
+class TaskReportUtilLLM(Extension):
+    async def execute(self, call_data=None, response=None, **kwargs):
+        # Same shape as chat_model_call_after minus the `reasoning` arg —
+        # util_model doesn't expose reasoning content. `response` is the
+        # assembled completion string, mirroring the chat path.
+        llm_call(self.agent, call_data, response)

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -306,6 +306,26 @@ def _extract_cache_tokens(usage) -> tuple[int, int]:
     return read, creation
 
 
+def _normalize_model(model: str | None) -> str | None:
+    """Canonicalize a model identifier before it lands in task JSON.
+
+    LiteLLM sometimes emits `anthropic/claude-sonnet-4-6` (provider-prefixed
+    form, used on the stream/util path) and sometimes `claude-sonnet-4-6`
+    (bare form, used on the chat path). Downstream aggregators — /today's
+    per-model breakdown, task summaries, /usage group-bys — compare by raw
+    string, so the two forms get charted as separate models despite being
+    identical. Strip the prefix here so every aggregator sees one name.
+
+    Keeps unknown providers (e.g. `openai/gpt-4o`) untouched — only
+    Anthropic drifts between the two forms inside AZ today (issue #24).
+    """
+    if not isinstance(model, str) or not model:
+        return model
+    if model.startswith("anthropic/"):
+        return model.split("/", 1)[1]
+    return model
+
+
 def _estimate_input_tokens(call_data) -> int:
     if not isinstance(call_data, dict):
         return 0
@@ -364,6 +384,11 @@ def llm_call(agent, call_data, response, reasoning=None) -> None:
             model = rm
     if not isinstance(model, str):
         model = None
+
+    # Collapse provider-prefixed and bare forms into a single canonical key so
+    # per-model aggregates don't split the same model into two rows. See
+    # `_normalize_model` docstring.
+    model = _normalize_model(model)
 
     # Priority:
     # 1) ContextVar from stream-usage-capture extension (real + cache fields)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,9 @@ services:
       - ./agent-zero/extensions/python/tool_execute_before/_50_task_report_tool_start.py:/a0/extensions/python/tool_execute_before/_50_task_report_tool_start.py:ro
       - ./agent-zero/extensions/python/tool_execute_after/_50_task_report_tool_end.py:/a0/extensions/python/tool_execute_after/_50_task_report_tool_end.py:ro
       - ./agent-zero/extensions/python/chat_model_call_after/_50_task_report_llm.py:/a0/extensions/python/chat_model_call_after/_50_task_report_llm.py:ro
+      # Wave 2 (issue #24): util_model_call_after fires from agent.py but had
+      # no extension listening — ~71 Haiku calls/day were missing from task JSON.
+      - ./agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py:/a0/extensions/python/util_model_call_after/_50_task_report_util_llm.py:ro
       - ./agent-zero/extensions/python/monologue_end/_50_task_report_finish.py:/a0/extensions/python/monologue_end/_50_task_report_finish.py:ro
       - ./agent-zero/settings.json:/a0/usr/settings.json
     entrypoint: ["/bin/sh", "-c", "sh /a0/git-init.sh && exec /exe/initialize.sh ${BRANCH:-main}"]

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -152,6 +152,22 @@ def calc_cost(
     )
 
 
+def _normalize_model(model: str) -> str:
+    """Canonicalize model name before aggregating.
+
+    LiteLLM's kwargs["model"] and the stream-probe POST sometimes carry the
+    provider prefix (`anthropic/claude-sonnet-4-6`) and sometimes don't
+    (`claude-sonnet-4-6`). Without this the `by_model` dict splits one model
+    into two rows with mismatched cache/cost stats. Mirrors the same helper
+    now living in agent-zero/lib/task_report.py (issue #24 Wave 2).
+    """
+    if not isinstance(model, str) or not model:
+        return model
+    if model.startswith("anthropic/"):
+        return model.split("/", 1)[1]
+    return model
+
+
 def track_usage(
     model: str,
     input_tokens: int,
@@ -161,6 +177,8 @@ def track_usage(
 ):
     """사용량 누적 (cache tokens 포함)"""
     global usage_today
+    # Collapse provider-prefixed and bare forms so /today by_model stays unified.
+    model = _normalize_model(model)
     today = _kst_now().strftime("%Y-%m-%d")
 
     # 날짜가 바뀌면 리셋


### PR DESCRIPTION
## Summary

Stacks on top of PR #25 (Wave 1). Closes two more root causes flagged in #24:

1. **util_model hook missing.** `agent.py:788` invokes `util_model_call_after` but no extension listened → every Haiku call from `call_utility_model()` (chat-title naming, side prompts, summarizers) was invisible to task JSON. Measured ~71 Haiku calls/day lost.
2. **Model-name split.** LiteLLM emits `anthropic/claude-sonnet-4-6` on the stream/util path and `claude-sonnet-4-6` on the chat path. `by_model` aggregators (task_report + bridge `/today` breakdown) keyed on raw strings → same model charted as two rows with mismatched cache/cost numbers.

## Changes

- **`agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py`** — new extension. Delegates to the existing `task_report.llm_call()` helper. Picks up real tokens when the stream probe fills `last_stream_usage`; falls back to `approximate_tokens` otherwise.
- **`agent-zero/lib/task_report.py`** — new `_normalize_model()`, applied at `llm_call()` entry.
- **`telegram-bridge/bot.py`** — mirrored `_normalize_model()` applied at `track_usage()` entry so `/usage` in-memory state also unifies.
- **`docker-compose.yml`** — mount the new util hook.

## Verification (in-container)

- `util_model_call_after` extension now discovered by AZ loader (was empty dir before).
- `_normalize_model` roundtrip on 6 cases: `anthropic/claude-sonnet-4-6 → claude-sonnet-4-6`, bare form pass-through, `openai/gpt-4o` untouched, `None`/`""` safe.
- Both chat and util hooks confirmed to delegate to the same `llm_call()` helper (`inspect.getsource` check).

Runtime verification (counts in new task JSONs) will happen on next normal chat session after merge.

## Deferred

Stream-usage capture accuracy gap (~4% of Sonnet calls, higher for Haiku land with `tokens_approximate=True`) — the missing usage comes from calls going through a non-`acompletion` path (sync `completion`, explicit-caching precheck) that bypasses the probe entirely. Tracked separately as a Wave 2.5 follow-up under #24.

## Test plan

- [ ] Merge Wave 1 (#25) first — this PR stacks on it and `base` is set to the Wave 1 branch.
- [ ] After merge, GitHub auto-retargets this PR's base to `main`.
- [ ] Recreate `agent-zero`, send a few chat messages, confirm new task JSONs contain `llm_calls[].model` without `anthropic/` prefix and include at least one Haiku entry when util_model fires.
- [ ] `/today` per-model breakdown shows at most one row per model.