### PR TITLE
feat(telegram): render markdown headers + tables in answers

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -126,6 +126,8 @@ def md_to_telegram_html(text: str) -> str:
     )
 
     # Step 2: ```lang\n...\n``` fenced code blocks.
+    # Run FIRST so the inner content (which may contain | or # chars) isn't
+    # touched by the table / header rules below.
     def _fence(m):
         lang = m.group(1) or ""
         body = m.group(2).rstrip("\n")
@@ -140,14 +142,38 @@ def md_to_telegram_html(text: str) -> str:
         flags=_re_md_to_html.DOTALL,
     )
 
-    # Step 3: `inline code`. Run AFTER fences so triple-backticks aren't
+    # Step 3: Markdown tables → <pre> blocks.
+    # Telegram has no <table> tag, but <pre> renders monospace, so the
+    # original `|` separators become a visually aligned ASCII table —
+    # which is the closest we can get. Strip the GitHub-style separator
+    # row (`|---|---|`) since it adds no value in monospace.
+    def _table(m):
+        block = m.group(0).strip("\n")
+        kept = []
+        for line in block.split("\n"):
+            stripped = line.strip()
+            # Skip the separator-only row, e.g. "|---|---|" or "| --- | :-: |"
+            if _re_md_to_html.match(r"^\|?\s*[-:|\s]+\|?\s*$", stripped):
+                continue
+            kept.append(line)
+        return "<pre>" + "\n".join(kept) + "</pre>"
+
+    out = _re_md_to_html.sub(
+        # Two or more consecutive lines starting with optional spaces + `|`.
+        r"(?:^[ \t]*\|.+(?:\n|$)){2,}",
+        _table,
+        out,
+        flags=_re_md_to_html.MULTILINE,
+    )
+
+    # Step 4: `inline code`. Run AFTER fences so triple-backticks aren't
     # eaten as three single-backtick spans.
     out = _re_md_to_html.sub(r"`([^`\n]+?)`", r"<code>\1</code>", out)
 
-    # Step 4: **bold** (must run before *italic* so ** doesn't match as two *)
+    # Step 5: **bold** (must run before *italic* so ** doesn't match as two *)
     out = _re_md_to_html.sub(r"\*\*([^*\n]+?)\*\*", r"<b>\1</b>", out)
 
-    # Step 5: *italic* — guard with negative lookarounds to avoid eating
+    # Step 6: *italic* — guard with negative lookarounds to avoid eating
     # asterisks already inside <b>...</b> bursts.
     out = _re_md_to_html.sub(
         r"(?<![*\w])\*([^*\n]+?)\*(?!\w)",
@@ -155,12 +181,30 @@ def md_to_telegram_html(text: str) -> str:
         out,
     )
 
-    # Step 6: [text](url). The `&` in URL would have been HTML-escaped to
+    # Step 7: [text](url). The `&` in URL would have been HTML-escaped to
     # &amp; in step 1; that's actually correct in href values.
     out = _re_md_to_html.sub(
         r"\[([^\]]+?)\]\((https?://[^\s)]+)\)",
         r'<a href="\2">\1</a>',
         out,
+    )
+
+    # Step 8: ATX headers `# heading` … `###### heading` → <b>heading</b>.
+    # Telegram has no header tag; bold is the closest visual proxy.
+    # Run AFTER all inline rules so a header like `## **important**` —
+    # which becomes `## <b>important</b>` after step 5 — gets the inner
+    # <b>...</b> stripped here before re-wrapping. Otherwise we'd end
+    # up with `<b><b>important</b></b>` (Telegram tolerates it but it's noise).
+    def _header(m):
+        body = m.group(1).strip()
+        body = body.replace("<b>", "").replace("</b>", "")
+        return f"<b>{body}</b>"
+
+    out = _re_md_to_html.sub(
+        r"^[ \t]*#{1,6}[ \t]+(.+?)[ \t]*$",
+        _header,
+        out,
+        flags=_re_md_to_html.MULTILINE,
     )
 
     return out


### PR DESCRIPTION
## User report

After PR #42 merged:
> 테스트 해봄. 볼드만 처리 된걸까?

Right — bold / italic / code / links worked, but markdown headers and tables came back as literal text. AZ emits both frequently (a weather query came back with a \`## 🌧️\` heading and a 7-row markdown table), so they need handling.

## What's added

| Markdown | Telegram HTML | Notes |
|---|---|---|
| \`# heading\` … \`###### heading\` | \`<b>heading</b>\` | Telegram has no \`<h1>\`; bold is the closest visual proxy |
| Markdown table (\`\| col \| col \|\`) | \`<pre>...</pre>\` | Monospace preserves the \`\|\`-aligned columns; separator row \`\|---\|---\|\` is stripped |

## Order matters

Reordered the rules so new ones don't fight existing ones:

1. **Fences first** — eat triple-backtick blocks before pipes/hashes inside can trigger table/header rules
2. **Tables** — eat \`|\`-block before inline rules touch them
3. **Inline** code, bold, italic, links
4. **Headers LAST** — so a header containing already-converted inline markup wraps correctly. \`## **important**\` → after step 3: \`## <b>important</b>\` → after step 4 (with nested-\`<b>\` strip): \`<b>important</b>\` (not the doubled \`<b><b>...</b></b>\`)

## Verification

**12/12 in-container smoke cases pass**:
- h1 through h6
- Header with nested \`**bold**\` → single \`<b>\`, no double-wrap
- Plain table
- Weather-style table with emoji
- Separator row stripped
- Code block with leading-pipe lines stays a code block (NOT table)
- All pre-existing rules (plain, inline, bold, italic, link, HTML injection) unchanged

**Live test** against running bridge:
\`\`\`
POST /notify markdown:true
  text: "## 🧪 테스트 헤더\n\n| 항목 | 값 |\n|----|----|\n| 테스트 | OK |\n
         | 표 | 정렬됨 |\n\n**확인** 부탁드립니다."
\`\`\`
→ Telegram \`sendMessage\` 200, no parse error, no fallback.

## Result on user's weather example

Before:
\`\`\`
🤖 ## 🌧️ 내일(4월 30일) 서초구 날씨

| 항목 | 상태 |
|------|------|
| 날씨 | 조금 비 🌦️ |
\`\`\`

After (rendered):
- 🌧️ 내일(4월 30일) 서초구 날씨 ← **bold**
- ASCII table in monospace box (separator row gone)
- Body text plain

## Test plan

- [ ] Merge
- [ ] Telegram: \`/today by:model\` (existing — unchanged path)
- [ ] Telegram: ask AZ "내일 서울 날씨 표로 정리해줘" → table renders monospace, header bold
- [ ] Ask AZ for a code answer → code block + bold both work