### PR TITLE
feat(chat_pdf_export): per-message PDF button (next to copy/branch)

### DIFF
--- a/agent-zero/usr-plugins/chat_pdf_export/README.md
+++ b/agent-zero/usr-plugins/chat_pdf_export/README.md
@@ -18,8 +18,10 @@ chat_pdf_export/
 │       └── chat.html.j2                           # CSS + per-role styling, A4 page
 └── extensions/
     └── webui/
-        └── sidebar-quick-actions-dropdown-start/
-            └── export-pdf-entry.html              # Alpine button → fetchApi → blob download
+        ├── chat-input-bottom-actions-start/
+        │   └── export-pdf-button.html             # full-chat button (always visible)
+        └── set_messages_after_loop/
+            └── inject-pdf-buttons.js              # per-message action button injector
 ```
 
 ## Pipeline
@@ -52,23 +54,42 @@ POST /api/plugins/chat_pdf_export/export_pdf
 Content-Type: application/json
 X-CSRF-Token: <token>
 
-{ "context": "<active-chat-context-id>" }
+{
+  "context": "<active-chat-context-id>",
+  "log_no":  42                            // optional — single-message export
+}
 ```
 
-Returns: `200 application/pdf` with `Content-Disposition: attachment` and a
-download filename derived from the chat name. Errors:
+When `log_no` is omitted, the entire visible chat is rendered. When set, only
+the LogItem with that `.no` is rendered, and the title becomes
+`<chat name> — message #<log_no>`. Returns `200 application/pdf` with
+`Content-Disposition: attachment` and a download filename derived from the
+title. Errors:
 
 | Status | Meaning |
 |--------|---------|
-| 400    | Missing context id, or chat has no exportable messages |
-| 404    | Context not found |
+| 400    | Missing context id, `log_no` not an integer, or chat has no exportable messages |
+| 404    | Context not found, or `log_no` out of range / message has no exportable content |
 | 500    | WeasyPrint missing (rebuild image), or render error |
 
 ## UI
 
-Slot: `sidebar-quick-actions-dropdown-start` (same family as `_time_travel`,
-`_memory`). Click → `fetchApi` (auto-attaches CSRF) → blob → `<a download>`.
+**Full chat** — `chat-input-bottom-actions-start` slot. Always-visible row
+under the chat input (same row as Browser, Compact, Pause Agent, Nudge,
+Terminal, Stop). Mirrors `_browser/.../browser-button.html`.
+
+**Per-message** — `set_messages_after_loop` extension injects a
+`picture_as_pdf` action button into every message's `.step-action-buttons`
+bar. Same hook + helper (`createActionButton`) as
+`_chat_branching/inject-branch-buttons.js` — appears next to copy / branch
+on each message.
+
+Both flows use `fetchApi` (auto-attaches CSRF) → blob → `<a download>`.
 Korean filenames use RFC 5987 `filename*=UTF-8''...` and decode client-side.
+
+(An earlier revision used `sidebar-quick-actions-dropdown-start` for the
+full-chat button, which hid it inside a collapsed dropdown — moved out for
+discoverability.)
 
 ## What's filtered out
 

--- a/agent-zero/usr-plugins/chat_pdf_export/api/export_pdf.py
+++ b/agent-zero/usr-plugins/chat_pdf_export/api/export_pdf.py
@@ -96,7 +96,17 @@ def _ts_from_log_item(item: dict[str, Any]) -> str | None:
         return None
 
 
-def _build_chat_dict(context: AgentContext) -> dict[str, Any]:
+def _build_chat_dict(
+    context: AgentContext,
+    log_no: int | None = None,
+) -> dict[str, Any]:
+    """Build a normalized chat dict.
+
+    When `log_no` is None, every visible LogItem is included. When set,
+    only the LogItem with that `.no` is included — used for the
+    per-message export button. Title is augmented to make the source
+    obvious in the resulting PDF and download filename.
+    """
     name = (getattr(context, "name", None) or "Chat").strip() or "Chat"
     created_at_dt = getattr(context, "created_at", None)
     created_at = created_at_dt.isoformat(timespec="seconds") if created_at_dt else None
@@ -104,6 +114,8 @@ def _build_chat_dict(context: AgentContext) -> dict[str, Any]:
     # context.log.logs is the canonical list of LogItem objects. (Log.output()
     # returns a LogOutput wrapper for the UI, not a plain list — easy footgun.)
     log_items = list(getattr(context.log, "logs", []) or [])
+    if log_no is not None:
+        log_items = [it for it in log_items if getattr(it, "no", None) == log_no]
 
     messages: list[dict[str, Any]] = []
     for item in log_items:
@@ -112,8 +124,10 @@ def _build_chat_dict(context: AgentContext) -> dict[str, Any]:
         if m is not None:
             messages.append(m)
 
+    title = name if log_no is None else f"{name} — message #{log_no}"
+
     return {
-        "title": name,
+        "title": title,
         "created_at": created_at,
         "messages": messages,
     }
@@ -139,12 +153,27 @@ class ExportPdf(ApiHandler):
         if not ctxid:
             return Response("Missing context id", 400)
 
+        # Optional: when the per-message button is clicked, the frontend sends
+        # the LogItem.no for that message. We render only that one log entry.
+        raw_log_no = (input or {}).get("log_no")
+        log_no: int | None = None
+        if raw_log_no is not None and raw_log_no != "":
+            try:
+                log_no = int(raw_log_no)
+            except (TypeError, ValueError):
+                return Response("log_no must be an integer", 400)
+
         context = AgentContext.get(ctxid)
         if not context:
             return Response("Context not found", 404)
 
-        chat = _build_chat_dict(context)
+        chat = _build_chat_dict(context, log_no=log_no)
         if not chat["messages"]:
+            if log_no is not None:
+                return Response(
+                    f"Message #{log_no} not found or has no exportable content",
+                    404,
+                )
             return Response("Chat has no exportable messages", 400)
 
         try:

--- a/agent-zero/usr-plugins/chat_pdf_export/extensions/webui/set_messages_after_loop/inject-pdf-buttons.js
+++ b/agent-zero/usr-plugins/chat_pdf_export/extensions/webui/set_messages_after_loop/inject-pdf-buttons.js
@@ -1,0 +1,69 @@
+// chat_pdf_export — inject a per-message "Export PDF" action button into
+// every message's action bar (.step-action-buttons). Same hook + helper
+// pattern used by _chat_branching/inject-branch-buttons.js.
+//
+// Click → POST /plugins/chat_pdf_export/export_pdf with the active
+// context id and the message's LogItem.no → blob download.
+
+import { createActionButton } from "/components/messages/action-buttons/simple-action-buttons.js";
+
+export default async function injectPdfButtons(context) {
+  if (!context?.results?.length) return;
+
+  for (const { args, result } of context.results) {
+    if (!result?.element || args?.no == null) continue;
+
+    const logNo = args.no;
+    for (const bar of result.element.querySelectorAll(".step-action-buttons")) {
+      // Idempotent: skip if we've already injected on this bar.
+      if (bar.querySelector(".action-picture_as_pdf")) continue;
+
+      bar.appendChild(
+        createActionButton("picture_as_pdf", "이 메시지를 PDF 로 추출", async () => {
+          const ctxid = globalThis.getContext?.();
+          if (!ctxid) {
+            alert("활성 채팅이 없습니다.");
+            return;
+          }
+
+          try {
+            const { fetchApi } = await import("/js/api.js");
+            const res = await fetchApi("/plugins/chat_pdf_export/export_pdf", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              credentials: "same-origin",
+              body: JSON.stringify({ context: ctxid, log_no: logNo }),
+            });
+            if (!res.ok) {
+              const msg = await res.text();
+              throw new Error(msg || "HTTP " + res.status);
+            }
+            const blob = await res.blob();
+
+            // Filename: prefer RFC 5987 filename*=UTF-8'' over ASCII fallback.
+            const disp = res.headers.get("Content-Disposition") || "";
+            let filename = "chat-message.pdf";
+            const star = disp.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
+            if (star) {
+              try { filename = decodeURIComponent(star[1]); } catch (_) {}
+            } else {
+              const plain = disp.match(/filename\s*=\s*"?([^";]+)"?/i);
+              if (plain) filename = plain[1];
+            }
+
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            setTimeout(() => URL.revokeObjectURL(url), 0);
+          } catch (e) {
+            alert("PDF 추출 실패: " + (e && e.message ? e.message : e));
+          }
+        }),
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Sibling to [#72](https://github.com/devyoon91/az-cliproxy-docker/pull/72) (full-chat button slot fix). Adds the granular flow the user asked for: every message gets its own \`picture_as_pdf\` button on the message's \`.step-action-buttons\` bar — the same row Claude-style "copy" buttons live in, and the same slot \`_chat_branching\` uses for its fork_right button.

> "근데 내가 원하는건 전체 출력도 맞고 너랑 대화할 때 처럼 질문 주면 답변을 주잖아? 그 답변 자체를 복사하는 기능이 있는데 거기에 그 답변만 pdf로 추출 하는 기능도 있으면 좋겠는데?"

So now the plugin has two flows:
- **Full chat** — bottom-actions row (already in #72)
- **Per-message** — action button on each message bar (this PR)

## API
\`export_pdf.py\` now accepts an optional \`log_no\`:

\`\`\`json
POST /api/plugins/chat_pdf_export/export_pdf
{ "context": "<ctxid>", "log_no": 42 }
\`\`\`

When set, \`_build_chat_dict()\` filters \`context.log.logs\` to the single \`LogItem\` with that \`.no\`. Title becomes \`<chat name> — message #<log_no>\`, so the PDF + download filename make the source obvious.

| Scenario | Status |
|---|---|
| valid \`log_no\` | 200 application/pdf |
| \`log_no\` out of range | 404 |
| \`log_no\` not an integer | 400 |
| \`log_no\` omitted | full-chat (unchanged) |

## UI
New extension [\`extensions/webui/set_messages_after_loop/inject-pdf-buttons.js\`](agent-zero/usr-plugins/chat_pdf_export/extensions/webui/set_messages_after_loop/inject-pdf-buttons.js). Mirrors [\`_chat_branching/inject-branch-buttons.js\`](https://github.com/agent0ai/agent-zero/blob/v1.13/plugins/_chat_branching/extensions/webui/set_messages_after_loop/inject-branch-buttons.js) exactly:

- Uses the same \`createActionButton(icon, tooltip, onClick)\` helper
- Idempotent guard via \`.action-picture_as_pdf\` selector
- \`fetchApi\` for CSRF
- Blob download with RFC 5987 filename decoding

## Verification (in-container)
- Adapter filtering: \`_build_chat_dict(ctx, log_no=None)\` → 3 msgs · \`log_no=2\` → 1 msg titled \`"... — message #2"\` · \`log_no=999\` → 0 msgs
- API end-to-end: \`log_no=2\` → 200 \`application/pdf\` 300 KB · \`log_no=999\` → 404 · \`log_no="abc"\` → 400
- Discovery: \`get_webui_extensions(None, "set_messages_after_loop")\` lists our \`inject-pdf-buttons.js\` alongside \`_browser\`, \`_chat_branching\`, \`_office\`

## Test plan
- [x] Backend smoke (filter + API status codes)
- [x] Backend discovery
- [ ] **Post-merge UI**: hard-refresh; PDF button appears on each message's action bar next to copy / branch / etc; click any message → that message-only PDF downloads with title \`"<chat name> — message #N"\`

## Note on stacking
Independent of [#72](https://github.com/devyoon91/az-cliproxy-docker/pull/72) — this PR only touches \`api/export_pdf.py\`, the new injector JS, and the README. No conflict expected when both land. Order of merge doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)