### PR TITLE
feat: capture reasoning_tokens end-to-end

### DIFF
--- a/agent-zero/extensions/python/agent_init/_91_chunk_usage_probe.py
+++ b/agent-zero/extensions/python/agent_init/_91_chunk_usage_probe.py
@@ -67,7 +67,15 @@ _patched = False
 
 
 def _extract_usage(assembled) -> dict | None:
-    """Return a plain dict of usage fields from an assembled ModelResponse."""
+    """Return a plain dict of usage fields from an assembled ModelResponse.
+
+    Includes `reasoning_tokens` for Claude 4.x extended thinking (and
+    OpenAI o-series models): LiteLLM normalizes these into the OpenAI
+    shape `usage.completion_tokens_details.reasoning_tokens`. Anthropic
+    bills thinking tokens at the output rate, so missing them shows up
+    as a small (~3-5%) under-count vs Anthropic Console — the gap we
+    saw on the 5/7 reconciliation.
+    """
     if assembled is None:
         return None
     usage = getattr(assembled, "usage", None)
@@ -84,12 +92,26 @@ def _extract_usage(assembled) -> dict | None:
         "completion_tokens": g("completion_tokens"),
         "cache_read_input_tokens": g("cache_read_input_tokens"),
         "cache_creation_input_tokens": g("cache_creation_input_tokens"),
+        "reasoning_tokens": 0,
     }
     # Fold OpenAI-style cached_tokens into cache_read if present
     details = getattr(usage, "prompt_tokens_details", None)
     if details is not None:
         cached = getattr(details, "cached_tokens", 0) or 0
         data["cache_read_input_tokens"] += cached
+
+    # Reasoning / thinking tokens — OpenAI-shape `completion_tokens_details`.
+    # LiteLLM normalizes Anthropic extended-thinking into this same shape.
+    cdetails = getattr(usage, "completion_tokens_details", None)
+    if cdetails is not None:
+        data["reasoning_tokens"] = int(
+            getattr(cdetails, "reasoning_tokens", 0) or 0
+        )
+    elif isinstance(usage, dict):
+        cd = usage.get("completion_tokens_details") or {}
+        if isinstance(cd, dict):
+            data["reasoning_tokens"] = int(cd.get("reasoning_tokens", 0) or 0)
+
     return data
 
 
@@ -131,6 +153,20 @@ def _merge_chunk_usage(chunk, acc: dict) -> None:
         if v > acc.get(f, 0):
             acc[f] = v
 
+    # Reasoning / thinking tokens — same cumulative-max merge as above
+    # because Claude can emit incremental thinking deltas before final.
+    cdetails = getattr(usage, "completion_tokens_details", None)
+    if cdetails is not None:
+        rt = int(getattr(cdetails, "reasoning_tokens", 0) or 0)
+        if rt > acc.get("reasoning_tokens", 0):
+            acc["reasoning_tokens"] = rt
+    elif isinstance(usage, dict):
+        cd = usage.get("completion_tokens_details") or {}
+        if isinstance(cd, dict):
+            rt = int(cd.get("reasoning_tokens", 0) or 0)
+            if rt > acc.get("reasoning_tokens", 0):
+                acc["reasoning_tokens"] = rt
+
     # OpenAI-style cache falls in prompt_tokens_details
     details = getattr(usage, "prompt_tokens_details", None)
     if details is not None:
@@ -161,6 +197,7 @@ async def _wrap_stream(wrapper, model_name: str):
         "completion_tokens": 0,
         "cache_read_input_tokens": 0,
         "cache_creation_input_tokens": 0,
+        "reasoning_tokens": 0,
     }
     n_chunks = 0
     n_swallowed = 0
@@ -233,6 +270,7 @@ async def _wrap_stream(wrapper, model_name: str):
                                 "output_tokens": acc["completion_tokens"],
                                 "cache_read_tokens": acc["cache_read_input_tokens"],
                                 "cache_creation_tokens": acc["cache_creation_input_tokens"],
+                                "reasoning_tokens": acc.get("reasoning_tokens", 0),
                             },
                             timeout=3,
                         )
@@ -243,6 +281,7 @@ async def _wrap_stream(wrapper, model_name: str):
                     f"in={acc['prompt_tokens']} out={acc['completion_tokens']} "
                     f"cache_read={acc['cache_read_input_tokens']} "
                     f"cache_creation={acc['cache_creation_input_tokens']} "
+                    f"reasoning={acc.get('reasoning_tokens', 0)} "
                     f"chunks={n_chunks} inner={len(inner_chunks)} drained={n_drained} "
                     f"usage_chunks={n_with_usage} swallowed={n_swallowed}",
                     flush=True,
@@ -297,6 +336,7 @@ async def _wrapped_acompletion(*args, **kwargs):
                             "output_tokens": usage["completion_tokens"],
                             "cache_read_tokens": usage["cache_read_input_tokens"],
                             "cache_creation_tokens": usage["cache_creation_input_tokens"],
+                            "reasoning_tokens": usage.get("reasoning_tokens", 0),
                         },
                         timeout=3,
                     )
@@ -306,7 +346,8 @@ async def _wrapped_acompletion(*args, **kwargs):
                 f"[NonStreamUsageCapture] model={model_name} "
                 f"in={usage['prompt_tokens']} out={usage['completion_tokens']} "
                 f"cache_read={usage['cache_read_input_tokens']} "
-                f"cache_creation={usage['cache_creation_input_tokens']}",
+                f"cache_creation={usage['cache_creation_input_tokens']} "
+                f"reasoning={usage.get('reasoning_tokens', 0)}",
                 flush=True,
             )
     except Exception as e:
@@ -332,6 +373,7 @@ def _wrap_sync_stream(wrapper, model_name: str):
         "completion_tokens": 0,
         "cache_read_input_tokens": 0,
         "cache_creation_input_tokens": 0,
+        "reasoning_tokens": 0,
     }
     n_chunks = 0
     n_swallowed = 0
@@ -391,6 +433,7 @@ def _wrap_sync_stream(wrapper, model_name: str):
                                 "output_tokens": acc["completion_tokens"],
                                 "cache_read_tokens": acc["cache_read_input_tokens"],
                                 "cache_creation_tokens": acc["cache_creation_input_tokens"],
+                                "reasoning_tokens": acc.get("reasoning_tokens", 0),
                             },
                             timeout=3,
                         )
@@ -401,6 +444,7 @@ def _wrap_sync_stream(wrapper, model_name: str):
                     f"in={acc['prompt_tokens']} out={acc['completion_tokens']} "
                     f"cache_read={acc['cache_read_input_tokens']} "
                     f"cache_creation={acc['cache_creation_input_tokens']} "
+                    f"reasoning={acc.get('reasoning_tokens', 0)} "
                     f"chunks={n_chunks} inner={len(inner_chunks)} drained={n_drained} "
                     f"usage_chunks={n_with_usage} swallowed={n_swallowed}",
                     flush=True,
@@ -450,6 +494,7 @@ def _wrapped_completion(*args, **kwargs):
                             "output_tokens": usage["completion_tokens"],
                             "cache_read_tokens": usage["cache_read_input_tokens"],
                             "cache_creation_tokens": usage["cache_creation_input_tokens"],
+                            "reasoning_tokens": usage.get("reasoning_tokens", 0),
                         },
                         timeout=3,
                     )
@@ -459,7 +504,8 @@ def _wrapped_completion(*args, **kwargs):
                 f"[SyncNonStreamUsageCapture] model={model_name} "
                 f"in={usage['prompt_tokens']} out={usage['completion_tokens']} "
                 f"cache_read={usage['cache_read_input_tokens']} "
-                f"cache_creation={usage['cache_creation_input_tokens']}",
+                f"cache_creation={usage['cache_creation_input_tokens']} "
+                f"reasoning={usage.get('reasoning_tokens', 0)}",
                 flush=True,
             )
     except Exception as e:

--- a/agent-zero/lib/pricing.py
+++ b/agent-zero/lib/pricing.py
@@ -149,6 +149,7 @@ def compute_cost(
     output_tokens: int = 0,
     cache_read_tokens: int = 0,
     cache_creation_tokens: int = 0,
+    reasoning_tokens: int = 0,
 ) -> float:
     """Compute total USD cost for one LLM call.
 
@@ -172,15 +173,23 @@ def compute_cost(
 
     Negative regular-input is clamped to 0 in case a provider one day
     sends overlapping numbers we can't reconcile.
+
+    `reasoning_tokens` (Claude 4.x extended thinking, OpenAI o-series) are
+    billed at the OUTPUT rate per Anthropic's docs. LiteLLM's normalized
+    `usage.completion_tokens` typically does NOT include the reasoning
+    portion (they're surfaced separately in `completion_tokens_details`),
+    so we add reasoning on top of output_tokens here. Closes the residual
+    ~3-5% Sonnet undercount we saw vs Anthropic Console after PR #51.
     """
     rates = get_rates(model)
     inp = max(0, int(input_tokens))
     cr = max(0, int(cache_read_tokens))
     cc = max(0, int(cache_creation_tokens))
+    rt = max(0, int(reasoning_tokens))
     regular = max(0, inp - cr - cc)
     cost = (
         regular * rates["input_cost_per_token"]
-        + max(0, int(output_tokens)) * rates["output_cost_per_token"]
+        + (max(0, int(output_tokens)) + rt) * rates["output_cost_per_token"]
         + cr * rates["cache_read_input_token_cost"]
         + cc * rates["cache_creation_input_token_cost"]
     )

--- a/agent-zero/lib/task_report.py
+++ b/agent-zero/lib/task_report.py
@@ -45,7 +45,8 @@ try:
     from helpers.pricing import compute_cost  # type: ignore
 except Exception:  # pragma: no cover - only runs inside AZ container
     def compute_cost(model=None, input_tokens=0, output_tokens=0,
-                     cache_read_tokens=0, cache_creation_tokens=0) -> float:  # type: ignore
+                     cache_read_tokens=0, cache_creation_tokens=0,
+                     reasoning_tokens=0) -> float:  # type: ignore
         return 0.0
 
 logger = logging.getLogger(__name__)
@@ -136,6 +137,7 @@ def _compute_totals(report: dict) -> dict:
         "output_tokens": sum(c.get("output_tokens", 0) for c in calls),
         "cache_read_tokens": sum(c.get("cache_read_tokens", 0) for c in calls),
         "cache_creation_tokens": sum(c.get("cache_creation_tokens", 0) for c in calls),
+        "reasoning_tokens": sum(c.get("reasoning_tokens", 0) for c in calls),
         # Per-call `cost_usd` is authoritative; we sum rather than re-computing
         # from totals so model-mix inside one task is priced accurately.
         "cost_usd": round(sum(c.get("cost_usd", 0.0) or 0.0 for c in calls), 6),
@@ -419,11 +421,17 @@ def llm_call(agent, call_data, response, reasoning=None) -> None:
 
     usage = getattr(response, "usage", None) if response is not None else None
 
+    reasoning_tokens = 0
     if stream_usage:
         input_tokens = int(stream_usage.get("prompt_tokens", 0) or 0)
         output_tokens = int(stream_usage.get("completion_tokens", 0) or 0)
         cache_read = int(stream_usage.get("cache_read_input_tokens", 0) or 0)
         cache_creation = int(stream_usage.get("cache_creation_input_tokens", 0) or 0)
+        # Reasoning / extended-thinking tokens (Claude 4.x, OpenAI o-series).
+        # Anthropic bills these at output rate so they need to flow through
+        # to compute_cost; before this change task_report missed them and
+        # /today undercounted Sonnet by ~3-5% vs Anthropic Console.
+        reasoning_tokens = int(stream_usage.get("reasoning_tokens", 0) or 0)
         approximate = False
         # Consume so the next call in the same monologue does not re-read
         # stale values. Stream-capture writes fresh values each call.
@@ -435,6 +443,11 @@ def llm_call(agent, call_data, response, reasoning=None) -> None:
         input_tokens = getattr(usage, "prompt_tokens", 0) or 0
         output_tokens = getattr(usage, "completion_tokens", 0) or 0
         cache_read, cache_creation = _extract_cache_tokens(usage)
+        # Same reasoning extraction as the probe's _extract_usage —
+        # OpenAI-shape `completion_tokens_details.reasoning_tokens`.
+        cdetails = getattr(usage, "completion_tokens_details", None)
+        if cdetails is not None:
+            reasoning_tokens = int(getattr(cdetails, "reasoning_tokens", 0) or 0)
         approximate = False
     else:
         input_tokens = _estimate_input_tokens(call_data)
@@ -453,6 +466,7 @@ def llm_call(agent, call_data, response, reasoning=None) -> None:
         output_tokens=output_tokens,
         cache_read_tokens=cache_read,
         cache_creation_tokens=cache_creation,
+        reasoning_tokens=reasoning_tokens,
     )
 
     r["llm_calls"].append({
@@ -462,6 +476,7 @@ def llm_call(agent, call_data, response, reasoning=None) -> None:
         "output_tokens": output_tokens,
         "cache_read_tokens": cache_read,
         "cache_creation_tokens": cache_creation,
+        "reasoning_tokens": reasoning_tokens,
         "cost_usd": cost,
         "tokens_approximate": approximate,
     })

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -316,6 +316,7 @@ usage_today: dict = {
     "output_tokens": 0,
     "cache_read_tokens": 0,
     "cache_creation_tokens": 0,
+    "reasoning_tokens": 0,
     "requests": 0,
     "cost_usd": 0.0,
     "by_model": {},  # 모델별 집계
@@ -376,6 +377,7 @@ def calc_cost(
     output_tokens: int,
     cache_read_tokens: int = 0,
     cache_creation_tokens: int = 0,
+    reasoning_tokens: int = 0,
 ) -> float:
     """Cache-aware cost calc.
 
@@ -401,10 +403,13 @@ def calc_cost(
     inp = max(0, int(input_tokens))
     cr = max(0, int(cache_read_tokens))
     cc = max(0, int(cache_creation_tokens))
+    rt = max(0, int(reasoning_tokens))
     regular = max(0, inp - cr - cc)
+    # Reasoning / extended-thinking tokens (Claude 4.x, OpenAI o-series) are
+    # billed at output rate. Mirrors agent-zero/lib/pricing.py:compute_cost.
     return (
         regular * in_rate
-        + max(0, int(output_tokens)) * out_rate
+        + (max(0, int(output_tokens)) + rt) * out_rate
         + cr * read_rate
         + cc * create_rate
     )
@@ -432,8 +437,14 @@ def track_usage(
     output_tokens: int,
     cache_read_tokens: int = 0,
     cache_creation_tokens: int = 0,
+    reasoning_tokens: int = 0,
 ):
-    """사용량 누적 (cache tokens 포함)"""
+    """사용량 누적 (cache + reasoning tokens 포함).
+
+    `reasoning_tokens` (Claude 4.x 확장 사고, OpenAI o-series) 는 별도
+    필드로 추적해서 ``/usage`` 표시 시 분리 표시 가능하게 한다. cost 계산
+    은 ``calc_cost`` 가 자동으로 output rate 로 청구.
+    """
     global usage_today
     # Collapse provider-prefixed and bare forms so /today by_model stays unified.
     model = _normalize_model(model)
@@ -451,17 +462,22 @@ def track_usage(
             "output_tokens": 0,
             "cache_read_tokens": 0,
             "cache_creation_tokens": 0,
+            "reasoning_tokens": 0,
             "requests": 0,
             "cost_usd": 0.0,
             "by_model": {},
         }
 
-    cost = calc_cost(model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+    cost = calc_cost(
+        model, input_tokens, output_tokens,
+        cache_read_tokens, cache_creation_tokens, reasoning_tokens,
+    )
 
     usage_today["input_tokens"] += input_tokens
     usage_today["output_tokens"] += output_tokens
     usage_today["cache_read_tokens"] = usage_today.get("cache_read_tokens", 0) + cache_read_tokens
     usage_today["cache_creation_tokens"] = usage_today.get("cache_creation_tokens", 0) + cache_creation_tokens
+    usage_today["reasoning_tokens"] = usage_today.get("reasoning_tokens", 0) + reasoning_tokens
     usage_today["requests"] += 1
     usage_today["cost_usd"] += cost
 
@@ -471,6 +487,7 @@ def track_usage(
             "output_tokens": 0,
             "cache_read_tokens": 0,
             "cache_creation_tokens": 0,
+            "reasoning_tokens": 0,
             "requests": 0,
             "cost_usd": 0.0,
         }
@@ -479,6 +496,7 @@ def track_usage(
     m["output_tokens"] += output_tokens
     m["cache_read_tokens"] = m.get("cache_read_tokens", 0) + cache_read_tokens
     m["cache_creation_tokens"] = m.get("cache_creation_tokens", 0) + cache_creation_tokens
+    m["reasoning_tokens"] = m.get("reasoning_tokens", 0) + reasoning_tokens
     m["requests"] += 1
     m["cost_usd"] += cost
 
@@ -2453,6 +2471,7 @@ def _aggregate(tasks: list[dict]) -> dict:
         "output_tokens": 0,
         "cache_read_tokens": 0,
         "cache_creation_tokens": 0,
+        "reasoning_tokens": 0,
         "cost_usd": 0.0,
         "by_model": {},
         "by_profile": {},
@@ -2463,7 +2482,8 @@ def _aggregate(tasks: list[dict]) -> dict:
             agg[reason] += 1
         totals = t.get("totals") or {}
         for k in ("tool_calls", "llm_calls", "input_tokens", "output_tokens",
-                  "cache_read_tokens", "cache_creation_tokens"):
+                  "cache_read_tokens", "cache_creation_tokens",
+                  "reasoning_tokens"):
             agg[k] += int(totals.get(k, 0) or 0)
         agg["cost_usd"] += float(totals.get("cost_usd", 0.0) or 0.0)
 
@@ -2761,6 +2781,11 @@ def _format_agg_block(title: str, agg: dict) -> list[str]:
             f"  캐시: read {agg['cache_read_tokens']:,} · "
             f"create {agg['cache_creation_tokens']:,}"
         )
+    rt = agg.get("reasoning_tokens", 0)
+    if rt:
+        # Reasoning / extended-thinking tokens — already folded into cost
+        # via output rate, shown separately so the breakdown is honest.
+        lines.append(f"  사고 토큰: {rt:,} (출력 요율 청구)")
     lines.append(f"  💰 ${agg['cost_usd']:.4f}")
     return lines
 
@@ -3154,6 +3179,7 @@ async def cmd_usage(update: Update, context: ContextTypes.DEFAULT_TYPE):
     today = usage_today
     cache_read = today.get("cache_read_tokens", 0)
     cache_create = today.get("cache_creation_tokens", 0)
+    reasoning = today.get("reasoning_tokens", 0)
 
     # 캐시 절약 추정치: cache_read 만큼은 90% 할인된다고 가정 (Anthropic)
     # 실절약 = cache_read × (input_rate - cache_read_rate) → 대략 input × 0.9
@@ -3167,6 +3193,11 @@ async def cmd_usage(update: Update, context: ContextTypes.DEFAULT_TYPE):
         lines.append(
             f"캐시: read {cache_read:,}  |  create {cache_create:,}"
         )
+    if reasoning:
+        # Reasoning / extended-thinking tokens (Claude 4.x, OpenAI o-series).
+        # Billed at output rate — already folded into cost_usd; shown
+        # separately so users can see how much thinking actually happened.
+        lines.append(f"사고 토큰: {reasoning:,} (출력 요율 청구)")
     lines.append(f"비용: ${today['cost_usd']:.4f}")
 
     by_model = today.get("by_model", {})
@@ -3175,11 +3206,13 @@ async def cmd_usage(update: Update, context: ContextTypes.DEFAULT_TYPE):
         for model, stats in sorted(by_model.items(), key=lambda x: x[1]["cost_usd"], reverse=True):
             cr = stats.get("cache_read_tokens", 0)
             cc = stats.get("cache_creation_tokens", 0)
+            rt = stats.get("reasoning_tokens", 0)
             cache_part = f" | cache r:{cr:,} c:{cc:,}" if (cr or cc) else ""
+            reason_part = f" | reasoning:{rt:,}" if rt else ""
             lines.append(
                 f"  {model}\n"
                 f"    {stats['requests']}건 | "
-                f"in:{stats['input_tokens']:,} out:{stats['output_tokens']:,}{cache_part}\n"
+                f"in:{stats['input_tokens']:,} out:{stats['output_tokens']:,}{cache_part}{reason_part}\n"
                 f"    ${stats['cost_usd']:.4f}"
             )
 
@@ -3375,14 +3408,16 @@ async def webhook_handler(request):
 
 
 async def usage_track_handler(request):
-    """HTTP POST로 토큰 사용량 기록 (cache 토큰 포함).
+    """HTTP POST로 토큰 사용량 기록 (cache + reasoning 토큰 포함).
 
     Payload: {
         "model": "anthropic/claude-sonnet-4-6",
         "input_tokens": 1500,
         "output_tokens": 500,
-        "cache_read_tokens": 0,     # optional (Anthropic prompt caching)
-        "cache_creation_tokens": 0  # optional
+        "cache_read_tokens": 0,        # optional (Anthropic prompt caching)
+        "cache_creation_tokens": 0,    # optional
+        "reasoning_tokens": 0          # optional (Claude 4.x extended thinking,
+                                       #          OpenAI o-series; billed at output rate)
     }
     """
     try:
@@ -3392,7 +3427,11 @@ async def usage_track_handler(request):
         output_tokens = int(data.get("output_tokens", 0))
         cache_read = int(data.get("cache_read_tokens", 0))
         cache_creation = int(data.get("cache_creation_tokens", 0))
-        track_usage(model, input_tokens, output_tokens, cache_read, cache_creation)
+        reasoning = int(data.get("reasoning_tokens", 0))
+        track_usage(
+            model, input_tokens, output_tokens,
+            cache_read, cache_creation, reasoning,
+        )
         # Budget check fires AFTER track_usage so the cumulative cost in the
         # on-disk task JSONs has caught up. Fire-and-forget — never let a
         # failed alert reject the /track request itself.


### PR DESCRIPTION
## Summary
- Surfaces `completion_tokens_details.reasoning_tokens` (Claude 4.x extended thinking, OpenAI o-series) end-to-end through probe → task_report → bridge → /usage and /today.
- Bills reasoning at the **output rate** (matches Anthropic semantics) — `pricing.compute_cost` and bridge `calc_cost` both fold reasoning into the output bucket before pricing.
- Closes the residual ~4-5% Sonnet undercount we'd been seeing vs Anthropic Console after PR #51 / #63.

## Changes
1. **`_91_chunk_usage_probe.py`** — `_extract_usage` reads both object-shape (`getattr(.completion_tokens_details, 'reasoning_tokens', 0)`) and dict-shape; `_merge_chunk_usage` takes cumulative max across chunks (Anthropic emits cumulative values, same as `completion_tokens`). All 4 `/track` POST paths (async/sync × stream/non-stream) forward the field. Print logs now include `reasoning=N`.
2. **`agent-zero/lib/task_report.py`** — `llm_call` extracts reasoning from `stream_usage` / `response.usage`, passes through to `compute_cost`, stores on the per-call dict. `_compute_totals` sums reasoning into task totals.
3. **`agent-zero/lib/pricing.py`** — `compute_cost` gains `reasoning_tokens` kwarg; reasoning added to output_tokens before multiplying by `output_cost_per_token`.
4. **`telegram-bridge/bot.py`** — `calc_cost` mirror gets the same change. `track_usage` accepts and accumulates `reasoning_tokens` into `usage_today` + `by_model`. Daily reset preserves the field. `/track` handler parses it. `/usage` and `/today` (`_aggregate` + `_format_agg_block`) display reasoning when non-zero.

## Why bill at output rate, not as a separate bucket
Anthropic's pricing schedule has 4 token rates: input, output, cache_read, cache_creation. Reasoning isn't a 5th rate — it's billed at output. Encoding it as `(output_tokens + reasoning_tokens) * output_rate` is the cleanest mapping and avoids the temptation to introduce a fictional rate.

## Verification
**Smoke harness (4 cases, all PASS):**
- `_extract_usage` returns `reasoning_tokens=4500` from `completion_tokens_details`
- Zero reasoning when details absent (no false positives)
- `pricing.compute_cost` delta = `reasoning_tokens * output_rate` exactly
- `_merge_chunk_usage` keeps `max(200, 1500) = 1500` across chunks (cumulative semantics)

**Live (bridge container, post-rebuild):**
```
POST /track {"model":"claude-sonnet-4-5","input_tokens":1000,"output_tokens":100,
             "cache_read_tokens":0,"cache_creation_tokens":0,"reasoning_tokens":500}
→ usage_today.cost_usd = $0.012 = 1000*$3/M + (100+500)*$15/M  ✓
→ usage_today.reasoning_tokens = 500  ✓
→ by_model.reasoning_tokens = 500  ✓
```

## Test plan
- [x] Smoke test (`smoke_reasoning.py`, 4 cases, removed after run)
- [x] Live `/track` POST + `/usage` GET round-trip with reasoning_tokens=500
- [x] Verify mounted files in `agent-zero` container have `reasoning_tokens` references (probe=22, task_report=8, pricing=3)
- [x] Verify rebuilt `telegram-bridge` image carries the new `bot.py`
- [ ] After merge: monitor `/today` vs Anthropic Console — Sonnet gap should drop from ~4-5% → ~3% (residual will be Console-side aggregation lag + LiteLLM price-table snapshot lag, both unavoidable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)