### PR TITLE
refactor(bridge): pricing 모듈 분리 — bot.py 첫 carve (#79 Phase A)

### DIFF
--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -8,5 +8,6 @@ RUN pip install --no-cache-dir \
     httpx
 
 COPY bot.py .
+COPY pricing/ ./pricing/
 
 CMD ["python", "bot.py"]

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -323,112 +323,18 @@ usage_today: dict = {
 }
 usage_history: list = []  # 최근 7일
 
-# LiteLLM 모델 가격표 (원격 자동 업데이트)
-_model_cost_map: dict = {}
-
-
-def _load_model_cost_map():
-    """LiteLLM의 최신 모델 가격표를 로드 (GitHub에서 자동 다운로드)"""
-    global _model_cost_map
-    try:
-        import httpx
-        resp = httpx.get(
-            "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
-            timeout=10,
-        )
-        if resp.status_code == 200:
-            _model_cost_map = resp.json()
-            logger.info(f"[Cost] Loaded {len(_model_cost_map)} model prices from LiteLLM")
-            return
-    except Exception as e:
-        logger.warning(f"[Cost] Failed to fetch remote prices: {e}")
-
-    # fallback: 기본값
-    _model_cost_map = {}
-    logger.warning("[Cost] Using fallback cost estimation")
-
-
-def _model_info(model: str) -> dict:
-    """Resolve a model name against the LiteLLM price map with AZ aliasing.
-
-    AZ tags streaming calls as "anthropic/claude-sonnet-4-6" but LiteLLM
-    keys them as "claude-sonnet-4-5-20250929". Try the exact key first,
-    then a few known aliases, then strip the `anthropic/` prefix.
-    """
-    if model in _model_cost_map:
-        return _model_cost_map[model]
-    aliases = {
-        "anthropic/claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
-        "claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
-        "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
-    }
-    if model in aliases and aliases[model] in _model_cost_map:
-        return _model_cost_map[aliases[model]]
-    if model.startswith("anthropic/"):
-        tail = model.split("/", 1)[1]
-        if tail in _model_cost_map:
-            return _model_cost_map[tail]
-    return {}
-
-
-def calc_cost(
-    model: str,
-    input_tokens: int,
-    output_tokens: int,
-    cache_read_tokens: int = 0,
-    cache_creation_tokens: int = 0,
-    reasoning_tokens: int = 0,
-) -> float:
-    r"""Cache-aware cost calc.
-
-    `input_tokens` here is LiteLLM's normalized `prompt_tokens` — the
-    TOTAL prompt token count INCLUDING the cache_read and cache_creation
-    buckets. The earlier assumption that Anthropic's split usage stayed
-    split through LiteLLM was wrong; LiteLLM normalizes everything into
-    OpenAI-style `prompt_tokens` semantics where the number is one
-    aggregate.
-
-    Verified against Anthropic Console on 2026-04-30:
-        raw inputs:  prompt=1.224M  cache_read=638k  cache_create=316k
-        pre-fix:  \$5.626  (double-counted cache)
-        post-fix: \$2.763  ≈ Console \$2.70
-
-    Same fix lives in agent-zero/lib/pricing.py:compute_cost.
-    """
-    info = _model_info(model)
-    in_rate = info.get("input_cost_per_token", 0.000003)      # $3 / 1M fallback
-    out_rate = info.get("output_cost_per_token", 0.000015)    # $15 / 1M
-    read_rate = info.get("cache_read_input_token_cost", in_rate * 0.10)
-    create_rate = info.get("cache_creation_input_token_cost", in_rate * 1.25)
-    inp = max(0, int(input_tokens))
-    cr = max(0, int(cache_read_tokens))
-    cc = max(0, int(cache_creation_tokens))
-    rt = max(0, int(reasoning_tokens))
-    regular = max(0, inp - cr - cc)
-    # Reasoning / extended-thinking tokens (Claude 4.x, OpenAI o-series) are
-    # billed at output rate. Mirrors agent-zero/lib/pricing.py:compute_cost.
-    return (
-        regular * in_rate
-        + (max(0, int(output_tokens)) + rt) * out_rate
-        + cr * read_rate
-        + cc * create_rate
-    )
-
-
-def _normalize_model(model: str) -> str:
-    """Canonicalize model name before aggregating.
-
-    LiteLLM's kwargs["model"] and the stream-probe POST sometimes carry the
-    provider prefix (`anthropic/claude-sonnet-4-6`) and sometimes don't
-    (`claude-sonnet-4-6`). Without this the `by_model` dict splits one model
-    into two rows with mismatched cache/cost stats. Mirrors the same helper
-    now living in agent-zero/lib/task_report.py (issue #24 Wave 2).
-    """
-    if not isinstance(model, str) or not model:
-        return model
-    if model.startswith("anthropic/"):
-        return model.split("/", 1)[1]
-    return model
+# Pricing primitives — moved to `pricing/cost.py` (issue #79 Phase A).
+# Re-exported here so existing references (track_usage, _resolve_litellm_key,
+# take_pricing_snapshot, _aggregate, …) keep working without prefix changes.
+# When all call sites in this file are eventually scoped under their own
+# carved-out modules, drop these re-exports.
+from pricing.cost import (
+    _load_model_cost_map,
+    _model_cost_map,
+    _model_info,
+    _normalize_model,
+    calc_cost,
+)
 
 
 def track_usage(

--- a/telegram-bridge/pricing/__init__.py
+++ b/telegram-bridge/pricing/__init__.py
@@ -1,0 +1,24 @@
+"""Telegram-bridge pricing module — first carve-out from the bot.py
+god-file (issue #79 Phase A).
+
+Mirrors the pricing primitives that already live in
+`agent-zero/lib/pricing.py` so the bridge's `/track`, `/today`, and
+budget paths agree on cost numbers with the per-task JSONs that
+agent-zero writes.
+"""
+
+from .cost import (
+    _load_model_cost_map,
+    _model_cost_map,
+    _model_info,
+    _normalize_model,
+    calc_cost,
+)
+
+__all__ = [
+    "calc_cost",
+    "_model_info",
+    "_normalize_model",
+    "_load_model_cost_map",
+    "_model_cost_map",
+]

--- a/telegram-bridge/pricing/cost.py
+++ b/telegram-bridge/pricing/cost.py
@@ -1,0 +1,153 @@
+"""Cost calculation for the Telegram bridge.
+
+Mirrors `agent-zero/lib/pricing.py:compute_cost` so the bridge's `/track`
+and `/today` paths produce the same numbers per task that agent-zero
+writes into the task JSONs. When the cache math or reasoning rate
+changes upstream, both files have to update together — see PRs #51
+(cache no-double-count) and #64 (reasoning at output rate) for the
+shared regressions that fired in both copies at once.
+
+This module is a Phase A carve-out from the 3,500-line bot.py
+(issue #79). What's here:
+
+- `_model_cost_map` — the LiteLLM price table, populated at process
+  startup by `_load_model_cost_map()`. The dict is mutated in place
+  (clear+update) rather than reassigned so importers can hold a stable
+  binding. See the comment in `_load_model_cost_map`.
+- `_load_model_cost_map()` — fetch + populate.
+- `_model_info(model)` — alias-aware lookup against the table.
+- `_normalize_model(model)` — strip `anthropic/` prefix so by_model
+  rows don't split.
+- `calc_cost(...)` — cache-aware, reasoning-aware cost in USD.
+
+What stays in bot.py for now:
+
+- `track_usage()` and the `usage_today` global — they own per-day
+  state and are entangled with `usage_history`. Phase B carve.
+- `_resolve_litellm_key()` and `take_pricing_snapshot()` — sibling
+  consumers of `_model_cost_map`. They access the map via
+  `pricing.cost._model_cost_map` (dynamic attribute lookup, stays
+  fresh through reloads).
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# LiteLLM model price table. Populated once by `_load_model_cost_map()`
+# at startup. Mutated in place (clear+update) rather than reassigned so
+# `from pricing.cost import _model_cost_map` bindings stay valid through
+# the load. (Reassignment would leave importers pointing at the empty
+# pre-load dict forever.)
+_model_cost_map: dict = {}
+
+
+def _load_model_cost_map() -> None:
+    """Fetch LiteLLM's latest price table and populate `_model_cost_map`.
+
+    Called once from bot.py main. Network failure logs a warning and
+    leaves the map empty — `_model_info` then falls back to the inline
+    per-token rates baked into `calc_cost`.
+    """
+    try:
+        import httpx
+
+        resp = httpx.get(
+            "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            _model_cost_map.clear()
+            _model_cost_map.update(resp.json())
+            logger.info(f"[Cost] Loaded {len(_model_cost_map)} model prices from LiteLLM")
+            return
+    except Exception as e:
+        logger.warning(f"[Cost] Failed to fetch remote prices: {e}")
+
+    _model_cost_map.clear()
+    logger.warning("[Cost] Using fallback cost estimation")
+
+
+def _model_info(model: str) -> dict:
+    """Resolve a model name against the LiteLLM price map with AZ aliasing.
+
+    AZ tags streaming calls as "anthropic/claude-sonnet-4-6" but LiteLLM
+    keys them as "claude-sonnet-4-5-20250929". Try the exact key first,
+    then a few known aliases, then strip the `anthropic/` prefix.
+    """
+    if model in _model_cost_map:
+        return _model_cost_map[model]
+    aliases = {
+        "anthropic/claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
+        "claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
+        "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
+    }
+    if model in aliases and aliases[model] in _model_cost_map:
+        return _model_cost_map[aliases[model]]
+    if model.startswith("anthropic/"):
+        tail = model.split("/", 1)[1]
+        if tail in _model_cost_map:
+            return _model_cost_map[tail]
+    return {}
+
+
+def calc_cost(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    reasoning_tokens: int = 0,
+) -> float:
+    r"""Cache-aware cost calc.
+
+    `input_tokens` here is LiteLLM's normalized `prompt_tokens` — the
+    TOTAL prompt token count INCLUDING the cache_read and cache_creation
+    buckets. The earlier assumption that Anthropic's split usage stayed
+    split through LiteLLM was wrong; LiteLLM normalizes everything into
+    OpenAI-style `prompt_tokens` semantics where the number is one
+    aggregate.
+
+    Verified against Anthropic Console on 2026-04-30:
+        raw inputs:  prompt=1.224M  cache_read=638k  cache_create=316k
+        pre-fix:  \$5.626  (double-counted cache)
+        post-fix: \$2.763  ≈ Console \$2.70
+
+    Same fix lives in agent-zero/lib/pricing.py:compute_cost.
+    """
+    info = _model_info(model)
+    in_rate = info.get("input_cost_per_token", 0.000003)  # $3 / 1M fallback
+    out_rate = info.get("output_cost_per_token", 0.000015)  # $15 / 1M
+    read_rate = info.get("cache_read_input_token_cost", in_rate * 0.10)
+    create_rate = info.get("cache_creation_input_token_cost", in_rate * 1.25)
+    inp = max(0, int(input_tokens))
+    cr = max(0, int(cache_read_tokens))
+    cc = max(0, int(cache_creation_tokens))
+    rt = max(0, int(reasoning_tokens))
+    regular = max(0, inp - cr - cc)
+    # Reasoning / extended-thinking tokens (Claude 4.x, OpenAI o-series) are
+    # billed at output rate. Mirrors agent-zero/lib/pricing.py:compute_cost.
+    return (
+        regular * in_rate
+        + (max(0, int(output_tokens)) + rt) * out_rate
+        + cr * read_rate
+        + cc * create_rate
+    )
+
+
+def _normalize_model(model: str) -> str:
+    """Canonicalize model name before aggregating.
+
+    LiteLLM's kwargs["model"] and the stream-probe POST sometimes carry the
+    provider prefix (`anthropic/claude-sonnet-4-6`) and sometimes don't
+    (`claude-sonnet-4-6`). Without this the `by_model` dict splits one model
+    into two rows with mismatched cache/cost stats. Mirrors the same helper
+    now living in agent-zero/lib/task_report.py (issue #24 Wave 2).
+    """
+    if not isinstance(model, str) or not model:
+        return model
+    if model.startswith("anthropic/"):
+        return model.split("/", 1)[1]
+    return model

--- a/tests/test_bridge_cost.py
+++ b/tests/test_bridge_cost.py
@@ -1,0 +1,93 @@
+"""Pin telegram-bridge/pricing/cost.py — the bridge's mirror of
+`agent-zero/lib/pricing.py`.
+
+These two files MUST agree on the math: the bridge's `/track` and
+agent-zero's `task_report.llm_call` both compute cost from the same
+inputs and any drift shows up as `/today` ≠ Anthropic Console. The
+shared regression series (#51 cache double-count, #64 reasoning
+at output rate) hit both files at once because they're mirrors —
+this test catches the bridge half independently.
+
+Test was deferred from #77 because at that point all the pricing
+logic lived inside the 3,500-line bot.py with import-heavy deps.
+After #79 Phase A carved `pricing/cost.py` out, the function loads
+cleanly with no agent-zero / telegram / aiohttp imports needed.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_COST_PATH = (
+    Path(__file__).resolve().parent.parent / "telegram-bridge" / "pricing" / "cost.py"
+)
+
+
+def _load_cost():
+    spec = importlib.util.spec_from_file_location("bridge_pricing_cost", _COST_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cost():
+    return _load_cost()
+
+
+# A model name guaranteed to fall back to the inline rates inside calc_cost
+# regardless of whether _load_model_cost_map() ran. Keeps the test
+# deterministic across remote price-table changes.
+FALLBACK_MODEL = "model-that-does-not-exist-xyz"
+
+
+def test_pure_input_output(cost):
+    c = cost.calc_cost(FALLBACK_MODEL, 1_000_000, 1_000_000)
+    # $3/1M input + $15/1M output = $18.00
+    assert c == pytest.approx(18.0, rel=1e-9)
+
+
+def test_cache_no_double_count(cost):
+    """PR #51 regression — prompt_tokens INCLUDES the cache buckets."""
+    c = cost.calc_cost(
+        FALLBACK_MODEL,
+        input_tokens=10_000,
+        output_tokens=0,
+        cache_read_tokens=8_000,
+        cache_creation_tokens=1_000,
+    )
+    expected = (1_000 * 3e-6) + (8_000 * 0.3e-6) + (1_000 * 3.75e-6)
+    assert c == pytest.approx(expected, rel=1e-6)
+
+
+def test_reasoning_at_output_rate(cost):
+    """PR #64 — reasoning_tokens billed at the output rate."""
+    base = cost.calc_cost(FALLBACK_MODEL, 1_000, 100, reasoning_tokens=0)
+    with_thinking = cost.calc_cost(FALLBACK_MODEL, 1_000, 100, reasoning_tokens=500)
+    # 500 tokens × $15/1M = $0.0075
+    assert with_thinking - base == pytest.approx(500 * 1.5e-5, rel=1e-9)
+
+
+def test_negative_regular_clamps(cost):
+    """If cache_read + cache_creation > input_tokens, regular bucket
+    must clamp to 0 — never go negative."""
+    c = cost.calc_cost(
+        FALLBACK_MODEL,
+        input_tokens=1_000,
+        output_tokens=0,
+        cache_read_tokens=900,
+        cache_creation_tokens=900,
+    )
+    expected = (900 * 0.3e-6) + (900 * 3.75e-6)
+    assert c == pytest.approx(expected, rel=1e-6)
+    assert c > 0
+
+
+def test_normalize_model_strips_anthropic_prefix(cost):
+    assert cost._normalize_model("anthropic/claude-sonnet-4-6") == "claude-sonnet-4-6"
+    assert cost._normalize_model("claude-sonnet-4-6") == "claude-sonnet-4-6"
+    assert cost._normalize_model("") == ""
+    assert cost._normalize_model(None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
**TL;DR**: 3,500줄 god-file 인 `bot.py` 에서 cost 계산 로직만 떼어 [`telegram-bridge/pricing/cost.py`](telegram-bridge/pricing/cost.py) 로 이동. 동작 변화 없음, 테스트 가능 surface 만 노출. [#77](https://github.com/devyoon91/az-cliproxy-docker/pull/77) 에서 deferred 됐던 bridge `calc_cost` 테스트도 함께 추가.

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase A. 이후 4 phase 더 (`budget/`, `dashboard/`, `tasks/`, `az_client/`).

---

## 무엇이 옮겨졌나

| 심볼 | from → to |
|---|---|
| `_model_cost_map` (price table cache) | bot.py → pricing/cost.py |
| `_load_model_cost_map()` | bot.py → pricing/cost.py |
| `_model_info(model)` | bot.py → pricing/cost.py |
| `calc_cost(...)` | bot.py → pricing/cost.py |
| `_normalize_model(model)` | bot.py → pricing/cost.py |

bot.py 는 동일 이름들을 re-export — `track_usage`, `_resolve_litellm_key`, `take_pricing_snapshot`, `_aggregate` 등 호출 지점은 변경 없음.

**Phase B 에서 추가 carve 예정**: `track_usage` + `usage_today` 글로벌 (per-day state, history rotation 엮여있음).

## 핵심 디자인 결정 — binding stability

`_model_cost_map` 을 **재할당이 아닌 in-place 변형** (`.clear()` + `.update()`) 으로 갱신:

```python
# 전: 재할당 — 외부 import 가 stale 됨
_model_cost_map = resp.json()

# 후: in-place — `from pricing.cost import _model_cost_map` 안전
_model_cost_map.clear()
_model_cost_map.update(resp.json())
```

재할당했으면 bot.py 의 re-export 가 `_load_model_cost_map()` 호출 후에도 빈 dict 를 가리키는 stale binding 으로 남았을 것. cost map 을 직접 참조하는 4개 callsite (`_resolve_litellm_key`, `take_pricing_snapshot` 2곳, `_aggregate`) 모두에 영향.

## bridge `calc_cost` 테스트 추가 ([tests/test_bridge_cost.py](tests/test_bridge_cost.py))

#77 에서 deferred 했던 테스트 — bot.py 가 너무 무거워 import 가 안 됐었음. carve-out 후 pricing/cost.py 는 `httpx` 외 의존 없음 → unit test 가능.

`test_pricing.py` (agent-zero/lib/pricing.py 의 `compute_cost`) 와 **동일한 3개 invariant** 을 bridge 쪽 사본에서도 핀:

- cache no-double-count (#51)
- reasoning at output rate (#64)
- negative-regular clamp

두 사본의 drift 는 정확히 `/today` 와 Anthropic Console 이 안 맞는 회귀 패턴. 양쪽에서 독립 테스트로 잡힘.

## 검증

```
$ ruff check .          # All checks passed!
$ pytest -q             # 25 passed in 0.26s  (20 기존 + 5 신규 bridge)
$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge | grep '\[Cost\]'
2026-05-08 15:48:54,603 - pricing.cost - INFO - [Cost] Loaded 2706 model prices from LiteLLM
                          ^^^^^^^^^^^^ 새 모듈에서 로딩됨
$ curl -X POST localhost:8443/track -d '{"model":"...","input_tokens":1000,"output_tokens":100,"reasoning_tokens":500,...}'
→ cost_usd: 0.012   # = 1000*$3/M + (100+500)*$15/M ✓
```

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup gap (P0)
- ✅ #77 CI 부트스트랩 (P1)
- ✅ #81 preflight (P3)
- 🔄 **#79 Phase A — pricing/ ← 본 PR**
- ⏳ #79 Phase B-E
- ⏳ #78 GUIDE 재작성 (P1)
- ⏳ #80 plugin manifest (P3)
- ⏳ #82 docs/plugins.md (P3)

## Test plan

- [x] ruff clean
- [x] 25/25 pytest (5 신규 bridge 포함)
- [x] bridge container rebuild + 시작
- [x] `[Cost]` 로그가 `pricing.cost` logger 로 기록 (carved module 동작 증거)
- [x] /track round-trip 정확한 비용 계산