### PR TITLE
feat(plugin): dashboard_link — one-click bridge dashboard from agent-zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,11 @@ agent-zero/usr-plugins/*
 !agent-zero/usr-plugins/.gitkeep
 !agent-zero/usr-plugins/chat_pdf_export/
 !agent-zero/usr-plugins/chat_pdf_export/**
+!agent-zero/usr-plugins/dashboard_link/
+!agent-zero/usr-plugins/dashboard_link/**
 # Re-exclude the python bytecode caches that get regenerated inside
 # the plugin's bind-mount during normal runtime.
 agent-zero/usr-plugins/chat_pdf_export/**/__pycache__/
 agent-zero/usr-plugins/chat_pdf_export/**/*.pyc
+agent-zero/usr-plugins/dashboard_link/**/__pycache__/
+agent-zero/usr-plugins/dashboard_link/**/*.pyc

--- a/agent-zero/usr-plugins/dashboard_link/README.md
+++ b/agent-zero/usr-plugins/dashboard_link/README.md
@@ -1,0 +1,72 @@
+# Dashboard Link Plugin
+
+One-click open of the telegram-bridge cost dashboard from agent-zero.
+
+## Why this exists
+
+The bridge serves the dashboard at `http://localhost:8443/dashboard?token=<token>`,
+but the URL is awkward to type and the token rotates per deployment.
+This plugin turns it into a button next to Browser / Compact / PDF in
+the chat input action row.
+
+## How it works
+
+```
+[Dashboard button click]
+  → fetchApi POST /plugins/dashboard_link/get_token
+      ← reads DASHBOARD_TOKEN from agent-zero env (env_file: .env)
+      ← returns { token, port }
+  → window.open(`${protocol}//${hostname}:${port}/dashboard?token=...`, "_blank")
+```
+
+The hostname comes from `window.location` so SSH-tunneled setups
+(`ssh -L 8443:localhost:8443 host`) work without configuration —
+whatever host you reached agent-zero on, the dashboard opens on the
+same host at port 8443.
+
+## Layout
+
+```
+agent-zero/usr-plugins/dashboard_link/
+├── plugin.yaml
+├── api/
+│   └── get_token.py                              # ApiHandler — POST /plugins/dashboard_link/get_token
+├── webui/
+│   └── dashboard-link-store.js                   # Alpine store with open() method
+└── extensions/
+    └── webui/
+        └── chat-input-bottom-actions-start/
+            └── dashboard-button.html             # button → $store.dashboardLink.open()
+```
+
+## API
+
+```
+POST /api/plugins/dashboard_link/get_token
+GET  /api/plugins/dashboard_link/get_token   (read-only — same response)
+```
+
+Returns:
+
+| Status | Body | Meaning |
+|---|---|---|
+| 200    | `{ "token": "<value>", "port": 8443 }` | Token available |
+| 503    | `{ "error": "DASHBOARD_TOKEN not set", "hint": "..." }` | Disabled, set env + recreate |
+
+## Configuration
+
+| Env var | Default | Notes |
+|---|---|---|
+| `DASHBOARD_TOKEN` | (required) | Same value the bridge uses; without it `/dashboard` and `/api/stats` 404 on the bridge side |
+| `DASHBOARD_PORT`  | `8443`     | Override only if `docker-compose.yml` maps the bridge to a different host port |
+
+Both vars come from `az-cliproxy-docker/.env` (loaded by the
+`env_file:` directive in docker-compose). Recreate `agent-zero` after
+changing them so the new env is picked up.
+
+## Why a separate plugin (vs adding to chat_pdf_export)
+
+Different concern. PDF export operates on chat content; this opens an
+external service. Bundling them would couple the install/disable
+toggle to two unrelated features. Same reason chat_pdf_export
+isn't part of `_chat_compaction`.

--- a/agent-zero/usr-plugins/dashboard_link/api/get_token.py
+++ b/agent-zero/usr-plugins/dashboard_link/api/get_token.py
@@ -1,0 +1,63 @@
+"""GET (or POST) /api/plugins/dashboard_link/get_token
+
+Returns the DASHBOARD_TOKEN that the telegram-bridge expects on
+`/dashboard?token=...` and `/api/stats?token=...`. The token lives in
+the agent-zero container's environment (loaded via `env_file: .env`
+in docker-compose.yml — same place the bridge reads it from).
+
+Status codes:
+- 200 { "token": "<value>", "port": 8443 }
+- 503 if DASHBOARD_TOKEN is unset/empty (dashboard intentionally
+  disabled per the README — see /dashboard 404 behavior on the bridge).
+
+The plugin frontend builds the final URL using the user's current
+browser hostname so SSH-tunneled (`ssh -L 8443:localhost:8443`) and
+direct setups both work without configuration.
+"""
+from __future__ import annotations
+
+import os
+
+from flask import jsonify
+
+from helpers.api import ApiHandler, Input, Output, Request
+
+
+# Default port for the bridge dashboard. Matches docker-compose.yml's
+# `ports: - "8443:8443"` mapping. Override via env if a custom mapping
+# is in use.
+_DEFAULT_PORT = 8443
+
+
+class GetToken(ApiHandler):
+    """Return the dashboard token + port so the frontend can build the URL."""
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        # POST is what ApiHandler defaults to, but the call is read-only —
+        # accept GET too so a curl probe works without crafting a body.
+        return ["GET", "POST"]
+
+    async def process(self, input: Input, request: Request) -> Output:
+        token = (os.environ.get("DASHBOARD_TOKEN") or "").strip()
+        if not token:
+            return (
+                jsonify(
+                    {
+                        "error": "DASHBOARD_TOKEN not set",
+                        "hint": (
+                            "Set DASHBOARD_TOKEN in az-cliproxy-docker/.env "
+                            "and recreate the agent-zero container."
+                        ),
+                    }
+                ),
+                503,
+            )
+
+        port_raw = (os.environ.get("DASHBOARD_PORT") or "").strip()
+        try:
+            port = int(port_raw) if port_raw else _DEFAULT_PORT
+        except ValueError:
+            port = _DEFAULT_PORT
+
+        return jsonify({"token": token, "port": port})

--- a/agent-zero/usr-plugins/dashboard_link/extensions/webui/chat-input-bottom-actions-start/dashboard-button.html
+++ b/agent-zero/usr-plugins/dashboard_link/extensions/webui/chat-input-bottom-actions-start/dashboard-button.html
@@ -1,0 +1,32 @@
+<!-- Dashboard Link — bottom-actions button.
+     Opens the telegram-bridge cost dashboard (port 8443 by default) in a
+     new tab. Token + port come from the plugin's backend, which reads
+     DASHBOARD_TOKEN/DASHBOARD_PORT from agent-zero's env. The host part
+     is taken from window.location so SSH-tunneled setups work too. -->
+<html>
+<head>
+  <script type="module" src="/plugins/dashboard_link/webui/dashboard-link-store.js"></script>
+</head>
+<body>
+  <template x-if="$store.dashboardLink">
+    <button
+      type="button"
+      class="text-button dashboard-link-action"
+      title="비용 대시보드 열기 (새 탭)"
+      aria-label="Open cost dashboard"
+      data-bs-placement="top"
+      data-bs-trigger="hover"
+      :disabled="$store.dashboardLink.busy"
+      @click="$store.dashboardLink.open()"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true">
+        <line x1="12" y1="20" x2="12" y2="10"></line>
+        <line x1="18" y1="20" x2="18" y2="4"></line>
+        <line x1="6" y1="20" x2="6" y2="14"></line>
+        <line x1="3" y1="20" x2="21" y2="20"></line>
+      </svg>
+      <p x-text="$store.dashboardLink.busy ? 'Dashboard…' : 'Dashboard'"></p>
+    </button>
+  </template>
+</body>
+</html>

--- a/agent-zero/usr-plugins/dashboard_link/plugin.yaml
+++ b/agent-zero/usr-plugins/dashboard_link/plugin.yaml
@@ -1,0 +1,4 @@
+name: dashboard_link
+title: Dashboard Link
+description: Sidebar action button that opens the telegram-bridge cost dashboard in a new tab. Reads DASHBOARD_TOKEN from agent-zero's env and constructs the URL using the current browser hostname (so SSH-tunneled and direct setups both work).
+version: 0.1.0

--- a/agent-zero/usr-plugins/dashboard_link/webui/dashboard-link-store.js
+++ b/agent-zero/usr-plugins/dashboard_link/webui/dashboard-link-store.js
@@ -1,0 +1,74 @@
+// Alpine store for the dashboard_link plugin.
+// Fetches DASHBOARD_TOKEN from the backend (which reads it from
+// agent-zero's env, where it lives because of `env_file: .env`),
+// builds the URL using the user's current browser hostname so
+// SSH-tunneled and direct setups both work, and opens the dashboard
+// in a new tab.
+//
+// Mirrors chat_pdf_export's store pattern — keeps the inline button
+// HTML attribute-safe (no multi-line x-data, no arrow functions).
+
+import { fetchApi } from "/js/api.js";
+
+export const store = {
+  busy: false,
+
+  async open() {
+    if (this.busy) return;
+    this.busy = true;
+    try {
+      const res = await fetchApi("/plugins/dashboard_link/get_token", {
+        method: "POST",
+        credentials: "same-origin",
+      });
+      if (!res.ok) {
+        const msg = await res.text();
+        throw new Error(msg || ("HTTP " + res.status));
+      }
+      const data = await res.json();
+      const token = data && data.token;
+      const port = (data && data.port) || 8443;
+      if (!token) {
+        throw new Error("Empty DASHBOARD_TOKEN — set it in .env and recreate agent-zero");
+      }
+
+      const proto = window.location.protocol;
+      const host = window.location.hostname;
+      const url = proto + "//" + host + ":" + port +
+                  "/dashboard?token=" + encodeURIComponent(token);
+
+      // Open in a new tab. `noopener,noreferrer` so the new tab can't
+      // navigate the agent-zero tab back via window.opener.
+      const win = window.open(url, "_blank", "noopener,noreferrer");
+      if (!win) {
+        // Popup blocker fallback — copy URL to clipboard so the user
+        // can paste it manually.
+        try {
+          await navigator.clipboard.writeText(url);
+          alert("팝업이 차단되었습니다. URL 을 클립보드에 복사했습니다 — 새 탭에 붙여넣기.");
+        } catch (_) {
+          alert("팝업이 차단되었습니다. 이 URL 을 직접 열어주세요:\n" + url);
+        }
+      }
+    } catch (e) {
+      alert("대시보드 열기 실패: " + (e && e.message ? e.message : e));
+    } finally {
+      this.busy = false;
+    }
+  },
+};
+
+// Register store on Alpine init. Mirror the chat_pdf_export idempotency.
+document.addEventListener("alpine:init", function () {
+  if (window.Alpine && !window.Alpine.store("dashboardLink")) {
+    window.Alpine.store("dashboardLink", store);
+  }
+});
+
+if (window.Alpine && typeof window.Alpine.store === "function") {
+  try {
+    if (!window.Alpine.store("dashboardLink")) {
+      window.Alpine.store("dashboardLink", store);
+    }
+  } catch (_) {}
+}


### PR DESCRIPTION
## Summary
The bridge cost dashboard already serves at \`http://<host>:8443/dashboard?token=<token>\`, but typing it by hand (especially after a \`DASHBOARD_TOKEN\` rotation) is friction. This plugin adds a **"Dashboard"** button to the chat-input bottom-actions row — same row as Browser / Compact / PDF / Pause / Nudge / Terminal / Stop — that opens the dashboard in a new tab.

## How it works

\`\`\`
[Dashboard click]
  → fetchApi POST /plugins/dashboard_link/get_token
      ← reads DASHBOARD_TOKEN from agent-zero env (env_file: .env)
      ← returns { token, port }
  → window.open(`${protocol}//${hostname}:${port}/dashboard?token=...`, "_blank")
\`\`\`

Hostname comes from \`window.location\` so SSH-tunneled setups (\`ssh -L 8443:localhost:8443 host\`) work without extra config — whatever host you reached agent-zero on, the dashboard opens on the same host.

## Files
- [\`plugin.yaml\`](agent-zero/usr-plugins/dashboard_link/plugin.yaml)
- [\`api/get_token.py\`](agent-zero/usr-plugins/dashboard_link/api/get_token.py) — POST/GET handler returning \`{ token, port }\` or 503 with a hint when \`DASHBOARD_TOKEN\` is unset
- [\`webui/dashboard-link-store.js\`](agent-zero/usr-plugins/dashboard_link/webui/dashboard-link-store.js) — Alpine store with \`open()\` method. Popup-blocker fallback copies URL to clipboard.
- [\`extensions/webui/chat-input-bottom-actions-start/dashboard-button.html\`](agent-zero/usr-plugins/dashboard_link/extensions/webui/chat-input-bottom-actions-start/dashboard-button.html) — bar-chart icon + \`Dashboard\` label, attribute-safe shape (no inline arrow functions — lesson from [#74](https://github.com/devyoon91/az-cliproxy-docker/pull/74))
- [\`.gitignore\`](.gitignore) — whitelist the plugin dir under the existing \`usr-plugins/*\` exclusion

## Configuration

| Env var | Default | Notes |
|---|---|---|
| \`DASHBOARD_TOKEN\` | (required) | Same value the bridge uses; without it both \`/dashboard\` and \`/api/stats\` 404 on the bridge |
| \`DASHBOARD_PORT\`  | \`8443\`   | Override only if \`docker-compose.yml\` maps the bridge to a different host port |

Both come from \`az-cliproxy-docker/.env\` (already loaded by \`env_file:\` for the agent-zero service).

## Why a separate plugin
Different concern from \`chat_pdf_export\`. PDF export operates on chat content; this opens an external service. Bundling them would couple install/disable to two unrelated features. Same reason \`chat_pdf_export\` isn't part of \`_chat_compaction\`.

## Verification (in-container after \`--force-recreate\`)
- \`helpers.plugins.get_plugins_list()\` → includes \`dashboard_link\`
- \`get_webui_extensions(None, "chat-input-bottom-actions-start")\` → 4 entries: \`_browser\`, \`_chat_compaction\`, \`chat_pdf_export\`, **\`dashboard_link\`**
- \`GET /plugins/dashboard_link/webui/dashboard-link-store.js\` → 200, ~2.6 KB
- \`POST /api/plugins/dashboard_link/get_token\` → 403 without CSRF (correct — \`fetchApi\` attaches it from frontend)

## Test plan
- [x] Plugin discovered, slot registered, store JS reachable, API mounted
- [ ] **Post-merge UI**: hard-refresh; bottom row shows "Dashboard" button next to PDF; click → bridge dashboard opens in new tab with charts loaded
- [ ] Confirm popup-blocker fallback (block popups in browser → click → URL ends up in clipboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)