### PR TITLE
fix(bridge): /new actually creates a new AZ chat instead of just clearing local state

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -689,16 +689,69 @@ async def cmd_switch(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def cmd_new(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    global az_context, monitor_context, monitor_log_version
+    """Create a brand-new Agent Zero chat context and switch to it.
+
+    Previous behavior: just zeroed the local az_context / monitor_context and
+    relied on the next user message to lazily create a context. That meant:
+      - The reply "새 대화를 시작합니다" was misleading (no chat created yet)
+      - /chats wouldn't show the new chat until something was sent
+      - With monitor_auto_follow ON, the next poll would latch back onto
+        AZ's previously-active context — defeating the reset entirely
+
+    Fixed behavior: calls AZ's /api/chat_create (the same endpoint the web
+    UI's "New Chat" button uses), gets the real ctxid back, then pins both
+    az_context and monitor_context to it before replying.
+    """
+    global az_context, monitor_context, monitor_log_version, monitor_log_guid
     if update.effective_chat.id != CHAT_ID:
         return
-    az_context = ""
-    monitor_context = ""
-    await close_az_session()
-    # 새 세션이므로 다음 poll에서 sync_log_version이 자동 처리
-    # 빈 컨텍스트는 poll 시 새 컨텍스트를 받아오며 그때 sync됨
-    monitor_log_version = await sync_log_version("")
-    await update.message.reply_text("새 대화를 시작합니다.")
+    msg = update.effective_message
+    if msg is None:
+        return
+
+    new_ctxid = ""
+    try:
+        session = await get_az_session()
+        headers = get_headers()
+        # Pass current_context so AZ can carry over project / model-override
+        # data per its chat_inherit_project setting (matches web UI behavior).
+        async with session.post(
+            f"{AZ_API_URL}{AZ_API_PREFIX}/chat_create",
+            json={"current_context": az_context or ""},
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            if resp.status == 403:
+                await close_az_session()
+                session = await get_az_session()
+                headers = get_headers()
+                async with session.post(
+                    f"{AZ_API_URL}{AZ_API_PREFIX}/chat_create",
+                    json={"current_context": az_context or ""},
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=15),
+                ) as retry:
+                    if retry.status == 200:
+                        new_ctxid = (await retry.json()).get("ctxid", "")
+            elif resp.status == 200:
+                new_ctxid = (await resp.json()).get("ctxid", "")
+    except Exception as e:
+        logger.error(f"chat_create failed: {e}")
+
+    if not new_ctxid:
+        await msg.reply_text("⚠️ 새 대화 생성 실패 — Agent Zero 응답 확인 필요.")
+        return
+
+    az_context = new_ctxid
+    monitor_context = new_ctxid
+    monitor_log_guid = ""
+    # Skip past whatever log_version the new context starts at so we don't
+    # re-stream the (empty) initial state. This mirrors /switch behavior.
+    monitor_log_version = await sync_log_version(new_ctxid)
+
+    await msg.reply_text(
+        f"✅ 새 대화 시작됨\nID: {new_ctxid[:12]}..."
+    )
 
 
 async def cmd_logs(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
## Summary

\`/new\` was lying. It zeroed local bridge state (\`az_context\`, \`monitor_context\`), closed the HTTP session, and replied \"새 대화를 시작합니다\" — but **no chat was actually created on Agent Zero**. The new context materialized only when the user sent their next message.

## Three concrete failures

1. **Misleading reply** — said a chat started when nothing had.
2. **\`/chats\` showed nothing new** — because nothing existed.
3. **Auto-follow snap-back** — with \`monitor_auto_follow=ON\` (default), the next \`/poll\` saw AZ's previously-active context, the monitor latched back, and the reset was silently undone.

## Fix

Call AZ's \`/api/chat_create\` — same endpoint the webui's \"New Chat\" button uses. AZ creates the context server-side, returns the ctxid, bridge pins both \`az_context\` and \`monitor_context\` to it before replying.

Pass \`current_context\` so AZ can carry over project / model-override state per its \`chat_inherit_project\` setting (matches webui semantics).

## Verification

End-to-end smoke test (inside bridge container, fake Update):

\`\`\`
Before: az_context='', monitor_context=''
After:  az_context='ZKAF1imc...', monitor_context='ZKAF1imc...'
        reply: '✅ 새 대화 시작됨\nID: ZKAF1imc...'
        /chats lists 2 contexts; new one present ✓
\`\`\`

## /chats and /switch (also reviewed)

Both correct.
- **/chats**: live fetch from \`/api/poll\` + cache update, \"→\" arrow on active context, hint to use /switch
- **/switch [N]**: index validation, sets \`az_context\`+\`monitor_context\` in sync, runs \`sync_log_version\` so monitor doesn't replay history

## Test plan

- [ ] Merge
- [ ] Telegram \`/chats\` → note current count
- [ ] Telegram \`/new\` → reply shows new ID; \`/chats\` lists +1 with \"→\" on the new one
- [ ] Telegram message \"hello\" → goes to the new context, response arrives
- [ ] \`/chats\` again → new context still pinned, no auto-follow snap-back