### PR TITLE
docs: document DASHBOARD_TOKEN setup in .env.example + GUIDE.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,25 @@ GITHUB_TOKEN=ghp_your_personal_access_token
 
 TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 TELEGRAM_CHAT_ID=123456789
+
+
+# ══════════════════════════════════════════════════════════════
+#  4) Web Dashboard  (선택)
+# ══════════════════════════════════════════════════════════════
+#  M5-E (issue #23). telegram-bridge:8443 에 비용/사용량 차트 페이지를
+#  제공합니다.
+#
+#  ▸ 빈 값 / 미설정 → /dashboard 와 /api/stats 가 404 (대시보드 비활성)
+#  ▸ 값 설정 → 토큰이 있어야 접근 가능 (?token= 또는 X-Dashboard-Token 헤더)
+#
+#  토큰 생성 (랜덤 32자 hex 권장):
+#    openssl rand -hex 16
+#
+#  접속:
+#    http://localhost:8443/dashboard?token=<TOKEN>
+#    curl -H "X-Dashboard-Token: <TOKEN>" http://localhost:8443/api/stats
+#
+#  보안: 텔레그램 토큰처럼 외부 노출 금지. 운영 환경에선 쿼리 파라미터보다
+#  헤더 인증을 권장합니다 (액세스 로그에 토큰이 남지 않음).
+
+# DASHBOARD_TOKEN=

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -571,6 +571,37 @@ Agent Zero에게 지시할 때 활용:
 - 세션 유지: aiohttp CookieJar로 쿠키 유지, 403 시 자동 재발급
 - 보안: `TELEGRAM_CHAT_ID`로 본인만 봇 사용 가능 (다른 사용자 차단)
 
+### Web Dashboard (선택, M5-E)
+
+`telegram-bridge` 의 8443 포트에 비용/사용량 차트 페이지가 함께 떠 있습니다 (issue #23). 텔레그램 텍스트 명령어 (`/today`, `/week`, `/usage`) 외에 시각화가 필요할 때 사용하세요.
+
+**활성화 (기본은 비활성)**:
+
+`.env` 에 토큰 추가 후 컨테이너 재기동.
+```bash
+echo "DASHBOARD_TOKEN=$(openssl rand -hex 16)" >> .env
+docker compose up -d --force-recreate telegram-bridge
+```
+
+`DASHBOARD_TOKEN` 이 빈 값/미설정이면 `/dashboard` 와 `/api/stats` 둘 다 **404** 로 차단됩니다 (대시보드 자체가 켜지지 않음). 임의의 비밀번호 역할을 하므로 외부 노출하지 마세요.
+
+**접속**:
+```
+브라우저:  http://localhost:8443/dashboard?token=<TOKEN>
+JSON API:  curl "http://localhost:8443/api/stats?range=30d&token=<TOKEN>"
+헤더 인증: curl -H "X-Dashboard-Token: <TOKEN>" http://localhost:8443/api/stats
+```
+
+쿼리 파라미터(`?token=`)는 액세스 로그/프록시에 토큰이 남으므로, 운영 환경에선 헤더 인증을 권장합니다.
+
+**제공 차트**: 일별 비용 (30일 bar), 모델별 비용 (7일 doughnut), 태스크 소요시간 vs 비용 (scatter, 프로파일별 색상), 윈도우 합계.
+
+**원격 접속**: 8443 포트는 `docker-compose.yml` 에서 호스트 로컬에만 바인딩됩니다. 원격에서 보려면 SSH 포트포워딩을 사용하세요:
+```bash
+ssh -L 8443:localhost:8443 <host>
+# 로컬 브라우저에서 http://localhost:8443/dashboard?token=<TOKEN> 접속
+```
+
 ---
 
 ## 15. 팁: 호스트 파일시스템 접근


### PR DESCRIPTION
## Summary

Follow-up to #31 (M5-E web dashboard). PR #31 wired the \`DASHBOARD_TOKEN\` env var and added a README section, but missed two natural setup-doc homes:

- **\`.env.example\`** — users copying the template don't see the dashboard option exists
- **\`GUIDE.md\` § 14 (Telegram Bot 원격 제어)** — runtime-config docs live here

Both gaps closed. **Docs-only, no code change.**

## What's added

\`.env.example\` (section 4 \"Web Dashboard\"):
- token generation snippet (\`openssl rand -hex 16\`)
- disabled-by-default behavior (empty/unset → 404)
- query param vs header auth modes
- security note on query-string logging

\`GUIDE.md\` (subsection under § 14):
- activation steps
- access URLs (browser / curl / header)
- available charts
- SSH port forwarding for remote access (\`ssh -L 8443:localhost:8443\`)

## Test plan

- [ ] Read \`.env.example\` — section 4 makes sense to a first-time user
- [ ] Read \`GUIDE.md\` § 14 \"Web Dashboard\" — covers everything PR #31 added