### PR TITLE
fix(backup): include _model_config + telegram-bridge/data — close data-loss gap (closes #76)

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -16,6 +16,8 @@
 | **프롬프트** | `agent-zero/prompts/` | 커스텀 시스템 프롬프트 | 🟢 낮음 | config |
 | **프로필** | `agent-zero/agents/` | 에이전트 프로필 (developer, reviewer, devops) | 🟢 낮음 | config |
 | **스크립트** | `agent-zero/git-init.sh` | Git/GitHub CLI 초기화 | 🟢 낮음 | config |
+| **플러그인 상태** | `agent-zero/usr-plugins/_model_config/` | 모델 override (`config.json` 의 chat/utility 선택) — `--force-recreate` 시 휘발. `_browser/_office/...` 는 이미지 재생성으로 복구되므로 백업 제외 | 🟡 중간 | config |
+| **브리지 상태** | `telegram-bridge/data/` | `/budget` 한도, alert cooldown, 향후 가격 스냅샷 | 🟡 중간 | config |
 | **메모리** | `agent-zero/memory/` | FAISS 벡터 DB (장기 기억) | 🟡 중간 | full |
 | **작업물** | `agent-zero/work_dir/` | 프로젝트 파일, clone된 저장소 | 🟡 중간 | full |
 | **로그** | `agent-zero/logs/` | 채팅 로그 (HTML) | 🟢 낮음 | full |
@@ -31,10 +33,10 @@
 # 경량 백업 (설정 + 인증만)
 ./scripts/backup.sh light
 
-# 설정 백업 (설정 + 인증 + 프롬프트 + 프로필)
+# 설정 백업 (설정 + 인증 + 프롬프트 + 프로필 + 플러그인 상태 + 브리지 상태)
 ./scripts/backup.sh config
 
-# 전체 백업 (설정 + 인증 + 프롬프트 + 프로필 + 메모리 + 작업물 + 로그)
+# 전체 백업 (config + 메모리 + 작업물 + 로그)
 ./scripts/backup.sh full
 ```
 
@@ -92,7 +94,7 @@ docker compose up -d --build
 | 모드 | 대상 | 크기 | 용도 |
 |------|------|------|------|
 | **light** | 설정 + 인증 | 수 KB | 다른 PC에서 빠르게 복원 |
-| **config** | light + 프롬프트 + 프로필 | 수십 KB | 커스텀 설정 전체 보존 |
+| **config** | light + 프롬프트 + 프로필 + 플러그인 상태 + 브리지 상태 | 수십 KB ~ 수 MB | 커스텀 설정 + `--force-recreate` 안전망 |
 | **full** | config + 메모리 + 작업물 + 로그 | 수 MB+ | 완전한 상태 복원 |
 | **telegram** | 설정 + 문서 + 사용량 | 수십 KB | 폰에서 원격 백업 |
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -34,11 +34,27 @@ BACKUP_DIRS_AUTH=(
     "cliproxy/auth"
 )
 
-# config: 프롬프트 + 프로필
+# config: 프롬프트 + 프로필 + 사용자 플러그인 상태 + 브리지 영구 상태
+#
+# usr-plugins/ 의 하위에는:
+#   - _model_config/config.json — 활성 chat/utility model 선택 (사용자 상태,
+#     `--force-recreate` 시 휘발 위험, 1KB 미만)
+#   - _browser/, _office/, docker_terminal/, stop_process/ — 업스트림 이미지가
+#     첫 실행 때 복사하는 vendored 자산 (수백 MB의 playwright 바이너리 포함,
+#     이미지 재생성으로 복구 가능 → 백업 불필요)
+#   - chat_pdf_export/, dashboard_link/ — 이 repo 의 git 추적 코드 (백업 불필요)
+# 따라서 _model_config/ 만 명시적으로 포함. 향후 다른 플러그인이 영구 상태를
+# 추가하면 그 플러그인의 state 디렉토리를 여기 명시적으로 추가한다.
+#
+# telegram-bridge/data/ 는 /budget 한도 + alert cooldown 같은 영구 데이터를
+# 들고 있고, docker-compose 상에서 :ro 가 아니라 read-write 로 마운트된다.
+# `--force-recreate` 한 번이면 의도와 무관하게 휘발될 수 있다.
 BACKUP_DIRS_CONFIG=(
     "agent-zero/prompts"
     "agent-zero/agents"
     "agent-zero/git-init.sh"
+    "agent-zero/usr-plugins/_model_config"
+    "telegram-bridge/data"
 )
 
 # full: 메모리 + 로그 + 작업물


### PR DESCRIPTION
Closes #76.

## Problem
The 2026-05-08 [repo audit](https://github.com/devyoon91/az-cliproxy-docker/issues/76) found two persistent state directories missing from \`BACKUP_DIRS_CONFIG\`. Both are mounted **read-write** in [\`docker-compose.yml\`](docker-compose.yml) and silently lost on a routine \`docker compose up -d --force-recreate\`:

- \`agent-zero/usr-plugins/_model_config/\` — active chat_model + utility_model selection (~1 KB). Wipe → AZ falls back to \`default_config.yaml\` whose \`claude-sonnet-4.6\` typo (with a dot) is rejected with 404 by Anthropic.
- \`telegram-bridge/data/\` — \`/budget\` limits, alert cooldown, future pricing snapshot store (M5-A). Wipe → user's spend caps lost, possible re-alert flood on next sweep.

## Fix
Add both to \`BACKUP_DIRS_CONFIG\` in [\`scripts/backup.sh\`](scripts/backup.sh).

**Important: scoped \`_model_config\` only, not the whole \`usr-plugins/\`**. The full directory contains \`_browser/\` (~895 MB of Playwright binaries), \`_office/\`, \`docker_terminal/\`, \`stop_process/\` — all vendored from the upstream image and regenerated on recreate. Including everything bloats \`config\` backups from the documented "수십 KB" to **272 MB**, defeating the mode's purpose.

Future plugins that introduce real persistent state should add their state dir explicitly, like \`_model_config\` does. Documented this in the inline comment.

\`restore.sh\` is a plain \`tar -xzf\` — automatically compatible with the new entries.

## Before / after
| | Before | After |
|---|---|---|
| \`backup.sh config\` size | ~수십 KB (no plugin state, no bridge data) | ~20 KB (with both) |
| \`backup.sh config\` after naive \`usr-plugins/\` add | 272 MB | — |
| Recreate-survives \`_model_config\` | ❌ silent loss | ✓ restored |
| Recreate-survives \`/budget\` settings | ❌ silent loss | ✓ restored |

## Docs
[\`docs/backup.md\`](docs/backup.md) updated:
- Two new rows in the 백업 대상 table covering the additions
- Mode-comparison row revised to call out "--force-recreate 안전망" as the practical reason \`config\` mode exists

## Verification
\`\`\`
$ ./scripts/backup.sh config
백업 대상:
  ✓ .env
  ✓ cliproxy/config.yaml
  ✓ agent-zero/settings.json
  ✓ docker-compose.yml
  ✓ cliproxy/auth
  ✓ agent-zero/prompts
  ✓ agent-zero/git-init.sh
  ✓ agent-zero/usr-plugins/_model_config   ← new
  ✓ telegram-bridge/data                   ← new

 크기: 20K
\`\`\`

## Test plan
- [x] \`config\` mode lists both new dirs in 백업 대상
- [x] Tarball stays in the documented size class (수십 KB)
- [ ] Post-merge: round-trip with \`restore.sh\` against a sacrificial branch (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)