### PR TITLE
fix(probe): capture usage on non-stream LiteLLM calls (closes #52)

### DIFF
--- a/agent-zero/extensions/python/agent_init/_91_chunk_usage_probe.py
+++ b/agent-zero/extensions/python/agent_init/_91_chunk_usage_probe.py
@@ -269,6 +269,49 @@ async def _wrapped_acompletion(*args, **kwargs):
     result = await _original_acompletion(*args, **kwargs)
     if kwargs.get("stream"):
         return _wrap_stream(result, kwargs.get("model", "unknown"))
+
+    # ── Non-stream path ─────────────────────────────────────────────────
+    # AZ's `unified_call` chooses stream=True only when at least one
+    # callback is set. Util-model calls (rename_chat, infection_check,
+    # chat_compaction, email_integration, etc.) typically pass NO callback
+    # → stream=False → we land here. The result is a complete
+    # ModelResponse with `.usage` already populated by LiteLLM, so we
+    # reuse the same ContextVar + bridge-track plumbing the stream branch
+    # uses. Closes issue #52 (util Haiku captured as in=1/out=3 sentinel
+    # because the prior code returned the result untouched and
+    # task_report's llm_call fell through to approximate_tokens).
+    try:
+        usage = _extract_usage(result)
+        if usage and (usage["prompt_tokens"] > 0 or usage["completion_tokens"] > 0):
+            model_name = kwargs.get("model", "unknown")
+            usage["model"] = model_name
+            last_stream_usage.set(usage)
+            if requests is not None:
+                try:
+                    requests.post(
+                        TELEGRAM_BRIDGE_URL,
+                        json={
+                            "model": model_name,
+                            "input_tokens": usage["prompt_tokens"],
+                            "output_tokens": usage["completion_tokens"],
+                            "cache_read_tokens": usage["cache_read_input_tokens"],
+                            "cache_creation_tokens": usage["cache_creation_input_tokens"],
+                        },
+                        timeout=3,
+                    )
+                except Exception:
+                    pass
+            print(
+                f"[NonStreamUsageCapture] model={model_name} "
+                f"in={usage['prompt_tokens']} out={usage['completion_tokens']} "
+                f"cache_read={usage['cache_read_input_tokens']} "
+                f"cache_creation={usage['cache_creation_input_tokens']}",
+                flush=True,
+            )
+    except Exception as e:
+        # Never let usage extraction failure impact the actual completion.
+        print(f"[NonStreamUsageCapture] extract failed: {e}", flush=True)
+
     return result
 
 


### PR DESCRIPTION
## Closes #52

Haiku \`util_model\` calls landed in task JSON as \`in=1, out=3, approx=True\` sentinel data. Anthropic Console showed \$0.95/day actual Haiku spend, our \`/today\` reported \$0.0002 — ~99.99% of util traffic was missing.

## Why \"Option A\" turned out small after re-investigation

The original \"force util to use stream=True\" framing in #52 was the wrong diagnosis. Util calls already go through the same \`acompletion\` we wrap. The actual gap, per \`/a0/models.py:unified_call\` line 514:

\`\`\`python
stream = (reasoning_callback is not None
          or response_callback is not None
          or tokens_callback is not None)
\`\`\`

Util callers (rename_chat, infection_check, chat_compaction, email_integration, ...) typically pass NO callback → \`stream=False\` → LiteLLM returns a complete \`ModelResponse\` with \`.usage\` populated normally — **but our \`_wrapped_acompletion\` only extracted usage on the stream path**. Non-stream completions were returned untouched, \`last_stream_usage\` ContextVar stayed None, \`task_report.llm_call\` fell through to \`approximate_tokens\` → ~1 input token, ~3 output tokens.

## Fix (one file, ~20 lines)

Added a non-stream branch to \`_wrapped_acompletion\` that mirrors the stream path:

1. Reuse \`_extract_usage(result)\` (already in this file) → returns the same dict shape \`_wrap_stream\` produces.
2. Set \`last_stream_usage\` ContextVar (consumed by \`task_report.llm_call\`).
3. POST to bridge \`/track\` (so \`/usage\` totals also pick up util traffic — symmetric with chat path).
4. \`try/except\` everything — usage extraction failure must never affect the actual completion.

Zero-usage / missing \`.usage\` cases short-circuit so we don't churn empty data.

## Verification

Smoke test, 4/4 cases pass:

| Case | Result |
|---|---|
| Typical Haiku util response (in=4521, out=88, cache_r=3000, cache_c=250) | ContextVar populated, /track POST fires with matching payload |
| Zero-usage response | ContextVar stays None, no POST |
| Response missing \`.usage\` attribute | No crash, no POST |
| Branch placement | New branch sits AFTER the stream \`return _wrap_stream(...)\` so stream calls bypass it |

**Live**: container recreated, file mounted, \`NonStreamUsageCapture\` marker present twice. Next util call (next chat rename, next compaction trigger) will fire \`[NonStreamUsageCapture]\` log line and write real numbers into the task JSON.

## Expected impact

Combined with PR #51 (Sonnet pricing fix):
- **Sonnet**: Already accurate within 3% of Console (PR #51).
- **Haiku**: After this merges, should match Console within similar margin.
- **Both via /today, /week, dashboard, /usage, /budget, task summary card** — they all share the same data sources.

## What this PR does NOT do

Historical task JSONs keep their \`approx=True\` sentinel data. Roll-ups will reflect real Haiku usage starting from new tasks; old days stay slightly wrong until they age out of the 30-day window.

## Test plan

- [ ] Merge
- [ ] Send any Telegram message that triggers AZ activity (chat rename + compaction will both call util model)
- [ ] \`docker logs agent-zero | grep NonStreamUsageCapture\` should show \`model=claude-haiku-4-5 in=NNN out=NNN ...\` lines with real numbers
- [ ] Tomorrow's \`/today\` Haiku line matches Anthropic Console