### PR TITLE
fix(prompts): strengthen response.text-is-literal rule (covers subordinate response forwarding)

### DIFF
--- a/agent-zero/prompts/agent.system.behaviour_default.md
+++ b/agent-zero/prompts/agent.system.behaviour_default.md
@@ -14,4 +14,10 @@
   - Anthropic / OpenAI keys: `[ -n "$ANTHROPIC_API_KEY" ] && echo "key present"`
   Only ask the user when the value is actually missing.
 
-- The `response` tool's `text` argument is what the user receives **literally** (Telegram, web UI, etc). Never put placeholders, file references, or template directives (`§§include(...)`, `{{var}}`, `<file:...>`) in there expecting the runtime to dereference them — those only expand during system-prompt rendering, not in tool-call args. If you wrote the answer to a file (e.g. via `text_editor`), **read the file back and paste its contents into `response.text`**. If the answer is long, paste it anyway — the Telegram bridge handles truncation (`…(생략)` at ~3,900 chars) and markdown→HTML conversion. There is no "send this file" shortcut; the tool args are the wire format.
+- **`response.text` = wire format.** Whatever string you put into the `response` tool's `text` argument is delivered **byte-for-byte** to the user (Telegram, web UI). The runtime does not dereference, expand, fetch, or interpret it in any way. This is non-negotiable regardless of where the actual content lives. Specifically forbidden:
+  - Template directives — `§§include(...)`, `{{var}}`, `<file:...>` (these expand only during system-prompt RENDERING, not in tool-call args)
+  - File path references of any flavor — your own files (`/a0/usr/workdir/*.md`), AZ's internal chat history (`/a0/usr/chats/<ctxid>/messages/*.txt`), workdir paths, anything
+  - Phrases like "see file X" / "the full output is at Y" / "I saved it to Z" with the expectation the user will open it
+  - Forwarding a subordinate's response by reference — the subordinate's text comes back to you as a string; you must **paste that string** into your `response.text`, not point at where AZ stored it
+
+  Decision rule: **if you can't show the actual answer text inline in this very tool call, you don't have an answer to send yet.** Read the file/subordinate-response back into your context and paste the literal content. Length is not an excuse — the Telegram bridge truncates long answers at ~3,900 chars with a `…(생략)` marker and renders markdown → HTML automatically; pasting a full 10k-char response is fine, the bridge handles it. There is no "send this file" shortcut.


### PR DESCRIPTION
## Issue

User report (PR #50 의 동일 패턴 재발):
> 이번 세션에서 또 채팅이 텔레그램에 전송하다가 짤리고 \`§§include(/a0/usr/chats/8sVWmG4O/messages/1.txt)\` 참조 했어.

## Task JSON 분석

\`\`\`
task-20260506-085042-8776f4 (parent, ecs-lead):
  tool_calls:
    - call_subordinate     5,902 byte response from ecs-db-expert
    - response             text=\"§§include(/a0/usr/chats/8sVWmG4O/messages/1.txt)\" (48 bytes)

task-20260506-085049-55b939 (subordinate, ecs-db-expert):
  final_response: 5,902 byte SQL answer ✓
\`\`\`

Subordinate 가 정답을 5,902자로 반환했는데, parent 가 그걸 **AZ 내부 chat history 파일 경로**로 reference. PR #50 룰이 분명 컨테이너에 로드돼있지만 agent 가 \"좁게\" 해석 — \"text_editor → user file\" 패턴만 금지로 인식.

## 룰 강화 (보편화)

기존 룰은 한 문단 + 예시 한 개 (text_editor). 이번 변경:

1. **표제 강화** — \"\`response.text\` = wire format, byte-for-byte\"
2. **금지 패턴 4가지 명시** —
   - 템플릿 directive (\`§§include\`, \`{{var}}\`, \`<file:...>\`)
   - 파일 경로 참조 (workdir / **AZ chat history (\`/a0/usr/chats/<ctxid>/messages/*.txt\`)** / 기타)
   - \"see file X\" / \"전체 출력은 Y에\" 같은 산문성 포인터
   - **subordinate response forwarding by reference** ← 이번 케이스
3. **Decision rule** — \"if you can't show the actual answer text inline in this very tool call, you don't have an answer to send yet\"
4. 길이 핑계 차단 — bridge 가 ~3,900자 truncate + markdown→HTML 자동 처리하므로 풀 내용 붙여넣기가 정답

## 검증

컨테이너 재기동 후 \`/a0/prompts/agent.system.behaviour_default.md\` tail 에 새 룰 라이브 확인됨.

## Test plan

- [ ] Merge
- [ ] subordinate 호출하는 task 던져보기 (예: \"ecs-db-expert 에 Oracle 쿼리 물어보고 결과 정리해줘\")
- [ ] \`response.text\` 에 subordinate 의 답변 본문이 그대로 나와야 함
- [ ] \`§§include\` / \`/a0/usr/chats/...\` 같은 reference 가 다시 나오면 룰 추가 강화 필요 (관찰 필요)