### PR TITLE
feat(observability): split task completion into 2 messages + quiet monitor by default

### DIFF
--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -263,6 +263,23 @@ def tool_start(agent, tool_name: str, tool_args) -> None:
         "_started_ts": time.time(),
     }
 
+    # AZ's `response` tool args carry the user-facing answer text (the
+    # message the agent wrote back). Capture it here at full length —
+    # `args_preview` is truncated to ~120 chars for the JSON, but the
+    # task summary card wants the whole thing. Last call wins so re-asks
+    # within one task end up with the final answer in the summary.
+    if tool_name == "response":
+        try:
+            text = None
+            if isinstance(tool_args, dict):
+                text = tool_args.get("text") or tool_args.get("message")
+            if isinstance(text, str) and text.strip():
+                r = get_report(agent)
+                if r is not None:
+                    r["final_response"] = text
+        except Exception as e:
+            logger.debug(f"[task_report] response capture failed: {e}")
+
 
 def tool_end(agent, tool_name: str, response) -> None:
     r = get_report(agent)
@@ -461,6 +478,11 @@ def _format_task_summary(snapshot: dict) -> str:
 
     Shown on `monologue_end` after `finish_task` writes the final JSON.
     Opt out with env var `AZ_TASK_SUMMARY=0`.
+
+    When the task ended with a `response` tool call (AZ's user-facing
+    answer), the message text is prepended so the user can read the
+    answer directly in the summary card without scrolling back through
+    the streamed monitor message.
     """
     totals = snapshot.get("totals") or {}
     elapsed = snapshot.get("elapsed_sec") or 0
@@ -481,11 +503,25 @@ def _format_task_summary(snapshot: dict) -> str:
         bucket["cache_create"] += c.get("cache_creation_tokens", 0) or 0
         bucket["cost"] += c.get("cost_usd", 0.0) or 0.0
 
-    lines = [
+    lines: list[str] = []
+
+    # Final answer first — that's what the user actually wants to read.
+    # Telegram caps messages at 4096 chars; reserve ~600 for the metrics
+    # block underneath so a long answer still leaves room.
+    final_response = snapshot.get("final_response")
+    if isinstance(final_response, str) and final_response.strip():
+        text = final_response.strip()
+        budget = 4096 - 600
+        if len(text) > budget:
+            text = text[:budget].rstrip() + "\n…(생략)"
+        lines.append(f"🤖 {text}")
+        lines.append("")  # blank line separates answer from metrics
+
+    lines.extend([
         f"✅ 태스크 완료 ({snapshot.get('task_id', '?')})",
         f"⏱ {elapsed:.1f}s  🔧 tools {totals.get('tool_calls', 0)}  💬 LLM {totals.get('llm_calls', 0)}",
         f"💰 ${cost_usd:.4f}",
-    ]
+    ])
     if by_model:
         for model, b in sorted(by_model.items(), key=lambda kv: kv[1]["cost"], reverse=True):
             cache_part = (

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -473,16 +473,36 @@ TELEGRAM_BRIDGE_NOTIFY_URL = os.environ.get(
 TASK_SUMMARY_ENABLED = os.environ.get("AZ_TASK_SUMMARY", "1") not in ("0", "false", "False")
 
 
+def _format_task_response(snapshot: dict) -> str | None:
+    """The user-facing answer text captured from the `response` tool, formatted
+    for Telegram. Returns None when no answer was captured (cancelled task,
+    error path, no response tool fired) so the caller can skip the post.
+
+    Telegram caps messages at 4096; truncate with `…(생략)` to stay safely
+    under that. The summary card is its OWN separate message, so this one
+    can use almost the full budget.
+    """
+    final_response = snapshot.get("final_response")
+    if not isinstance(final_response, str):
+        return None
+    text = final_response.strip()
+    if not text:
+        return None
+    budget = 4096 - 100  # tiny margin for the 🤖 prefix + safety
+    if len(text) > budget:
+        text = text[:budget].rstrip() + "\n…(생략)"
+    return f"🤖 {text}"
+
+
 def _format_task_summary(snapshot: dict) -> str:
-    """Compact Telegram-friendly per-task summary.
+    """Compact metrics card for a completed task.
 
     Shown on `monologue_end` after `finish_task` writes the final JSON.
-    Opt out with env var `AZ_TASK_SUMMARY=0`.
+    The user-facing answer text is sent as a SEPARATE Telegram message
+    immediately before this card (see `_format_task_response`) so the
+    chat reads as: 🤖 answer → ✅ summary, two clean messages.
 
-    When the task ended with a `response` tool call (AZ's user-facing
-    answer), the message text is prepended so the user can read the
-    answer directly in the summary card without scrolling back through
-    the streamed monitor message.
+    Opt out with env var `AZ_TASK_SUMMARY=0`.
     """
     totals = snapshot.get("totals") or {}
     elapsed = snapshot.get("elapsed_sec") or 0
@@ -503,25 +523,11 @@ def _format_task_summary(snapshot: dict) -> str:
         bucket["cache_create"] += c.get("cache_creation_tokens", 0) or 0
         bucket["cost"] += c.get("cost_usd", 0.0) or 0.0
 
-    lines: list[str] = []
-
-    # Final answer first — that's what the user actually wants to read.
-    # Telegram caps messages at 4096 chars; reserve ~600 for the metrics
-    # block underneath so a long answer still leaves room.
-    final_response = snapshot.get("final_response")
-    if isinstance(final_response, str) and final_response.strip():
-        text = final_response.strip()
-        budget = 4096 - 600
-        if len(text) > budget:
-            text = text[:budget].rstrip() + "\n…(생략)"
-        lines.append(f"🤖 {text}")
-        lines.append("")  # blank line separates answer from metrics
-
-    lines.extend([
+    lines = [
         f"✅ 태스크 완료 ({snapshot.get('task_id', '?')})",
         f"⏱ {elapsed:.1f}s  🔧 tools {totals.get('tool_calls', 0)}  💬 LLM {totals.get('llm_calls', 0)}",
         f"💰 ${cost_usd:.4f}",
-    ])
+    ]
     if by_model:
         for model, b in sorted(by_model.items(), key=lambda kv: kv[1]["cost"], reverse=True):
             cache_part = (
@@ -535,19 +541,47 @@ def _format_task_summary(snapshot: dict) -> str:
     return "\n".join(lines)
 
 
-def _post_task_summary(snapshot: dict) -> None:
-    if not TASK_SUMMARY_ENABLED:
-        return
+def _post(text: str) -> None:
+    """Fire-and-forget POST to the Telegram bridge /notify endpoint.
+    Failure is intentionally swallowed (debug log only) — a notification
+    glitch must never crash the monologue shutdown path."""
     try:
         import requests  # local import so we don't pay the cost on happy-path imports
     except Exception:
         return
     try:
-        text = _format_task_summary(snapshot)
         requests.post(TELEGRAM_BRIDGE_NOTIFY_URL, json={"text": text}, timeout=3)
     except Exception as e:
-        # Never let notification failure impact the monologue shutdown.
-        logger.debug(f"[task_report] summary post failed: {e}")
+        logger.debug(f"[task_report] notify post failed: {e}")
+
+
+def _post_task_response(snapshot: dict) -> None:
+    """Send AZ's user-facing answer as its own Telegram message.
+
+    Sent BEFORE the metrics card so the user reads:
+       🤖 [answer]            ← this post
+       ✅ 태스크 완료 + 메트릭   ← the next post (_post_task_summary)
+
+    No-op when no `response` tool fired during the task (cancelled, error,
+    or task ended via a different break path) — caller's summary card
+    still goes out.
+    """
+    if not TASK_SUMMARY_ENABLED:
+        return
+    text = _format_task_response(snapshot)
+    if text is None:
+        return
+    _post(text)
+
+
+def _post_task_summary(snapshot: dict) -> None:
+    if not TASK_SUMMARY_ENABLED:
+        return
+    try:
+        text = _format_task_summary(snapshot)
+        _post(text)
+    except Exception as e:
+        logger.debug(f"[task_report] summary format failed: {e}")
 
 
 def finish_task(agent) -> dict | None:
@@ -576,6 +610,11 @@ def finish_task(agent) -> dict | None:
             summary_snapshot["elapsed_sec"] = round(time.time() - started_ts, 3)
         summary_snapshot.pop("started_ts", None)
         summary_snapshot["totals"] = _compute_totals(summary_snapshot)
+        # Two messages, in order: AZ's actual answer, then the metrics card.
+        # Bridge's monitor stays silent during the task (see bot.py
+        # format_monitor_message), so these two posts are the user's whole
+        # task-completion notification — no in-progress streaming noise.
+        _post_task_response(summary_snapshot)
         _post_task_summary(summary_snapshot)
     finally:
         agent.data.pop(DATA_KEY, None)

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -59,6 +59,13 @@ monitor_log_version = 0
 monitor_context = ""
 monitor_log_guid = ""
 monitor_auto_follow = True  # 웹에서 활성 채팅 변경 시 자동 추적
+# When False (the default), only `user` log types echo through to Telegram
+# during a task — AZ's intermediate activity (info/tool/code_exe/response/
+# error/warning) is suppressed. The user instead gets two clean messages
+# at task completion: AZ's answer + the metrics card (driven from
+# task_report.py). When True, every log type passes through unchanged for
+# debugging. Toggled via /verbose_on, /verbose_off.
+monitor_verbose = False
 
 # Telegram Bot 인스턴스 (모니터에서 사용)
 tg_bot: Bot | None = None
@@ -566,13 +573,29 @@ async def monitor_agent_zero():
 
 
 def format_monitor_message(log_type: str, heading: str, content: str) -> str | None:
-    """로그 타입에 따라 Telegram 메시지 포맷"""
+    """로그 타입에 따라 Telegram 메시지 포맷.
+
+    Quiet mode (default, `monitor_verbose=False`): only `user` log types
+    echo through. The user-facing answer + metrics card are sent at task
+    completion via `task_report.py`'s `_post_task_response` /
+    `_post_task_summary`, so the in-progress monitor doesn't need to
+    repeat what's coming anyway.
+
+    Verbose mode (`monitor_verbose=True`, toggled via /verbose_on): every
+    log type formats and forwards as before — useful when debugging an
+    AZ profile or a stuck task.
+    """
     if not content and not heading:
         return None
 
     if log_type == "user":
         return f"👤 사용자: {content}"
-    elif log_type in ("response", "ai", "agent"):
+
+    if not monitor_verbose:
+        # Quiet path — let task completion drive the actual answer + metrics.
+        return None
+
+    if log_type in ("response", "ai", "agent"):
         if len(content) > 2000:
             content = content[:2000] + "\n...(생략)"
         return f"🤖 Agent Zero:\n{content}"
@@ -3029,6 +3052,31 @@ async def cmd_track_chat_off(update: Update, context: ContextTypes.DEFAULT_TYPE)
     )
 
 
+async def cmd_verbose_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Show every AZ log (info/tool/code_exe/response/error/warning) during
+    a task — useful when debugging a stuck profile. Default-quiet behavior
+    (only user echoes + task-completion summary) is the normal mode."""
+    global monitor_verbose
+    if update.effective_chat.id != CHAT_ID:
+        return
+    monitor_verbose = True
+    await update.message.reply_text(
+        "🔊 상세 모니터 켜짐: AZ 활동 로그(도구/코드/info 등) 모두 텔레그램으로 전송."
+    )
+
+
+async def cmd_verbose_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Return to quiet mode — only user echoes during task, completion-time
+    answer + metrics card from task_report."""
+    global monitor_verbose
+    if update.effective_chat.id != CHAT_ID:
+        return
+    monitor_verbose = False
+    await update.message.reply_text(
+        "🔇 상세 모니터 꺼짐: 진행 중엔 조용, 완료 시 답변+메트릭만."
+    )
+
+
 async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.effective_chat.id != CHAT_ID:
         return
@@ -3047,7 +3095,9 @@ async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "  /monitor_on → 웹 채팅 알림 켜기 (현재 시점부터)\n"
         "  /monitor_off → 웹 채팅 알림 끄기\n"
         "  /track_chat_on → 채팅 자동 추적 켜기 (웹 UI 채팅 전환 따라감)\n"
-        "  /track_chat_off → 채팅 자동 추적 끄기 (현재 채팅 고정)\n\n"
+        "  /track_chat_off → 채팅 자동 추적 끄기 (현재 채팅 고정)\n"
+        "  /verbose_on → 진행 중 AZ 활동 로그도 보기 (디버그용)\n"
+        "  /verbose_off → 진행 중엔 조용히, 완료 시만 알림 (기본)\n\n"
         "상태/비용:\n"
         "  /status → Agent Zero 상태 확인\n"
         "  /usage → 세션 내 토큰/비용 (bridge 재시작 시 초기화)\n"
@@ -3230,6 +3280,9 @@ def main():
     # are AZ→Telegram concerns, /track_chat picks WHICH chat to watch).
     app.add_handler(CommandHandler("track_chat_on", cmd_track_chat_on))
     app.add_handler(CommandHandler("track_chat_off", cmd_track_chat_off))
+    # Verbose mode — show every AZ activity log instead of just user echoes.
+    app.add_handler(CommandHandler("verbose_on", cmd_verbose_on))
+    app.add_handler(CommandHandler("verbose_off", cmd_verbose_off))
     # Legacy aliases — old names still work for muscle memory / saved scripts.
     # Drop these after a transition window if desired.
     app.add_handler(CommandHandler("follow_on", cmd_track_chat_on))


### PR DESCRIPTION
## Summary

Course-corrected after user feedback:

> 태스크 완료 메세지랑 합쳐달라는게 아니고 그 시점을 알고 있으면 계속 스트리밍 해서 메세지가 막 합쳐지는게 아니고  
> **task 완료 → task 결과 메세지 전송 → 태스크 완료 메세지 전송**

The first revision of this PR prepended the answer into the metrics card. Wrong direction. The right design:

| Phase | Behavior |
|---|---|
| User types in Telegram | 👤 사용자: ... (echo) |
| AZ working (~10s) | **silent** — no in-progress streaming |
| Task completes | 🤖 [answer]  |
|  | ✅ 태스크 완료 + metrics |

Three messages per turn. No edits. No fragmentation.

## Architecture

\`task_report.py\` drives **both** completion messages from \`finish_task\`:

\`\`\`python
_post_task_response(snapshot)  # 🤖 answer text
_post_task_summary(snapshot)   # ✅ metrics card
\`\`\`

\`bot.py\`'s monitor goes quiet by default (\`monitor_verbose=False\`) — only \`user\`-type logs pass through, all AZ activity (\`info\`, \`tool\`, \`code_exe\`, \`response\`, \`error\`, \`warning\`) returns \`None\` from the formatter.

\`/verbose_on\` opt-in brings the streamed in-progress logs back for debugging a stuck profile or watching a long task. \`/verbose_off\` reverts to quiet (default).

## What didn't change

- PR #39's streaming infrastructure stays in \`bot.py\` — it's now a no-op in quiet mode but kicks in seamlessly when verbose is toggled
- \`final_response\` capture (PR #40 v1) — kept; that's the data source for the new \`_post_task_response\`
- Cancelled/errored tasks where no \`response\` tool fired: \`_format_task_response\` returns None, summary card still goes out alone

## Verification

In-container smoke test, all paths covered:

| Test | Result |
|---|---|
| \`_format_task_response\` with text | 🤖-prefixed |
| empty / missing | None (skip post) |
| long → truncate w/ "(생략)", < 4096 chars | ✓ |
| \`_format_task_summary\` post-revert | pure metrics, no 🤖 prepend |
| monitor quiet: 7 log types | only \`user\` passes; rest → None |
| monitor verbose: 7 log types | all format with their emoji prefixes |

Both containers recreated and live.

## New commands

\`\`\`
/verbose_on   진행 중 AZ 활동 로그도 보기 (디버그용)
/verbose_off  진행 중엔 조용히, 완료 시만 알림 (기본)
\`\`\`

## Test plan

- [ ] Merge
- [ ] Telegram: send \"안녕\" → see only 👤 echo + (silent work) + 🤖 answer + ✅ summary
- [ ] Confirm 3 messages total per turn
- [ ] \`/verbose_on\` → next task shows tool/code_exe/info/response logs streamed in real-time
- [ ] \`/verbose_off\` → back to quiet
- [ ] Cancel a task → no response message goes out, summary card still appears with no answer (legacy behavior)