### PR TITLE
fix(chat_pdf_export): refactor to Alpine store — button no longer renders raw JS

### DIFF
--- a/agent-zero/usr-plugins/chat_pdf_export/extensions/webui/chat-input-bottom-actions-start/export-pdf-button.html
+++ b/agent-zero/usr-plugins/chat_pdf_export/extensions/webui/chat-input-bottom-actions-start/export-pdf-button.html
@@ -1,69 +1,31 @@
 <!-- Chat PDF Export — bottom-actions button.
-     Mirrors the structure of _browser/chat-input-bottom-actions-start so the
-     button sits in the same always-visible row as Browser / Compact / Pause /
-     Nudge / Terminal / Stop. -->
-<button
-  type="button"
-  class="text-button chat-pdf-export-action"
-  title="채팅을 PDF 로 추출"
-  aria-label="Export chat as PDF"
-  data-bs-placement="top"
-  data-bs-trigger="hover"
-  x-data="{
-    busy: false,
-    async exportPdf() {
-      if (this.busy) return;
-      const ctxid = globalThis.getContext?.();
-      if (!ctxid) { alert('활성 채팅이 없습니다.'); return; }
-      this.busy = true;
-      try {
-        const { fetchApi } = await import('/js/api.js');
-        const res = await fetchApi('/plugins/chat_pdf_export/export_pdf', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'same-origin',
-          body: JSON.stringify({ context: ctxid }),
-        });
-        if (!res.ok) {
-          const msg = await res.text();
-          throw new Error(msg || ('HTTP ' + res.status));
-        }
-        const blob = await res.blob();
-
-        // Filename: prefer RFC 5987 filename*=UTF-8'' over the ASCII fallback.
-        const disp = res.headers.get('Content-Disposition') || '';
-        let filename = 'chat-export.pdf';
-        const star = disp.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
-        if (star) {
-          try { filename = decodeURIComponent(star[1]); } catch (_) {}
-        } else {
-          const plain = disp.match(/filename\s*=\s*\"?([^\";]+)\"?/i);
-          if (plain) filename = plain[1];
-        }
-
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = filename;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        setTimeout(() => URL.revokeObjectURL(url), 0);
-      } catch (e) {
-        alert('PDF 추출 실패: ' + (e && e.message ? e.message : e));
-      } finally {
-        this.busy = false;
-      }
-    },
-  }"
-  :disabled="busy"
-  @click="exportPdf()"
->
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true">
-    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-    <polyline points="14 2 14 8 20 8"></polyline>
-    <line x1="9" y1="13" x2="15" y2="13"></line>
-    <line x1="9" y1="17" x2="13" y2="17"></line>
-  </svg>
-  <p x-text="busy ? 'PDF…' : 'PDF'"></p>
-</button>
+     Imports the plugin's Alpine store (same pattern as _chat_compaction)
+     so the button HTML stays attribute-safe — no multi-line x-data, no
+     arrow-function `>` chars that close the start tag prematurely. -->
+<html>
+<head>
+  <script type="module" src="/plugins/chat_pdf_export/webui/chat-pdf-export-store.js"></script>
+</head>
+<body>
+  <template x-if="$store.chatPdfExport">
+    <button
+      type="button"
+      class="text-button chat-pdf-export-action"
+      title="채팅을 PDF 로 추출"
+      aria-label="Export chat as PDF"
+      data-bs-placement="top"
+      data-bs-trigger="hover"
+      :disabled="$store.chatPdfExport.busy"
+      @click="$store.chatPdfExport.export()"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+        <polyline points="14 2 14 8 20 8"></polyline>
+        <line x1="9" y1="13" x2="15" y2="13"></line>
+        <line x1="9" y1="17" x2="13" y2="17"></line>
+      </svg>
+      <p x-text="$store.chatPdfExport.busy ? 'PDF…' : 'PDF'"></p>
+    </button>
+  </template>
+</body>
+</html>

--- a/agent-zero/usr-plugins/chat_pdf_export/extensions/webui/set_messages_after_loop/inject-pdf-buttons.js
+++ b/agent-zero/usr-plugins/chat_pdf_export/extensions/webui/set_messages_after_loop/inject-pdf-buttons.js
@@ -2,10 +2,14 @@
 // every message's action bar (.step-action-buttons). Same hook + helper
 // pattern used by _chat_branching/inject-branch-buttons.js.
 //
-// Click → POST /plugins/chat_pdf_export/export_pdf with the active
-// context id and the message's LogItem.no → blob download.
+// All export logic lives in the plugin's Alpine store
+// (/plugins/chat_pdf_export/webui/chat-pdf-export-store.js). Importing
+// it here registers the store if it hasn't been already (e.g. when the
+// chat-input bottom button HTML hasn't loaded its <script> yet) and
+// gives us a direct reference to call from the click handler.
 
 import { createActionButton } from "/components/messages/action-buttons/simple-action-buttons.js";
+import { store as pdfStore } from "/plugins/chat_pdf_export/webui/chat-pdf-export-store.js";
 
 export default async function injectPdfButtons(context) {
   if (!context?.results?.length) return;
@@ -19,49 +23,8 @@ export default async function injectPdfButtons(context) {
       if (bar.querySelector(".action-picture_as_pdf")) continue;
 
       bar.appendChild(
-        createActionButton("picture_as_pdf", "이 메시지를 PDF 로 추출", async () => {
-          const ctxid = globalThis.getContext?.();
-          if (!ctxid) {
-            alert("활성 채팅이 없습니다.");
-            return;
-          }
-
-          try {
-            const { fetchApi } = await import("/js/api.js");
-            const res = await fetchApi("/plugins/chat_pdf_export/export_pdf", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              credentials: "same-origin",
-              body: JSON.stringify({ context: ctxid, log_no: logNo }),
-            });
-            if (!res.ok) {
-              const msg = await res.text();
-              throw new Error(msg || "HTTP " + res.status);
-            }
-            const blob = await res.blob();
-
-            // Filename: prefer RFC 5987 filename*=UTF-8'' over ASCII fallback.
-            const disp = res.headers.get("Content-Disposition") || "";
-            let filename = "chat-message.pdf";
-            const star = disp.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
-            if (star) {
-              try { filename = decodeURIComponent(star[1]); } catch (_) {}
-            } else {
-              const plain = disp.match(/filename\s*=\s*"?([^";]+)"?/i);
-              if (plain) filename = plain[1];
-            }
-
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = url;
-            a.download = filename;
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-            setTimeout(() => URL.revokeObjectURL(url), 0);
-          } catch (e) {
-            alert("PDF 추출 실패: " + (e && e.message ? e.message : e));
-          }
+        createActionButton("picture_as_pdf", "이 메시지를 PDF 로 추출", function () {
+          return pdfStore.export(logNo);
         }),
       );
     }

--- a/agent-zero/usr-plugins/chat_pdf_export/webui/chat-pdf-export-store.js
+++ b/agent-zero/usr-plugins/chat_pdf_export/webui/chat-pdf-export-store.js
@@ -1,0 +1,91 @@
+// Alpine store for the chat-pdf-export plugin.
+// Holds `busy` + the `export(logNo?)` method so the inline button HTML
+// stays trivial (no multi-line attribute, no arrow functions to clash
+// with HTML parsing).
+//
+// Mirrors the pattern of _chat_compaction/webui/compact-store.js — the
+// extension HTML imports this module via <script type="module" src=...>
+// and dispatches with $store.chatPdfExport.export().
+
+import { fetchApi } from "/js/api.js";
+
+function _filenameFromContentDisposition(disp) {
+  if (!disp) return "chat-export.pdf";
+  const star = disp.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
+  if (star) {
+    try { return decodeURIComponent(star[1]); } catch (_) {}
+  }
+  const plain = disp.match(/filename\s*=\s*"?([^";]+)"?/i);
+  if (plain) return plain[1];
+  return "chat-export.pdf";
+}
+
+export const store = {
+  busy: false,
+
+  /**
+   * POST to /plugins/chat_pdf_export/export_pdf and trigger a browser
+   * download of the returned PDF blob.
+   *
+   * @param {number|null} logNo  Optional LogItem.no for per-message export.
+   *                             Omit / null for full-chat export.
+   */
+  async export(logNo) {
+    if (this.busy) return;
+    const ctxid = globalThis.getContext && globalThis.getContext();
+    if (!ctxid) {
+      alert("활성 채팅이 없습니다.");
+      return;
+    }
+    this.busy = true;
+    try {
+      const body = { context: ctxid };
+      if (logNo !== undefined && logNo !== null) body.log_no = logNo;
+
+      const res = await fetchApi("/plugins/chat_pdf_export/export_pdf", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const msg = await res.text();
+        throw new Error(msg || ("HTTP " + res.status));
+      }
+      const blob = await res.blob();
+      const filename = _filenameFromContentDisposition(
+        res.headers.get("Content-Disposition")
+      );
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(function () { URL.revokeObjectURL(url); }, 0);
+    } catch (e) {
+      alert("PDF 추출 실패: " + (e && e.message ? e.message : e));
+    } finally {
+      this.busy = false;
+    }
+  },
+};
+
+// Register the Alpine store. Same idempotency guard pattern as other plugins.
+document.addEventListener("alpine:init", function () {
+  if (window.Alpine && !window.Alpine.store("chatPdfExport")) {
+    window.Alpine.store("chatPdfExport", store);
+  }
+});
+
+// If Alpine has already initialized by the time this module loads
+// (extension assets can land late), register directly.
+if (window.Alpine && typeof window.Alpine.store === "function") {
+  try {
+    if (!window.Alpine.store("chatPdfExport")) {
+      window.Alpine.store("chatPdfExport", store);
+    }
+  } catch (_) {}
+}


### PR DESCRIPTION
## Bug
The bottom-actions PDF button [#72](https://github.com/devyoon91/az-cliproxy-docker/pull/72) rendered as **raw JavaScript text** between Compact and Pause Agent — see the screenshot in the chat. The button shape was fine; the surrounding bar showed a chunk of my export logic as plain text.

## Root cause
The button's \`x-data\` was a multi-line attribute that contained an arrow function:

\`\`\`js
setTimeout(() => URL.revokeObjectURL(url), 0);
//          ^^^ the > in => closes <button> mid-attribute
\`\`\`

HTML parsers don't understand JS — they see a literal \`>\` and treat it as the end of the start tag. Everything after that point (most of the export logic, the closing \`:disabled\`, \`@click\`, and the closing \`>\`) becomes the button's text content. That's why the bar showed:

\`\`\`
... URL.revokeObjectURL(url), 0); } catch (e) { alert('PDF 추출 실패: ' + ...
\`\`\`

## Fix
Refactor to the Alpine-store pattern that \`_chat_compaction\` already uses, so the inline button HTML stays attribute-safe (no multi-line \`x-data\`, no arrow functions for the parser to misinterpret).

- **New** [\`webui/chat-pdf-export-store.js\`](agent-zero/usr-plugins/chat_pdf_export/webui/chat-pdf-export-store.js) — Alpine store holding \`busy\` + \`export(logNo?)\`. Registers as \`Alpine.store("chatPdfExport")\`. Single source of truth for the export pipeline (RFC 5987 filename parsing, blob download, error alerts).
- **Rewritten** [\`extensions/webui/chat-input-bottom-actions-start/export-pdf-button.html\`](agent-zero/usr-plugins/chat_pdf_export/extensions/webui/chat-input-bottom-actions-start/export-pdf-button.html) — wrapped as full \`<html><head><body>\` with \`<script type="module" src=".../store.js">\`. The \`<button>\` now just calls \`$store.chatPdfExport.export()\`. No multi-line attribute, no arrow functions.
- **Refactored** [\`extensions/webui/set_messages_after_loop/inject-pdf-buttons.js\`](agent-zero/usr-plugins/chat_pdf_export/extensions/webui/set_messages_after_loop/inject-pdf-buttons.js) — imports the same store and dispatches via \`pdfStore.export(logNo)\`. One pipeline, two entry points.

The arrow function in the store JS file is fine because it lives in an actual \`.js\` module, not inside an HTML attribute.

## Why this pattern is robust
- HTML parser never sees JS expression characters in attribute values
- Both buttons (full + per-message) call the same store method
- Future changes (cost footer, range filter, etc.) only need touching the store

## Verification
\`\`\`
$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:50001/plugins/chat_pdf_export/webui/chat-pdf-export-store.js
200
\`\`\`

In-container the new HTML and JS are both mounted with the corrected contents.

## Test plan
- [x] Store endpoint reachable (200, ~3 KB)
- [x] Bottom-actions HTML imports the store via \`<script type="module">\`
- [ ] **Post-merge UI**: hard-refresh; bottom row shows clean "PDF" button (no raw JS text); click → PDF downloads
- [ ] **Post-merge UI**: per-message \`picture_as_pdf\` icon still works (now goes through the same store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)