### PR TITLE
fix(md): protect fenced code blocks from header/table/bold rules

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -126,18 +126,33 @@ def md_to_telegram_html(text: str) -> str:
     )
 
     # Step 2: ```lang\n...\n``` fenced code blocks.
-    # Run FIRST so the inner content (which may contain | or # chars) isn't
-    # touched by the table / header rules below.
-    def _fence(m):
+    # Stash each fence as a placeholder token and only restore them at the
+    # very end. Without this, line-anchored rules like the header regex
+    # (`^#{1,6} `) chase Bash comments INSIDE the fence and wrap them in
+    # `<b>...</b>`, producing nested `<b><pre><code>...</b></code></pre>`
+    # mush that Telegram rejects with "can't parse entities" → bridge
+    # falls back to plain text → user sees literal ``` markers. Same shape
+    # of problem applies to the table rule and the bold/italic regexes
+    # whenever shell/code content contains `|`, `*`, `**`.
+    #
+    # Sentinel chars `\x00` aren't valid in user input we'd render, so
+    # they're a safe placeholder boundary.
+    fence_placeholders: list[str] = []
+
+    def _stash_fence(m):
         lang = m.group(1) or ""
         body = m.group(2).rstrip("\n")
         if lang:
-            return f'<pre><code class="language-{lang}">{body}</code></pre>'
-        return f"<pre>{body}</pre>"
+            html = f'<pre><code class="language-{lang}">{body}</code></pre>'
+        else:
+            html = f"<pre>{body}</pre>"
+        idx = len(fence_placeholders)
+        fence_placeholders.append(html)
+        return f"\x00FENCE{idx}\x00"
 
     out = _re_md_to_html.sub(
         r"```(\w*)\n?(.*?)```",
-        _fence,
+        _stash_fence,
         out,
         flags=_re_md_to_html.DOTALL,
     )
@@ -206,6 +221,12 @@ def md_to_telegram_html(text: str) -> str:
         out,
         flags=_re_md_to_html.MULTILINE,
     )
+
+    # Step 9: Restore stashed fenced code blocks. Plain string replace —
+    # placeholder tokens carry the index, content was already escaped + tag-
+    # wrapped at stash time so nothing else needs to happen here.
+    for idx, html in enumerate(fence_placeholders):
+        out = out.replace(f"\x00FENCE{idx}\x00", html)
 
     return out
 


### PR DESCRIPTION
## Issue

User report (during k-skill testing, issue #53):

> 마지막 질문에서 텔레그램에 결과 전송할때 마크다운이 제대로 변환되어서 전송이 안된거 같아 양식 그대로 갔어. 코드 블록 바로 위에 텍스트가 입력되면 변환이 안되는건 아냐?

User's hypothesis ("label-directly-above-fence") was the right symptom, wrong mechanism.

## Root cause

Header rule was running multiline-regex over the **entire document AFTER** fence conversion. AZ answers explaining shell tools commonly include Bash comments inside code fences:

\`\`\`bash
# Rust toolchain이 있으면 (권장)
cargo install rhwp
\`\`\`

After fence conversion that became:

\`\`\`
<pre><code class=\"language-bash\"># Rust toolchain이 있으면 (권장)
cargo install rhwp
</code></pre>
\`\`\`

The header rule then matched the \`# Rust toolchain...\` line at line-start (it IS at line-start in the document) and wrapped it as \`<b>...</b>\`:

\`\`\`
<pre><code class=\"language-bash\"><b>Rust toolchain이 있으면 (권장)</b>
cargo install rhwp
</code></pre>
\`\`\`

Tag balance broke. Telegram rejected with \"can't parse entities\", bridge fell back to plain text via \`fallback_text\`, user saw literal \`\`\` markers and \`##\` headers.

Same shape of bug applies to: table rule (\`|\` in shell pipelines), bold rule (\`**\` globs), italic rule (\`*\` globs).

## Fix

**Placeholder substitution.** Step 2 stashes each fenced block as a sentinel token \`\x00FENCE{n}\x00\`, runs all subsequent rules over the document with fences replaced by opaque markers, then step 9 restores. \`\x00\` isn't valid in user-facing text → collision-free.

\`\`\`python
fence_placeholders = []

def _stash_fence(m):
    ...
    idx = len(fence_placeholders)
    fence_placeholders.append(html)
    return f\"\x00FENCE{idx}\x00\"

# ... all other rules run on document with placeholder tokens ...

# Step 9: restore
for idx, html in enumerate(fence_placeholders):
    out = out.replace(f\"\x00FENCE{idx}\x00\", html)
\`\`\`

Other rules now see the document as if fences weren't there.

## Verification

4/4 smoke cases pass:

| Case | Result |
|---|---|
| Real broken response (Bash comments inside fence) | Tag balance clean (0 unclosed, 0 unmatched), \`#\` lines stay inside \`<pre><code>\` |
| Shell glob \`*.txt *.py\` inside fence | No \`<i>\` conversion inside |
| Pipes inside fence | Table rule doesn't fire |
| Regular markdown outside fence | h1-h6 → \`<b>\`, \`**bold**\`, \`*italic*\`, \`\`inline\`\` all still convert correctly |

Live: bridge rebuilt + recreated. Same k-skill question that produced the broken render should now deliver properly.

## Test plan

- [ ] Merge
- [ ] Re-ask the same prompt that broke (\"HWP IR 덤프로 표 깨진 위치 디버깅...\")
- [ ] Telegram should show: bold headers, properly rendered code blocks, no literal \`\`\` markers