### PR TITLE
refactor(bridge): rename /follow_on,off → /track_chat_on,off

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -614,8 +614,8 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "• /backup → 설정 백업 파일 전송\n"
         "• /monitor_on → 모니터링 켜기\n"
         "• /monitor_off → 모니터링 끄기\n"
-        "• /follow_on → 자동 추적 켜기\n"
-        "• /follow_off → 자동 추적 끄기\n"
+        "• /track_chat_on → 채팅 자동 추적 켜기 (웹 UI 채팅 전환 따라감)\n"
+        "• /track_chat_off → 채팅 자동 추적 끄기 (현재 채팅 고정)\n"
         "• /help → 도움말"
     )
 
@@ -2704,20 +2704,36 @@ async def cmd_monitor_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text("🔇 웹 채팅 모니터링이 꺼졌습니다.")
 
 
-async def cmd_follow_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
+async def cmd_track_chat_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Auto-track which AZ chat the monitor watches.
+
+    Renamed from /follow_on for clarity — old name was ambiguous about
+    direction (does \"follow\" mean Telegram→AZ or AZ→Telegram?). Both
+    /monitor and /track_chat are AZ→Telegram concerns; /track_chat
+    specifically controls whether the monitor switches its target when
+    the AZ web UI activates a different chat.
+
+    /follow_on is kept registered as an alias for muscle memory.
+    """
     global monitor_auto_follow
     if update.effective_chat.id != CHAT_ID:
         return
     monitor_auto_follow = True
-    await update.message.reply_text("✅ 자동 추적 켜짐: 웹에서 채팅 전환 시 모니터가 자동으로 따라갑니다.")
+    await update.message.reply_text(
+        "✅ 채팅 자동 추적 켜짐: 웹에서 채팅 전환 시 모니터가 따라갑니다."
+    )
 
 
-async def cmd_follow_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
+async def cmd_track_chat_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Pin the monitor to its current chat regardless of AZ web's active chat.
+    See cmd_track_chat_on for the rename rationale."""
     global monitor_auto_follow
     if update.effective_chat.id != CHAT_ID:
         return
     monitor_auto_follow = False
-    await update.message.reply_text("📌 자동 추적 꺼짐: 현재 채팅만 고정 추적합니다.")
+    await update.message.reply_text(
+        "📌 채팅 자동 추적 꺼짐: 현재 채팅만 고정 추적합니다."
+    )
 
 
 async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -2737,8 +2753,8 @@ async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "모니터링:\n"
         "  /monitor_on → 웹 채팅 알림 켜기 (현재 시점부터)\n"
         "  /monitor_off → 웹 채팅 알림 끄기\n"
-        "  /follow_on → 채팅 자동 추적 켜기\n"
-        "  /follow_off → 채팅 자동 추적 끄기\n\n"
+        "  /track_chat_on → 채팅 자동 추적 켜기 (웹 UI 채팅 전환 따라감)\n"
+        "  /track_chat_off → 채팅 자동 추적 끄기 (현재 채팅 고정)\n\n"
         "상태/비용:\n"
         "  /status → Agent Zero 상태 확인\n"
         "  /usage → 세션 내 토큰/비용 (bridge 재시작 시 초기화)\n"
@@ -2917,8 +2933,14 @@ def main():
     app.add_handler(CommandHandler("backup", cmd_backup))
     app.add_handler(CommandHandler("monitor_on", cmd_monitor_on))
     app.add_handler(CommandHandler("monitor_off", cmd_monitor_off))
-    app.add_handler(CommandHandler("follow_on", cmd_follow_on))
-    app.add_handler(CommandHandler("follow_off", cmd_follow_off))
+    # Primary names (clearer about direction — both /monitor and /track_chat
+    # are AZ→Telegram concerns, /track_chat picks WHICH chat to watch).
+    app.add_handler(CommandHandler("track_chat_on", cmd_track_chat_on))
+    app.add_handler(CommandHandler("track_chat_off", cmd_track_chat_off))
+    # Legacy aliases — old names still work for muscle memory / saved scripts.
+    # Drop these after a transition window if desired.
+    app.add_handler(CommandHandler("follow_on", cmd_track_chat_on))
+    app.add_handler(CommandHandler("follow_off", cmd_track_chat_off))
     app.add_handler(CommandHandler("help", cmd_help))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
 


### PR DESCRIPTION
## Summary

User feedback: \`/follow\` is ambiguous about direction.

> \"monitor 랑 follow 의미가 하나는 az 발생한 채팅 텔레그램에 보내주는거 follow는 반대로 텔레그램 채팅 az 로 보내주는거지?\"

That's a reasonable mental model — but it's wrong. **Both \`/monitor\` and \`/follow\` are AZ→Telegram concerns**; \`/follow\` specifically picks WHICH chat the monitor watches when the AZ web UI activates a different chat. The Telegram→AZ direction is always-on with no toggle.

Rename to make this clearer.

## Changes

| Old | New | Same effect |
|---|---|---|
| \`/follow_on\` | \`/track_chat_on\` | flips \`monitor_auto_follow\` to True |
| \`/follow_off\` | \`/track_chat_off\` | flips it to False |

- Reply text: \`자동 추적\` → \`채팅 자동 추적\` (matches \`/status\` wording)
- \`/help\` and \`/start\` advertise new names + a short hint on what they actually do
- Both new (primary) and legacy (alias) names are registered, so existing muscle memory / saved scripts keep working. Alias can be dropped after a transition window.
- Internal flag name (\`monitor_auto_follow\`) untouched — private to the module, no UX value to changing it.

## Smoke test (inside bridge, all pass)

- ✅ Both \`/track_chat_on,off\` AND \`/follow_on,off\` aliases registered
- ✅ \`/track_chat_on\` flips flag to True, replies with new text
- ✅ \`/track_chat_off\` flips back, distinct reply
- ✅ \`/follow_on\` alias resolves to the same handler (same flag flip)
- ✅ \`/help\` advertises \`track_chat_*\`, hides legacy \`follow_*\`

## Test plan

- [ ] Telegram \`/track_chat_off\` → reply \"📌 채팅 자동 추적 꺼짐...\"
- [ ] \`/status\` confirms \`자동 추적: 꺼짐\`
- [ ] Telegram \`/follow_on\` (legacy) → same toggle, no error
- [ ] \`/help\` shows new names only