### PR TITLE
feat(prompts): strengthen relevant-skills recall + raise desc truncate

### DIFF
--- a/agent-zero/extensions/python/message_loop_prompts_after/_63_recall_relevant_skills.py
+++ b/agent-zero/extensions/python/message_loop_prompts_after/_63_recall_relevant_skills.py
@@ -1,0 +1,54 @@
+"""Recall skills whose trigger patterns match the user's current message.
+
+Vendored from upstream agent-zero v1.13 with one local change: the
+description truncate ceiling is raised from 220 → 400 chars.
+
+Why: Korean-domain skill descriptions ship lower information density
+per char than English (no whitespace tokens, multibyte glyphs), so 220
+clips guard phrases like "이 스킬을 browser/search_engine 보다 우선
+사용하라" before they reach the prompt. 400 keeps the guard intact
+without bloating the system prompt — typical descriptions still come
+in well under that.
+
+Mounted into the container at the same upstream path so it overrides
+the default extension. See docker-compose.yml for the bind mount.
+"""
+from agent import LoopData
+from helpers.extension import Extension
+from helpers import skills as skills_helper
+
+
+class RecallRelevantSkills(Extension):
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        if not self.agent or loop_data.iteration != 0:
+            return
+
+        user_instruction = (
+            loop_data.user_message.output_text() if loop_data.user_message else ""
+        ).strip()
+        if len(user_instruction) < 8:
+            return
+
+        matches = skills_helper.search_skills(
+            user_instruction,
+            limit=6,
+            agent=self.agent,
+        )
+        if not matches:
+            return
+
+        lines: list[str] = []
+        for skill in matches:
+            name = skill.name.strip().replace("\n", " ")[:100]
+            desc = (skill.description or "").replace("\n", " ").strip()
+            if len(desc) > 400:
+                desc = desc[:400].rstrip() + "…"
+            lines.append(f"- {name}: {desc}")
+
+        if not lines:
+            return
+
+        loop_data.extras_temporary["relevant_skills"] = self.agent.read_prompt(
+            "agent.system.skills.relevant.md",
+            skills="\n".join(lines),
+        )

--- a/agent-zero/prompts/agent.system.skills.relevant.md
+++ b/agent-zero/prompts/agent.system.skills.relevant.md
@@ -1,5 +1,24 @@
-# relevant skills
-- the following skills matched the user's current request by lexical search, including trigger phrases
-- use `skills_tool:load` to load one before following it
+# Relevant Skills (auto-matched)
+
+**The following skills matched the user's current request via trigger patterns. You MUST load one of these via `skills_tool:load` before falling back to general tools (`browser_agent`, `search_engine`, `code_execution_tool`).**
+
+## Rules
+
+1. **MUST**: If a skill is matched below, call `skills_tool:load` and follow its guidance.
+2. **MUST NOT**: Do not call `browser_agent` or `search_engine` standalone for Korean-domain queries (laws, public-company filings, HWP files, privacy policies, Korean company info, etc.) when a matching skill is listed below.
+3. **Priority**: When multiple skills match, evaluate in listed order (highest score first). Skip to the next only if the first is clearly inapplicable.
+4. **Exception**: General tools may be used only when (a) the matched skill is clearly a false-positive against the user's intent, or (b) the user explicitly requested a general tool.
+
+## Matched Skills
 
 {{skills}}
+
+## Wrong vs Right
+
+❌ **Wrong**:
+> User: "Show me Samsung Electronics' 10 most recent disclosures."
+> Agent: invokes `search_engine` → imprecise results
+
+✅ **Right**:
+> User: "Show me Samsung Electronics' 10 most recent disclosures."
+> Agent: `skills_tool:load(skill_name="k-dart")` → precise data via DART API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,9 @@ services:
       # no extension listening — ~71 Haiku calls/day were missing from task JSON.
       - ./agent-zero/extensions/python/util_model_call_after/_50_task_report_util_llm.py:/a0/extensions/python/util_model_call_after/_50_task_report_util_llm.py:ro
       - ./agent-zero/extensions/python/monologue_end/_50_task_report_finish.py:/a0/extensions/python/monologue_end/_50_task_report_finish.py:ro
+      # Override upstream skill-recall extension: raise description truncate
+      # 220 → 400 so Korean-domain guard phrases survive into the prompt.
+      - ./agent-zero/extensions/python/message_loop_prompts_after/_63_recall_relevant_skills.py:/a0/extensions/python/message_loop_prompts_after/_63_recall_relevant_skills.py:ro
       - ./agent-zero/settings.json:/a0/usr/settings.json
       # Persist plugin overrides — chiefly /a0/usr/plugins/_model_config/config.json
       # which holds the active chat/utility model selection. Without this mount


### PR DESCRIPTION
## Summary
- Rewrite [agent.system.skills.relevant.md](agent-zero/prompts/agent.system.skills.relevant.md) so auto-matched skills are treated as MUST-load, not as optional advice.
- Vendor [_63_recall_relevant_skills.py](agent-zero/extensions/python/message_loop_prompts_after/_63_recall_relevant_skills.py) and raise the description truncate from 220 → 400 chars so Korean-domain guard phrases survive into the prompt.
- Mount the vendored extension via [docker-compose.yml](docker-compose.yml) so the override survives image upgrades.

## Why
Vendored Korean-domain skills from [az-agent-config#35](https://github.com/devyoon91/az-agent-config/pull/35) (`k-dart`, `korean-law-search`, `hwp`, `rhwp-edit`, `rhwp-advanced`, `korean-privacy-terms`) all had correct `trigger_patterns` + `tags`, and `search_skills()` was matching them against requests like "삼성전자 최근 공시 10건". But the agent was ignoring the recall block and falling through to `search_engine` / `browser_agent` because:

1. The recall prompt said "use `skills_tool:load` to load one before following it" — soft enough to read as optional.
2. There was no anti-pattern guard against standalone `browser_agent` / `search_engine` for Korean-domain queries.
3. No priority signal for the multi-match case.
4. No Wrong/Right example to anchor the pattern.
5. The 220-char description truncate was clipping guard phrases at the end of denser Korean descriptions.

Result: trigger reliability hovered around 50% against the vendored skills.

## Changes

**`agent.system.skills.relevant.md`** — replaced contents with:
- MUST/MUST-NOT framing
- Explicit anti-pattern: do not call `browser_agent` / `search_engine` standalone for Korean-domain intents (laws, public-company filings, HWP, privacy policies, Korean company info) when a skill is listed
- Priority rule (listed order = highest score)
- Narrow exception (clear false-positive against intent, or user explicitly asked for a general tool)
- Wrong/Right example: "삼성전자 최근 공시 10건" → `skills_tool:load(skill_name="k-dart")`

**`_63_recall_relevant_skills.py`** (vendored at upstream path) — raise truncate `220 → 400`. Identical to upstream otherwise. Mounted in docker-compose to override the in-image copy.

**`docker-compose.yml`** — single new bind-mount line for the vendored extension, sitting alongside the other `task_report` extensions.

## Verification
- [x] After `docker compose up -d --force-recreate agent-zero`, in-container `/a0/prompts/agent.system.skills.relevant.md` shows the new MUST framing
- [x] In-container `/a0/extensions/.../_63_recall_relevant_skills.py` shows `len(desc) > 400`
- [ ] UI smoke (manual, post-merge):
  - "삼성전자 최근 공시 10건 보여줘" → `k-dart` loads (not search_engine)
  - "개인정보보호법 제15조 보여줘" → `korean-law-search` loads
  - "이 hwp 파일 마크다운으로 변환" → `hwp` loads
  - "개인정보처리방침 만들어줘" → `korean-privacy-terms` loads
  - Target: ~50% → 95%+ trigger reliability

## Notes
Prompt kept in English to match the rest of `agent.system.*`. Korean only appears in one example string and the vendored-file commentary explaining the truncate rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)