### PR TITLE
fix(prompts): use gh CLI for github.com URLs instead of asking for PAT

### DIFF
--- a/agent-zero/prompts/agent.system.behaviour_default.md
+++ b/agent-zero/prompts/agent.system.behaviour_default.md
@@ -1,1 +1,15 @@
 - favor linux commands for simple tasks where possible instead of python
+
+- For ANY `github.com` URL (PRs, issues, repos, branches, files), use `gh` CLI **first** before any browser-based tool. Examples:
+  - `gh pr view <url|number> --repo <owner>/<repo> --json title,body,files,additions,deletions`
+  - `gh pr diff <url|number> --repo <owner>/<repo>`
+  - `gh issue view <url|number> --repo <owner>/<repo>`
+  - `gh api repos/<owner>/<repo>/pulls/<N>/files`
+  The container ships with `gh` already authenticated via `GITHUB_TOKEN` (scopes: `repo`, `admin:org`, `workflow`) so private repos work without extra setup. **Never ask the user for a GitHub PAT** — if `gh` returns 404/403 unexpectedly, surface the actual error and the URL you tried; don't fall back to asking for credentials.
+
+- Before asking the user for credentials, env vars, or configuration, **check the existing setup**:
+  - Env: `env | grep -iE "<var>"` or `[ -n "$VAR" ] && echo set`
+  - GitHub: `gh auth status`
+  - Git: `git config --get user.name`, `git config --get user.email`
+  - Anthropic / OpenAI keys: `[ -n "$ANTHROPIC_API_KEY" ] && echo "key present"`
+  Only ask the user when the value is actually missing.


### PR DESCRIPTION
## Issue

User reported the agent doing this on a private repo PR URL:

> 🤖 Private 레포라 직접 접근이 불가합니다 …  
> 방법 2. GitHub Personal Access Token 제공  
> PAT가 있으면 GitHub API로 diff를 자동으로 가져올 수 있습니다.

Their reaction:
> 내가 분명 우리 조직 계정 깃허브 PR 주소 주면서 시킨거야. 근데 우리 기능 중에 gh 기능 있지않아? 그리고 .env 에 설정도 있어서 이미 선언했는데 왜 물어볼까?

## Diagnosis

**Infrastructure was 100% correct.** Verified live in the AZ container:

| Check | Result |
|---|---|
| \`GITHUB_TOKEN\` in env | ✅ 40 chars |
| \`gh\` CLI installed | ✅ v2.92.0 |
| \`gh auth status\` | ✅ logged in as devyoon91 |
| Token scopes | \`repo, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, copilot, notifications, workflow\` |
| \`gh repo view ecs-telecom/esp-ui\` | ✅ \`{\"name\":\"esp-ui\",\"visibility\":\"PRIVATE\"}\` |

The agent simply **chose \`browser_agent\` first** (anonymous web, blocked on private repos) and then asked the user for a PAT instead of trying the auth'd \`gh\` that was already sitting there. Pure prompt-level miss.

## Fix

Two rules added to \`agent-zero/prompts/agent.system.behaviour_default.md\`:

**Rule 1 — github.com URL → \`gh\` first.** Concrete command list:
- \`gh pr view <url> --json title,body,files\`
- \`gh pr diff <url>\`
- \`gh issue view <url>\`
- \`gh api repos/owner/repo/pulls/N/files\`

Explicit: container's \`gh\` is already authenticated, **never ask user for PAT**. On 404/403 surface the URL/error rather than fall back to credential prompts.

**Rule 2 — check existing setup before asking for any credential / env var / config.** \`env | grep\`, \`gh auth status\`, \`git config --get\`, \`[ -n \"\$KEY\" ]\`. Only ask when value is actually missing.

Rule 1 fixes today's complaint. Rule 2 is the underlying principle that prevents the same bug shape with future credentials (Anthropic, OpenAI, Telegram, etc).

## Verification

- File mounted into container, \`head -3\` confirms the new rules are at the top of the loaded behaviour file.
- Container recreated.

Next time the user pastes a private GitHub PR URL, the agent's plan should open with \`gh pr view ... --json files,...\` rather than \`browser_agent.navigate(...)\`.

## Test plan

- [ ] Merge
- [ ] Send a private repo PR URL via Telegram (e.g. \"https://github.com/ecs-telecom/esp-ui/pull/N 리뷰해줘\")
- [ ] Agent should NOT ask for PAT
- [ ] Agent should call \`gh pr diff\` or \`gh pr view --json files\` and return actual diff content