### PR TITLE
fix(skills): Korean-aware reverse-direction trigger match

### DIFF
--- a/agent-zero/extensions/python/message_loop_prompts_after/_63_recall_relevant_skills.py
+++ b/agent-zero/extensions/python/message_loop_prompts_after/_63_recall_relevant_skills.py
@@ -1,14 +1,27 @@
 """Recall skills whose trigger patterns match the user's current message.
 
-Vendored from upstream agent-zero v1.13 with one local change: the
-description truncate ceiling is raised from 220 → 400 chars.
+Vendored from upstream agent-zero v1.13 with two local changes:
 
-Why: Korean-domain skill descriptions ship lower information density
-per char than English (no whitespace tokens, multibyte glyphs), so 220
-clips guard phrases like "이 스킬을 browser/search_engine 보다 우선
-사용하라" before they reach the prompt. 400 keeps the guard intact
-without bloating the system prompt — typical descriptions still come
-in well under that.
+1. Description truncate ceiling raised 220 → 400. Korean descriptions
+   carry less information per char (no whitespace tokens, multibyte
+   glyphs), so 220 was clipping guard phrases like "이 스킬을 browser/
+   search_engine 보다 우선 사용하라" before they reached the prompt.
+
+2. Korean-aware match augmenter. Upstream `search_skills()` whitespace-
+   splits the query and drops tokens shorter than 3 chars (unless they
+   contain a digit). For Korean queries that's catastrophic — "공시"
+   (2 chars) is exactly the kind of keyword that should fire k-dart,
+   but it never makes it past the filter. Worse, the upstream scorer
+   only checks `term in trigger` (does my query word appear inside any
+   trigger phrase?) and not the natural reverse `trigger in query`
+   (does any trigger phrase appear inside the user's query?). So even
+   if "공시" survived filtering, the only matches would come from
+   substring-in-trigger semantics, missing the obvious case where the
+   user wrote the trigger phrase verbatim.
+
+   Fix: after the upstream call, run our own `trigger in query` pass
+   over `list_skills()` and merge any extra matches in. Upstream hits
+   keep their position; ko-augmented hits fill the rest of the top-6.
 
 Mounted into the container at the same upstream path so it overrides
 the default extension. See docker-compose.yml for the bind mount.
@@ -16,6 +29,52 @@ the default extension. See docker-compose.yml for the bind mount.
 from agent import LoopData
 from helpers.extension import Extension
 from helpers import skills as skills_helper
+
+
+def _augment_matches_korean(query: str, agent, base_matches):
+    """Score skills by `trigger in query` (reverse of upstream's
+    `term in trigger`) so Korean phrases like "최근 공시 보여줘" match
+    a "공시" trigger. Returns a merged list — base_matches first
+    (preserve upstream ranking), then ko-scored additions deduped.
+    """
+    q = (query or "").lower().strip()
+    if not q:
+        return base_matches
+
+    try:
+        candidates = skills_helper.list_skills(agent)
+    except Exception:
+        return base_matches
+
+    seen = {m.name for m in base_matches}
+    scored: list[tuple[int, object]] = []
+    for s in candidates:
+        if s.name in seen:
+            continue
+        score = 0
+        for trigger in s.triggers or []:
+            t = (trigger or "").strip().lower()
+            # Floor at len 2 — "공시", "배당" etc. are valid signals in CJK.
+            # Skip ultra-short triggers (1 char) to avoid runaway false positives.
+            if len(t) >= 2 and t in q:
+                # Specificity weight: longer phrases ("지분 공시") beat shorter
+                # generic ones ("공시") so a more precise match ranks higher.
+                score += max(len(t), 4)
+        for tag in s.tags or []:
+            t = (tag or "").lower()
+            if len(t) >= 3 and t in q:
+                score += 2
+        name = (s.name or "").lower()
+        if len(name) >= 3 and name in q:
+            score += 6
+        if score > 0:
+            scored.append((score, s))
+
+    scored.sort(key=lambda pair: -pair[0])
+    extras = [s for _, s in scored]
+
+    merged = list(base_matches) + extras
+    return merged[:6]
 
 
 class RecallRelevantSkills(Extension):
@@ -29,11 +88,25 @@ class RecallRelevantSkills(Extension):
         if len(user_instruction) < 8:
             return
 
-        matches = skills_helper.search_skills(
+        upstream = skills_helper.search_skills(
             user_instruction,
             limit=6,
             agent=self.agent,
         )
+        matches = _augment_matches_korean(user_instruction, self.agent, upstream)
+
+        # One-line trace for /a0 logs so we can audit recall hits without
+        # tailing turn-by-turn. Cheap and useful — keep it on.
+        try:
+            print(
+                f"[RecallSkills] q={user_instruction[:80]!r} "
+                f"upstream={[m.name for m in upstream]} "
+                f"final={[m.name for m in matches]}",
+                flush=True,
+            )
+        except Exception:
+            pass
+
         if not matches:
             return
 


### PR DESCRIPTION
## Summary
Auto-recall was failing silently on Korean queries because upstream `search_skills()` returns 0 matches when all the high-signal keywords are 2-char Korean tokens. This PR adds a narrow Korean-aware augmenter inside the already-vendored [`_63_recall_relevant_skills.py`](agent-zero/extensions/python/message_loop_prompts_after/_63_recall_relevant_skills.py).

## Diagnosis
Direct in-container probe with the canonical test prompt:

```
$ python -c 'from helpers import skills; print(skills.search_skills("삼성전자 최근 공시 10건 보여줘", limit=6, agent=None))'
[]
```

Tracing upstream's [`search_skills`](https://github.com/agent0ai/agent-zero/blob/v1.13/python/helpers/skills.py) revealed two compounding issues for Korean:

1. **Term-length filter drops CJK keywords.** The query is whitespace-split, then filtered with `len(t) >= 3 or has_digit(t)`. For `"삼성전자 최근 공시 10건 보여줘"` this yields `["삼성전자", "10건", "보여줘"]` — `"공시"` (2 chars, no digits) is gone before scoring even starts. CJK glyphs carry more semantic weight per char than ASCII, but the filter doesn't know that.
2. **Asymmetric matching direction.** The scorer only runs `term in trigger` ("is my word inside a trigger phrase?"). The natural reverse — `trigger in query` ("did the user write any of my trigger phrases verbatim?") — isn't checked at all. So even if `"공시"` survived filtering, it wouldn't match a `"공시"` trigger via the reverse direction (it would still match by ASCII substring rules but only if the term were already in `terms`).

Net result: matches=0, recall block stays empty, the strengthened MUST prompt from [#65](https://github.com/devyoon91/az-cliproxy-docker/pull/65) is never injected, agent falls through to `code_execution_tool` and writes its own DART API call from training-data memory. Confirmed in [task-20260507-052608-3a76fc.json](agent-zero/logs/tasks/task-20260507-052608-3a76fc.json) — `"skills_loaded": []`, three `code_execution_tool` invocations, no `skills_tool:load`.

## Fix (Path B — narrow)
Inside `_63`'s `execute()`, after the upstream call:

1. Iterate `list_skills(agent)` and score each candidate by `trigger in query`, with specificity weighting (longer trigger phrases beat shorter generic ones — `"지분 공시"` outranks `"공시"`).
2. Floor at `len(trigger) >= 2` so CJK 2-char keywords pass; 1-char triggers still skipped to avoid runaway matches.
3. Also score tag-in-query (+2) and name-in-query (+6).
4. Merge with upstream: upstream hits keep their position (don't disturb existing ranking), ko-augmented hits fill the rest of top-6.

Path A (vendoring all of `helpers/skills.py`) was rejected as the surface area and v1.14+ upgrade cost weren't worth it. Auto-recall is the only path that depends on the strengthened MUST prompt; `skills_tool:list/search` is invoked manually by the agent and isn't on the failure-mode hot path.

## Verification
In-container probe across all 4 [PR #65](https://github.com/devyoon91/az-cliproxy-docker/pull/65) verification prompts:

| Query | Upstream | Final |
|---|---|---|
| 삼성전자 최근 공시 10건 보여줘 | `[]` | `[k-dart]` |
| 개인정보보호법 제15조 보여줘 | `[korean-privacy-terms, korean-law-search]` | same |
| 이 hwp 파일 마크다운으로 변환 | `[hwp, rhwp-advanced, rhwp-edit]` | same |
| 개인정보처리방침 만들어줘 | `[korean-privacy-terms]` | same |

Only the k-dart case needed rescue; the other 3 already worked upstream because their queries contained ≥3-char ASCII tokens (`hwp`) or ≥3-char Korean tokens (`개인정보처리방침`).

Also: replaced the temporary `[RecallSkillsDebug]` print with a permanent one-line `[RecallSkills] q=… upstream=[…] final=[…]` trace — useful for ongoing audit without re-instrumenting.

## Test plan
- [x] In-container probe passes for all 4 prompts (above)
- [x] Container recreated post-edit; mounted file shows new behavior
- [ ] Post-merge UI run: `삼성전자 최근 공시 10건 보여줘` should now produce `skills_loaded: [k-dart]` in the task JSON instead of three `code_execution_tool` calls

## Notes
- No upstream files modified — only the local vendored extension.
- No prompt changes; PR #65's MUST prompt remains as-is.
- Per-language note: print trace + commit message in English; commentary inside the extension uses Korean only where it quotes Korean trigger examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)