### PR TITLE
fix(pricing): stop double-counting cache tokens — input_tokens already includes them

### DIFF
--- a/agent-zero/lib/pricing.py
+++ b/agent-zero/lib/pricing.py
@@ -152,22 +152,37 @@ def compute_cost(
 ) -> float:
     """Compute total USD cost for one LLM call.
 
-    `input_tokens` in AZ's task_report is the RAW `prompt_tokens` from the
-    provider — on Anthropic this is already the billed regular-input count
-    (cache_read and cache_creation are NOT double-counted inside it). On
-    OpenAI, `prompt_tokens_details.cached_tokens` IS included in
-    prompt_tokens, so subtract it to avoid billing the same tokens twice.
+    `input_tokens` here is LiteLLM's normalized `prompt_tokens`, which —
+    contrary to an earlier assumption in this docstring — is the TOTAL
+    prompt token count INCLUDING the cache_read and cache_creation
+    buckets. (LiteLLM normalizes Anthropic's split usage into OpenAI-style
+    `prompt_tokens` semantics: a single number that represents
+    everything billed on the input side.)
 
-    The stream-usage probe normalizes to the Anthropic convention, so we
-    treat `input_tokens` as regular-only here. If callers pass a raw OpenAI
-    total they should subtract cache_read first.
+    Verified against Anthropic Console on 2026-04-30:
+      raw inputs:  prompt=1.224M  cache_read=638k  cache_create=316k
+      OUR previous logic (pre-fix): \$5.626  ← double-counts cache
+      THIS function (post-fix):     \$2.763
+      Anthropic Console:            \$2.70
+
+    So we have to subtract the cache buckets from `input_tokens` before
+    pricing the regular bucket — otherwise the cache tokens get billed
+    twice (once at input rate via input_tokens, once at cache rate
+    via the dedicated buckets).
+
+    Negative regular-input is clamped to 0 in case a provider one day
+    sends overlapping numbers we can't reconcile.
     """
     rates = get_rates(model)
+    inp = max(0, int(input_tokens))
+    cr = max(0, int(cache_read_tokens))
+    cc = max(0, int(cache_creation_tokens))
+    regular = max(0, inp - cr - cc)
     cost = (
-        max(0, int(input_tokens)) * rates["input_cost_per_token"]
+        regular * rates["input_cost_per_token"]
         + max(0, int(output_tokens)) * rates["output_cost_per_token"]
-        + max(0, int(cache_read_tokens)) * rates["cache_read_input_token_cost"]
-        + max(0, int(cache_creation_tokens)) * rates["cache_creation_input_token_cost"]
+        + cr * rates["cache_read_input_token_cost"]
+        + cc * rates["cache_creation_input_token_cost"]
     )
     return round(cost, 6)
 

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -356,21 +356,36 @@ def calc_cost(
     cache_read_tokens: int = 0,
     cache_creation_tokens: int = 0,
 ) -> float:
-    """Cache-aware cost calc. On Anthropic the provider-reported
-    `input_tokens` is already the regular-input-only count (cache_read /
-    cache_creation are billed separately), so we don't subtract — we just
-    price each bucket at its own rate.
+    """Cache-aware cost calc.
+
+    `input_tokens` here is LiteLLM's normalized `prompt_tokens` — the
+    TOTAL prompt token count INCLUDING the cache_read and cache_creation
+    buckets. The earlier assumption that Anthropic's split usage stayed
+    split through LiteLLM was wrong; LiteLLM normalizes everything into
+    OpenAI-style `prompt_tokens` semantics where the number is one
+    aggregate.
+
+    Verified against Anthropic Console on 2026-04-30:
+        raw inputs:  prompt=1.224M  cache_read=638k  cache_create=316k
+        pre-fix:  \$5.626  (double-counted cache)
+        post-fix: \$2.763  ≈ Console \$2.70
+
+    Same fix lives in agent-zero/lib/pricing.py:compute_cost.
     """
     info = _model_info(model)
     in_rate = info.get("input_cost_per_token", 0.000003)      # $3 / 1M fallback
     out_rate = info.get("output_cost_per_token", 0.000015)    # $15 / 1M
     read_rate = info.get("cache_read_input_token_cost", in_rate * 0.10)
     create_rate = info.get("cache_creation_input_token_cost", in_rate * 1.25)
+    inp = max(0, int(input_tokens))
+    cr = max(0, int(cache_read_tokens))
+    cc = max(0, int(cache_creation_tokens))
+    regular = max(0, inp - cr - cc)
     return (
-        max(0, int(input_tokens)) * in_rate
+        regular * in_rate
         + max(0, int(output_tokens)) * out_rate
-        + max(0, int(cache_read_tokens)) * read_rate
-        + max(0, int(cache_creation_tokens)) * create_rate
+        + cr * read_rate
+        + cc * create_rate
     )
 
 


### PR DESCRIPTION
## Issue

User compared /today to Anthropic Console (2026-04-30):

| Source | Sonnet | Haiku | Total |
|---|---|---|---|
| Anthropic Console | \$2.70 | \$0.95 | \$3.65 |
| Our /today | \$5.63 | \$0.0002 | \$5.63 |

Two **separate** bugs. This PR fixes Bug #1 (Sonnet over-count). Bug #2 (Haiku capture) tracked as a separate issue.

## Bug #1 — \`input_tokens\` double-counts cache buckets

Earlier docstrings claimed Anthropic's split usage stayed split through LiteLLM. **Wrong**. LiteLLM normalizes \`input_tokens\` / \`cache_read_input_tokens\` / \`cache_creation_input_tokens\` into OpenAI-style \`prompt_tokens\` semantics — one number that includes the cache buckets. We then added the cache buckets again at their own rates → 2x charge.

### Verified with today's data

Sonnet input mix:
\`\`\`
prompt:        1,224,000
cache_read:      638,000
cache_create:    316,000
\`\`\`

Re-pricing:
\`\`\`
pre-fix:   input(\$3.67) + cache_r(\$0.19) + cache_c(\$1.18) + output(\$0.58) = \$5.626
                                                                              ^^^^^^^
post-fix:  regular = input - cache_r - cache_c = 270,000
           regular(\$0.81) + cache_r(\$0.19) + cache_c(\$1.18) + output(\$0.58) = \$2.763
                                                                              ^^^^^^^
Console:   \$2.70   (within 2.3% — Anthropic dashboard rounding/lag)
\`\`\`

## Fix

Both copies of the cost calculator (\`agent-zero/lib/pricing.py:compute_cost\` + \`telegram-bridge/bot.py:calc_cost\`) get the same change:

\`\`\`python
regular = max(0, input_tokens - cache_read - cache_creation)
cost = (regular * input_rate
        + output_tokens * output_rate
        + cache_read * cache_read_rate
        + cache_creation * cache_creation_rate)
\`\`\`

\`max(0, ...)\` is defensive — if a provider ever sends overlapping counts we can't reconcile, regular pins at zero rather than going negative.

Both docstrings updated to document what was verified against the Console on 2026-04-30.

## Scope

- **Going forward**: per-call \`cost_usd\` and roll-ups (\`/today\`, \`/week\`, dashboard, \`/usage\`, \`/budget\`, task summary card) all use the corrected math.
- **Historical task JSONs**: stored \`cost_usd\` reflects the old logic and won't auto-rewrite. \`/today\` / \`/week\` sum the stored values so old days stay slightly inflated until they age out of the 30-day window.

## Bug #2 (separate)

Haiku util_model calls log only \`in=1, out=3, approx=True\` per call. The LiteLLM stream-usage probe doesn't intercept util (non-streaming) → falls through to \`approximate_tokens\` → ~0. Anthropic Console shows real \$0.95/day for Haiku so we're missing ~99.99% of it. **Tracked as a separate issue** — needs a different capture mechanism (probably routing the LiteLLM success callback that already feeds bridge's \`usage_today\` into the active task report too).

## Test plan

- [ ] Merge
- [ ] Run a task, check task JSON's \`cost_usd\` is the new (lower) value
- [ ] Tomorrow: compare /today to Anthropic Console — Sonnet should match within ~3%