### PR TITLE
fix(observability): cmd_today/cmd_week tolerate message edits

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -1285,8 +1285,18 @@ async def cmd_today(update: Update, context: ContextTypes.DEFAULT_TYPE):
       /today              — default summary + compact model list
       /today by:model     — detailed per-model table (replaces compact list)
       /today by:profile   — per-profile table
+
+    NOTE on `effective_message`: python-telegram-bot's `CommandHandler` fires
+    on BOTH new messages and edits (edits go through `update.edited_message`,
+    not `update.message`). Reaching for `update.message.reply_text` directly
+    crashes with NoneType when the user edits a previous /today (e.g. "/today"
+    → "/today by:model" to test variants). `effective_message` resolves to
+    whichever variant actually carries the command text.
     """
     if update.effective_chat.id != CHAT_ID:
+        return
+    msg = update.effective_message
+    if msg is None:
         return
     tasks = _load_task_jsons()
     today_start = _kst_now().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1335,7 +1345,7 @@ async def cmd_today(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     f"in {b['input']:,} out {b['output']:,}{cache} → ${b['cost']:.4f}"
                 )
 
-    await update.message.reply_text("\n".join(lines))
+    await msg.reply_text("\n".join(lines))
 
 
 async def cmd_week(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -1345,8 +1355,13 @@ async def cmd_week(update: Update, context: ContextTypes.DEFAULT_TYPE):
       /week              — default daily rows + compact weekly model list
       /week by:model     — detailed per-model table for the week
       /week by:profile   — per-profile table for the week
+
+    See cmd_today for the `effective_message` rationale (edit-aware).
     """
     if update.effective_chat.id != CHAT_ID:
+        return
+    msg = update.effective_message
+    if msg is None:
         return
     all_tasks = _load_task_jsons()
     today_start = _kst_now().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1408,7 +1423,7 @@ async def cmd_week(update: Update, context: ContextTypes.DEFAULT_TYPE):
             ):
                 lines.append(f"  • {model}: {b['calls']}× → ${b['cost']:.4f}")
 
-    await update.message.reply_text("\n".join(lines))
+    await msg.reply_text("\n".join(lines))
 
 
 async def cmd_tasks(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
## Summary

Hotfix on top of Wave 3 (#27).

`CommandHandler` fires on both new messages and edits. Edits set `update.edited_message` and leave `update.message` as `None`, so `update.message.reply_text(...)` raises `AttributeError`. Symptom from the user side: editing \`/today\` → \`/today by:model\` looks like the bot is re-showing the previous result — actually it crashed silently and no new reply went out.

Fix: `update.effective_message` (resolves to whichever variant carries the command) in `cmd_today` / `cmd_week`, with a None guard.

## Evidence
\`\`\`
AttributeError: 'NoneType' object has no attribute 'reply_text'
  File "/app/bot.py", line 1338, in cmd_today
\`\`\`

## Test plan
- [ ] Type \`/today\` fresh → reply lands
- [ ] Edit that message to \`/today by:model\` → new reply with profile/model breakdown lands (was broken)
- [ ] Edit again to \`/today by:profile\` → also works
- [ ] Repeat for \`/week\` variants

## Note
Other handlers in bot.py have the same latent bug but aren't triggered by typical edit patterns. Deferred until they break.