### PR TITLE
fix(prompts): forbid file references / template directives in response.text

### DIFF
--- a/agent-zero/prompts/agent.system.behaviour_default.md
+++ b/agent-zero/prompts/agent.system.behaviour_default.md
@@ -13,3 +13,5 @@
   - Git: `git config --get user.name`, `git config --get user.email`
   - Anthropic / OpenAI keys: `[ -n "$ANTHROPIC_API_KEY" ] && echo "key present"`
   Only ask the user when the value is actually missing.
+
+- The `response` tool's `text` argument is what the user receives **literally** (Telegram, web UI, etc). Never put placeholders, file references, or template directives (`§§include(...)`, `{{var}}`, `<file:...>`) in there expecting the runtime to dereference them — those only expand during system-prompt rendering, not in tool-call args. If you wrote the answer to a file (e.g. via `text_editor`), **read the file back and paste its contents into `response.text`**. If the answer is long, paste it anyway — the Telegram bridge handles truncation (`…(생략)` at ~3,900 chars) and markdown→HTML conversion. There is no "send this file" shortcut; the tool args are the wire format.


### PR DESCRIPTION
## Issue

User report with screenshot:
> 중간에 메세지가 짤리고 나서 다시 작성해달라고 했는데 텔레그램에는 이게 전송이 안되네?

Telegram showed a literal \`§§include(/a0/usr/workdir/review-pr-5470.md)\` where the actual review content was supposed to be.

## Root cause

Task JSON for the failing run shows the agent:

1. \`text_editor\` → wrote the full 5,577-byte review to \`/a0/usr/workdir/review-pr-5470.md\`
2. \`response\` → called with \`{\"text\": \"§§include(/a0/usr/workdir/review-pr-5470.md)\"}\`

\`§§include(...)\` is an Agent Zero **prompt-template directive** that expands only during system-prompt rendering. In tool-call args it's just a 44-character literal string. The bridge faithfully forwarded that string to Telegram — so the user saw the directive, not the review.

The first task in the same screenshot (the one that worked) put the 2,552-char review directly into \`response.text\`. That's the correct pattern. The second task tried to be clever about long output, picked the wrong technique, silently produced a broken delivery.

## Fix

New behavioral rule in \`agent.system.behaviour_default.md\`:

> The \`response\` tool's \`text\` argument is what the user receives **literally** (Telegram, web UI, etc). Never put placeholders, file references, or template directives (\`§§include(...)\`, \`{{var}}\`, \`<file:...>\`) in there expecting the runtime to dereference them — those only expand during system-prompt rendering, not in tool-call args. If you wrote the answer to a file (e.g. via \`text_editor\`), read the file back and paste its contents into \`response.text\`. If the answer is long, paste it anyway — the Telegram bridge handles truncation (\`…(생략)\` at ~3,900 chars) and markdown→HTML conversion. There is no \"send this file\" shortcut; the tool args are the wire format.

## Verification

Container recreated with the new prompt loaded. Next time the agent emits a long review, it should paste the full text in \`response.text\` rather than try a file reference.

## Test plan

- [ ] Merge
- [ ] Send the same private PR review prompt that produced the broken \`§§include(...)\` reply
- [ ] Telegram should now show the actual review body (likely truncated at \`…(생략)\` if > 3,900 chars, that's fine)