### PR TITLE
fix(telegram): apply 🤖 prefix AFTER markdown conversion so leading ## headers render

### DIFF
--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -474,13 +474,22 @@ TASK_SUMMARY_ENABLED = os.environ.get("AZ_TASK_SUMMARY", "1") not in ("0", "fals
 
 
 def _format_task_response(snapshot: dict) -> str | None:
-    """The user-facing answer text captured from the `response` tool, formatted
-    for Telegram. Returns None when no answer was captured (cancelled task,
-    error path, no response tool fired) so the caller can skip the post.
+    """Return the raw answer text captured from the `response` tool.
 
-    Telegram caps messages at 4096; truncate with `…(생략)` to stay safely
-    under that. The summary card is its OWN separate message, so this one
-    can use almost the full budget.
+    Returns None when nothing was captured (cancelled task, error path,
+    or task ended without a response tool firing) so the caller can
+    skip the post.
+
+    The 🤖 emoji prefix is intentionally NOT added here — the bridge
+    prepends it AFTER markdown conversion. If we glued "🤖 " on the
+    front before conversion, a leading `## header` would no longer be
+    at line-start (it'd be after "🤖 ") and the converter's
+    `^#{1,6}` regex would miss it. Apply prefix post-conversion so
+    line-anchored markdown rules still match.
+
+    Telegram caps messages at 4096; truncate with `…(생략)`. Reserve
+    ~150 chars to absorb both the bridge-prepended emoji and any
+    HTML expansion from the converter.
     """
     final_response = snapshot.get("final_response")
     if not isinstance(final_response, str):
@@ -488,10 +497,10 @@ def _format_task_response(snapshot: dict) -> str | None:
     text = final_response.strip()
     if not text:
         return None
-    budget = 4096 - 100  # tiny margin for the 🤖 prefix + safety
+    budget = 4096 - 150
     if len(text) > budget:
         text = text[:budget].rstrip() + "\n…(생략)"
-    return f"🤖 {text}"
+    return text
 
 
 def _format_task_summary(snapshot: dict) -> str:
@@ -541,7 +550,7 @@ def _format_task_summary(snapshot: dict) -> str:
     return "\n".join(lines)
 
 
-def _post(text: str, markdown: bool = False) -> None:
+def _post(text: str, markdown: bool = False, kind: str | None = None) -> None:
     """Fire-and-forget POST to the Telegram bridge /notify endpoint.
     Failure is intentionally swallowed (debug log only) — a notification
     glitch must never crash the monologue shutdown path.
@@ -551,6 +560,12 @@ def _post(text: str, markdown: bool = False) -> None:
     (not pre-converted HTML) so the conversion logic stays in one place
     and we don't hard-code AZ's task_report against Telegram's HTML
     flavor.
+
+    `kind` is a free-form hint to the bridge (e.g. "task_response").
+    The bridge uses it to decide which UI prefix emoji to prepend
+    AFTER markdown conversion — required so leading line-anchored
+    markdown (`## header`, `| table |`) at the start of the body
+    isn't displaced by a "🤖 " prefix that breaks the regex.
     """
     try:
         import requests  # local import so we don't pay the cost on happy-path imports
@@ -559,6 +574,8 @@ def _post(text: str, markdown: bool = False) -> None:
     payload = {"text": text}
     if markdown:
         payload["markdown"] = True
+    if kind:
+        payload["kind"] = kind
     try:
         requests.post(TELEGRAM_BRIDGE_NOTIFY_URL, json=payload, timeout=3)
     except Exception as e:
@@ -581,10 +598,12 @@ def _post_task_response(snapshot: dict) -> None:
     text = _format_task_response(snapshot)
     if text is None:
         return
-    # Answer text often contains markdown (```code```, **bold**, etc).
-    # Bridge converts to Telegram HTML and falls back to plain text on
-    # parse error, so the user never gets a worse experience than today.
-    _post(text, markdown=True)
+    # Answer text often contains markdown (```code```, **bold**, ## header,
+    # tables, etc). Bridge converts to Telegram HTML, prepends the 🤖 emoji
+    # AFTER conversion (so leading `## header` etc. isn't displaced from
+    # line-start), and falls back to plain text on parse error — user
+    # never gets a worse experience than today.
+    _post(text, markdown=True, kind="task_response")
 
 
 def _post_task_summary(snapshot: dict) -> None:

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -3289,26 +3289,50 @@ async def webhook_handler(request):
         "text": "...",
         "markdown": true,        # optional — convert text from markdown to
                                  # Telegram-safe HTML before sending
-        "parse_mode": "HTML"     # optional — sent verbatim if you've
+        "parse_mode": "HTML",    # optional — sent verbatim if you've
                                  # already-formatted HTML/MarkdownV2
+        "kind": "task_response"  # optional — adds a UI prefix emoji
+                                 # AFTER markdown conversion so leading
+                                 # `## header` / `| table |` aren't
+                                 # displaced from line-start
       }
 
     `markdown: true` is the easy path: senders write plain markdown
     (```code```, **bold**, etc.) and the bridge handles conversion +
-    fallback to plain text on parse failure. AZ's task_report uses this.
+    fallback to plain text on parse failure. AZ's task_report uses this
+    with kind="task_response" so the 🤖 emoji lands AFTER conversion.
     """
+    # Map of `kind` → UI prefix emoji + space. Keep tiny; this is purely
+    # presentation. Empty/unknown kind → no prefix.
+    KIND_PREFIX = {
+        "task_response": "🤖 ",
+    }
     try:
         data = await request.json()
         raw_text = data.get("text", data.get("message", str(data)))
         parse_mode = data.get("parse_mode")
+        kind = data.get("kind")
+        prefix = KIND_PREFIX.get(kind, "")
+
         if data.get("markdown"):
+            # Convert THEN prefix — order matters. If we prefixed first,
+            # leading "## header" would no longer be at line-start, breaking
+            # the converter's `^#` regex. Same goes for table rows
+            # starting with `|`.
+            converted = md_to_telegram_html(raw_text)
+            if prefix:
+                converted = f"{prefix}{converted}"
+                fallback = f"{prefix}{raw_text}"
+            else:
+                fallback = raw_text
             await send_telegram(
-                md_to_telegram_html(raw_text),
+                converted,
                 parse_mode="HTML",
-                fallback_text=raw_text,
+                fallback_text=fallback,
             )
         else:
-            await send_telegram(raw_text, parse_mode=parse_mode)
+            text = f"{prefix}{raw_text}" if prefix else raw_text
+            await send_telegram(text, parse_mode=parse_mode)
         return web.json_response({"ok": True})
     except Exception as e:
         return web.json_response({"ok": False, "error": str(e)}, status=500)


### PR DESCRIPTION
## Issue

User's weather screenshot showed:
\`\`\`
🤖 ## ☁️ 어제(4월 28일) 서초구 날씨
\`\`\`

The table rendered correctly as \`<pre>\` (PR #44), but the leading \`## header\` was still literal text. Headers and tables both worked in PR #44's smoke tests, so why?

## Root cause

\`task_report.py\` was prepending \`\"🤖 \"\` to the answer text BEFORE sending it to the bridge. After prefixing, the first line was no longer \`\"## ...\"\` but \`\"🤖 ## ...\"\` — the converter's header regex (\`^#{1,6}[ \\t]+...\` with MULTILINE) requires the \`#\` at line-start (after optional whitespace), and \`\"🤖 \"\` isn't whitespace. The header silently fell through as plain text.

The same trap would hit any line-anchored markdown rule: tables are caught by \`^[ \\t]*\\|...\` which would also miss if \`\"🤖 \"\` sat in front. Tables in the user's screenshot only worked because they appeared on subsequent lines, not the first one — those line starts weren't displaced.

## Fix

Apply the 🤖 prefix on the **bridge side, AFTER** markdown→HTML conversion. \`task_report\` just produces raw answer body and hints at message kind.

### \`agent-zero/lib/task_report.py\`
- \`_format_task_response\`: returns raw text, no 🤖 prefix
- \`_post\`: new optional \`kind\` arg, forwarded as JSON field
- \`_post_task_response\`: passes \`kind=\"task_response\"\`

### \`telegram-bridge/bot.py\` (webhook_handler)
- New \`KIND_PREFIX = {\"task_response\": \"🤖 \"}\` (tiny dispatch table)
- Markdown path: convert → prepend prefix → send (\`parse_mode=\"HTML\"\`, \`fallback_text\` also prefixed)
- Plain path (no markdown): prefix prepended unchanged
- Unknown kind: no prefix, no error

## Verification

**4/4 smoke cases pass**:

| Case | Result |
|---|---|
| \`kind=task_response\` w/ leading \`## header\` | \`🤖 <b>🌧️ 내일 서초구 날씨</b>\\n\\n<pre>...table...</pre>\` ✓ |
| Markdown w/o \`kind\` | Header bolded, no 🤖 prefix |
| Plain w/ \`kind\` | 🤖 prefix on plain text |
| Unknown \`kind\` | Ignored gracefully |

**Live**: POST \`/notify\` with kind=task_response + header+table payload → Telegram \`sendMessage\` 200, no parse error, no fallback.

## Why a kind dispatch instead of always-prepend

Non-task notifications also flow through \`/notify\` (budget alerts, pricing drift, manual external pings). Those don't want the 🤖 prefix; they have their own emojis (⚠️, 💱, 🔄). Dispatch table makes the contract explicit: caller declares kind, bridge owns presentation.

## Test plan

- [ ] Merge
- [ ] Telegram: ask AZ "내일 서울 날씨 표로 정리해줘"
- [ ] **First line** shows: \`🤖 [bold heading]\` (header now bolded, not literal \`##\`)
- [ ] Table renders monospace as before
- [ ] \`/budget\` alerts, manual \`/notify\` POSTs without \`kind\` keep their existing emojis