### PR TITLE
fix(compose): persist /a0/usr/plugins so model overrides survive recreate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ docker-compose.override.yaml
 # M5-A: telegram-bridge persistent runtime data (budget settings, alert
 # cooldown, future pricing snapshots). Per-deploy state — never commit.
 telegram-bridge/data/
+
+# AZ user-plugin overrides — _model_config/config.json holds the
+# chat/utility model selection (per-deploy state, may include API keys).
+# Mount target: /a0/usr/plugins (see docker-compose.yml). Allow .gitkeep
+# through so the bind-mount source directory is tracked in git.
+agent-zero/usr-plugins/*
+!agent-zero/usr-plugins/.gitkeep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,12 @@ services:
       - ./agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py:/a0/extensions/python/util_model_call_after/_50_task_report_util_llm.py:ro
       - ./agent-zero/extensions/python/monologue_end/_50_task_report_finish.py:/a0/extensions/python/monologue_end/_50_task_report_finish.py:ro
       - ./agent-zero/settings.json:/a0/usr/settings.json
+      # Persist plugin overrides — chiefly /a0/usr/plugins/_model_config/config.json
+      # which holds the active chat/utility model selection. Without this mount
+      # `docker compose up --force-recreate` wipes the override and AZ falls
+      # back to default_config.yaml — whose default chat_model name has a typo
+      # (claude-sonnet-4.6 with a DOT) that Anthropic rejects with 404.
+      - ./agent-zero/usr-plugins:/a0/usr/plugins
     entrypoint: ["/bin/sh", "-c", "sh /a0/git-init.sh && exec /exe/initialize.sh ${BRANCH:-main}"]
     depends_on:
       cliproxy:


### PR DESCRIPTION
## Summary

Diagnosed when chat broke with \`litellm.NotFoundError\` for
\`anthropic/claude-sonnet-4.6\` right after a \`docker compose up --force-recreate agent-zero\`.

## Root cause chain

1. AZ v1.9 \`_model_config\` plugin saves the user's chat/utility model selection to \`/a0/usr/plugins/_model_config/config.json\`
2. Repo bind-mounts \`/a0/usr/settings.json\` individually but **the \`/a0/usr/plugins\` subtree was unmounted**
3. Base image declares no volume on \`/a0\` (\`docker inspect\` returns \`Config.Volumes = null\`), so \`/a0/usr/plugins\` lives in the container's writable layer — **destroyed on every \`--force-recreate\`**
4. Without the override, AZ falls back to the bundled \`default_config.yaml\` whose \`chat_model.name\` is \`"anthropic/claude-sonnet-4.6"\` — note the **DOT**, not the dash Anthropic accepts → 404 \`NotFoundError\` on first call

## What broke

- Day 1: user opens AZ web UI → picks Sonnet 4-6 / Haiku 4-5 → \`/a0/usr/plugins/_model_config/config.json\` written
- Days of bridge work: many \`--force-recreate telegram-bridge\` (safe — bridge mounts everything from host)
- One \`--force-recreate agent-zero\` to pick up extension/code changes → **wipes the override** → next chat hits the broken default → 404

## Fix

Bind-mount the whole plugins subtree:

\`\`\`yaml
- ./agent-zero/usr-plugins:/a0/usr/plugins
\`\`\`

\`agent-zero/usr-plugins/\` is gitignored (per-deploy state, may include API keys); \`.gitkeep\` is allowed through so the bind-mount source path is tracked.

## Verification

Live in container, two consecutive \`--force-recreate agent-zero\`:

| Round | Result |
|---|---|
| Pre-fix | \`chat: 'anthropic/claude-sonnet-4.6'\` (default, broken) — 404 |
| Apply mount, recreate #1 | \`chat: 'claude-sonnet-4-6'\`, \`util: 'claude-haiku-4-5'\` ✅ |
| recreate #2 | same — override truly persistent ✅ |

## Note

This commit doesn't fix the upstream typo in \`default_config.yaml\` (that's an Agent Zero ticket, not this repo). The mount side-steps it for anyone who has saved a config via the web UI at least once. Fresh deploys with no UI save still hit the same default-config bug — out of scope here.

## Test plan

- [ ] Merge
- [ ] \`docker compose up -d --force-recreate agent-zero\`
- [ ] Wait for AZ ready
- [ ] Telegram \`/status\` → models show \`claude-sonnet-4-6\` and \`claude-haiku-4-5\`
- [ ] Send a normal message → no NotFoundError, response arrives