### PR TITLE
chore(deps): bump agent-zero v1.9 → v1.13 (closes #46)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   # ── Agent Zero: AI Agent Framework ──
   agent-zero:
-    image: agent0ai/agent-zero:v1.9
+    image: agent0ai/agent-zero:v1.13
     container_name: agent-zero
     ports:
       - "50001:80"


### PR DESCRIPTION
## Closes #46

4개 마이너 누적 (v1.10, v1.11, v1.12, v1.13).

## 주요 변경 요약

| 버전 | 주요 |
|---|---|
| v1.10 | 내장 Browser, Time Travel, Office canvas, Codex OAuth, FastMCP 3.x, CVE-2026-32871 |
| v1.11 | Browser multi-tab, LibreOffice (Collabora 교체), Linux Desktop skill |
| v1.12 | 🐛 PTY fd leak 픽스, browser stale context recovery |
| v1.13 | ODF-first, persistent Desktop, Bash-style 입력 히스토리 |

## Dry-run 검증 결과

| 항목 | 결과 |
|---|---|
| 이미지 풀 (12GB) | ✅ |
| 컨테이너 부팅 — supervisor 프로세스, error/exception/warn/fail 없음 | ✅ |
| 마운트된 4개 헬퍼 파일 컨테이너에서 보임 | ✅ |
| \`/api/csrf_token\` | ✅ 200 |
| \`/api/settings_get\` (\`{settings, additional}\` 스키마 동일) | ✅ |
| \`/api/plugins/_model_config/model_config_get\` (\`config\` 키) | ✅ |
| \`/api/poll\` (\`log_version\` 키) | ✅ |
| \`/api/chat_create\` (\`ctxid\` 키) | ✅ |

**API 호환성 100%** — PR #15-#55 가 의존하는 모든 엔드포인트 동일 응답.

**비용 정확도** (라이브 검증, 2026-05-06):
- Sonnet: Console \$0.64 vs 우리 \$0.6441 (**0.6% 오차** ✅)
- Haiku: Console \$0.19 vs 우리 \$0.0347 (5.5x 미달 — 별도 이슈 #56 추적 중, v1.13 무관)

## 알려진 갭 (블로커 아님)

Haiku 캡처 정확도 격차는 v1.13 무관 — sync \`litellm.completion\` 우회 때문이며 v1.9 에서도 동일 양상. 이슈 #56 에 분리 등록, 별도 작은 PR 으로 해결 예정. Sonnet 정확도가 비용 모니터링의 핵심 가치 대부분을 이미 커버.

## 롤백 (필요 시)

\`\`\`yaml
image: agent0ai/agent-zero:v1.9
\`\`\`
+ \`docker compose up -d --force-recreate agent-zero\`. v1.9 이미지 로컬 캐시에 그대로 있음.

## Test plan

- [x] dry-run 부팅 OK
- [x] 4 API 엔드포인트 OK
- [x] 헬퍼 파일 마운트 OK
- [ ] 머지 후 텔레그램 일반 워크플로우 (\`/today\`, \`/usage\`, \`/status\`, \`/new\`, \`/chats\`, \`/pricing\`, \`/budget\`, 일반 메시지)
- [ ] 마크다운 렌더링 (코드 블록 + 헤더 + 표) — PR #55 의 fence 보호가 v1.13 에서도 동작