### PR TITLE
refactor(bridge): usage_today + track_usage 분리 (#79 Phase B)

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -310,24 +310,15 @@ async def _stream_extend(ctx_key: str, new_chunk: str) -> None:
 
 
 # ── 토큰 사용량 추적 ──
-usage_today: dict = {
-    "date": _kst_now().strftime("%Y-%m-%d"),
-    "input_tokens": 0,
-    "output_tokens": 0,
-    "cache_read_tokens": 0,
-    "cache_creation_tokens": 0,
-    "reasoning_tokens": 0,
-    "requests": 0,
-    "cost_usd": 0.0,
-    "by_model": {},  # 모델별 집계
-}
-usage_history: list = []  # 최근 7일
-
-# Pricing primitives — moved to `pricing/cost.py` (issue #79 Phase A).
-# Re-exported here so existing references (track_usage, _resolve_litellm_key,
-# take_pricing_snapshot, _aggregate, …) keep working without prefix changes.
-# When all call sites in this file are eventually scoped under their own
-# carved-out modules, drop these re-exports.
+#
+# Pricing + per-day accumulation moved to `pricing/` (issue #79 Phase A
+# carved out cost; Phase B carved usage). Both modules use clear+update
+# instead of reassignment so importers can hold stable bindings — see
+# the docstrings there for the rationale.
+#
+# Names re-exported here so existing call sites (cmd_today, daily_usage_reporter,
+# /usage handler, _resolve_litellm_key, take_pricing_snapshot, _aggregate, …)
+# keep working without prefix changes during the multi-phase split.
 from pricing.cost import (
     _load_model_cost_map,
     _model_cost_map,
@@ -335,76 +326,11 @@ from pricing.cost import (
     _normalize_model,
     calc_cost,
 )
-
-
-def track_usage(
-    model: str,
-    input_tokens: int,
-    output_tokens: int,
-    cache_read_tokens: int = 0,
-    cache_creation_tokens: int = 0,
-    reasoning_tokens: int = 0,
-):
-    """사용량 누적 (cache + reasoning tokens 포함).
-
-    `reasoning_tokens` (Claude 4.x 확장 사고, OpenAI o-series) 는 별도
-    필드로 추적해서 ``/usage`` 표시 시 분리 표시 가능하게 한다. cost 계산
-    은 ``calc_cost`` 가 자동으로 output rate 로 청구.
-    """
-    global usage_today
-    # Collapse provider-prefixed and bare forms so /today by_model stays unified.
-    model = _normalize_model(model)
-    today = _kst_now().strftime("%Y-%m-%d")
-
-    # 날짜가 바뀌면 리셋
-    if usage_today["date"] != today:
-        if usage_today["requests"] > 0:
-            usage_history.append(usage_today.copy())
-            while len(usage_history) > 7:
-                usage_history.pop(0)
-        usage_today = {
-            "date": today,
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_tokens": 0,
-            "cache_creation_tokens": 0,
-            "reasoning_tokens": 0,
-            "requests": 0,
-            "cost_usd": 0.0,
-            "by_model": {},
-        }
-
-    cost = calc_cost(
-        model, input_tokens, output_tokens,
-        cache_read_tokens, cache_creation_tokens, reasoning_tokens,
-    )
-
-    usage_today["input_tokens"] += input_tokens
-    usage_today["output_tokens"] += output_tokens
-    usage_today["cache_read_tokens"] = usage_today.get("cache_read_tokens", 0) + cache_read_tokens
-    usage_today["cache_creation_tokens"] = usage_today.get("cache_creation_tokens", 0) + cache_creation_tokens
-    usage_today["reasoning_tokens"] = usage_today.get("reasoning_tokens", 0) + reasoning_tokens
-    usage_today["requests"] += 1
-    usage_today["cost_usd"] += cost
-
-    if model not in usage_today["by_model"]:
-        usage_today["by_model"][model] = {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_tokens": 0,
-            "cache_creation_tokens": 0,
-            "reasoning_tokens": 0,
-            "requests": 0,
-            "cost_usd": 0.0,
-        }
-    m = usage_today["by_model"][model]
-    m["input_tokens"] += input_tokens
-    m["output_tokens"] += output_tokens
-    m["cache_read_tokens"] = m.get("cache_read_tokens", 0) + cache_read_tokens
-    m["cache_creation_tokens"] = m.get("cache_creation_tokens", 0) + cache_creation_tokens
-    m["reasoning_tokens"] = m.get("reasoning_tokens", 0) + reasoning_tokens
-    m["requests"] += 1
-    m["cost_usd"] += cost
+from pricing.usage import (
+    track_usage,
+    usage_history,
+    usage_today,
+)
 
 
 async def get_az_session() -> aiohttp.ClientSession:

--- a/telegram-bridge/pricing/__init__.py
+++ b/telegram-bridge/pricing/__init__.py
@@ -14,6 +14,11 @@ from .cost import (
     _normalize_model,
     calc_cost,
 )
+from .usage import (
+    track_usage,
+    usage_history,
+    usage_today,
+)
 
 __all__ = [
     "calc_cost",
@@ -21,4 +26,7 @@ __all__ = [
     "_normalize_model",
     "_load_model_cost_map",
     "_model_cost_map",
+    "track_usage",
+    "usage_today",
+    "usage_history",
 ]

--- a/telegram-bridge/pricing/usage.py
+++ b/telegram-bridge/pricing/usage.py
@@ -1,0 +1,121 @@
+"""Per-day usage accumulator + 7-day history rotation.
+
+Phase B carve-out from bot.py (issue #79). Owns:
+
+- `usage_today` — current day's totals (KST). Cleared + updated in place
+  on date rollover, never reassigned, so bot.py and the dashboard can
+  hold stable `from pricing.usage import usage_today` bindings.
+- `usage_history` — last 7 days. Mutated in place (append + bounded
+  pop), same binding-stability story.
+- `track_usage(...)` — single entry point for the `/track` webhook.
+  Calls `pricing.cost.calc_cost` so cost numbers stay in lockstep with
+  agent-zero/lib/pricing.py:compute_cost.
+
+Why the binding-stability dance: agent-zero/lib/pricing's price-table
+cache hit the same trap in Phase A — naive `usage_today = {...}`
+re-assignment after `from x import usage_today` would leave bot.py
+pointing at the pre-rollover bucket forever.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from .cost import _normalize_model, calc_cost
+
+KST = timezone(timedelta(hours=9))
+
+
+def _kst_now() -> datetime:
+    return datetime.now(KST)
+
+
+def _empty_today_bucket(date_str: str) -> dict:
+    return {
+        "date": date_str,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "reasoning_tokens": 0,
+        "requests": 0,
+        "cost_usd": 0.0,
+        "by_model": {},  # model_name -> _empty_model_bucket()
+    }
+
+
+def _empty_model_bucket() -> dict:
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "reasoning_tokens": 0,
+        "requests": 0,
+        "cost_usd": 0.0,
+    }
+
+
+# Module-level state. Importers see these bindings; helpers below
+# mutate the dict / list in place rather than rebinding.
+usage_today: dict = _empty_today_bucket(_kst_now().strftime("%Y-%m-%d"))
+usage_history: list = []
+
+
+def _rotate_if_new_day(today_str: str) -> None:
+    """If `usage_today` is for an older date, archive it (when there was
+    actual activity) and reset in place to a fresh bucket for `today_str`.
+    No-op when already on `today_str`.
+    """
+    if usage_today["date"] == today_str:
+        return
+    if usage_today["requests"] > 0:
+        # Snapshot — `dict(...)` copies the top-level fields and the
+        # `by_model` reference. Good enough for read-only history.
+        usage_history.append(dict(usage_today))
+        while len(usage_history) > 7:
+            usage_history.pop(0)
+    usage_today.clear()
+    usage_today.update(_empty_today_bucket(today_str))
+
+
+def track_usage(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    reasoning_tokens: int = 0,
+) -> None:
+    """Accumulate one /track event.
+
+    `reasoning_tokens` (Claude 4.x 확장 사고, OpenAI o-series) are kept
+    in their own bucket for `/usage` display, but `calc_cost` bills them
+    at the OUTPUT rate per Anthropic's schedule — see #64.
+    """
+    model = _normalize_model(model)
+    _rotate_if_new_day(_kst_now().strftime("%Y-%m-%d"))
+
+    cost = calc_cost(
+        model, input_tokens, output_tokens,
+        cache_read_tokens, cache_creation_tokens, reasoning_tokens,
+    )
+
+    usage_today["input_tokens"] += input_tokens
+    usage_today["output_tokens"] += output_tokens
+    usage_today["cache_read_tokens"] += cache_read_tokens
+    usage_today["cache_creation_tokens"] += cache_creation_tokens
+    usage_today["reasoning_tokens"] += reasoning_tokens
+    usage_today["requests"] += 1
+    usage_today["cost_usd"] += cost
+
+    by_model = usage_today["by_model"]
+    if model not in by_model:
+        by_model[model] = _empty_model_bucket()
+    m = by_model[model]
+    m["input_tokens"] += input_tokens
+    m["output_tokens"] += output_tokens
+    m["cache_read_tokens"] += cache_read_tokens
+    m["cache_creation_tokens"] += cache_creation_tokens
+    m["reasoning_tokens"] += reasoning_tokens
+    m["requests"] += 1
+    m["cost_usd"] += cost

--- a/tests/test_bridge_usage.py
+++ b/tests/test_bridge_usage.py
@@ -1,0 +1,195 @@
+"""Pin telegram-bridge/pricing/usage.py — per-day accumulator + rotation.
+
+Phase B carve-out from bot.py (issue #79). What's pinned:
+
+1. `track_usage` increments all 7 token fields + cost on `usage_today`.
+2. `track_usage` accumulates by_model totals separately from the
+   top-level totals (and they stay consistent).
+3. Daily rollover: when KST date advances, `usage_today` resets in
+   place; previous day archived into `usage_history` (if non-empty).
+4. `usage_history` capped at 7 entries.
+5. `usage_today` and `usage_history` bindings stay valid through
+   rollovers — that's the whole point of the clear+update pattern.
+"""
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_PRICING_DIR = Path(__file__).resolve().parent.parent / "telegram-bridge" / "pricing"
+
+
+def _load_usage_module():
+    """Load `pricing.usage` along with its `pricing.cost` dependency.
+
+    We can't just `spec_from_file_location` usage.py — it does
+    `from .cost import _normalize_model, calc_cost`, which needs the
+    `pricing` package present. Easiest path: spec-load both and stitch
+    them into sys.modules under the package name.
+    """
+    import sys
+    import types
+
+    pkg = types.ModuleType("bridge_pricing")
+    pkg.__path__ = [str(_PRICING_DIR)]  # type: ignore[attr-defined]
+    sys.modules["bridge_pricing"] = pkg
+
+    cost_spec = importlib.util.spec_from_file_location(
+        "bridge_pricing.cost", _PRICING_DIR / "cost.py"
+    )
+    assert cost_spec and cost_spec.loader
+    cost_mod = importlib.util.module_from_spec(cost_spec)
+    sys.modules["bridge_pricing.cost"] = cost_mod
+    cost_spec.loader.exec_module(cost_mod)
+
+    # usage.py says `from .cost import ...` — we need to give it the
+    # right relative-import target. Easiest: rewrite the import on load
+    # by patching its source at parse time. But cleaner: just register
+    # the cost module under the same package name usage.py expects.
+    src = (_PRICING_DIR / "usage.py").read_text(encoding="utf-8")
+    # The relative import resolves against __package__. Setting it to
+    # "bridge_pricing" makes `.cost` resolve to bridge_pricing.cost.
+    usage_spec = importlib.util.spec_from_loader(
+        "bridge_pricing.usage",
+        loader=importlib.util.spec_from_file_location(
+            "bridge_pricing.usage", _PRICING_DIR / "usage.py"
+        ).loader,
+    )
+    assert usage_spec
+    usage_mod = importlib.util.module_from_spec(usage_spec)
+    usage_mod.__package__ = "bridge_pricing"
+    sys.modules["bridge_pricing.usage"] = usage_mod
+    exec(compile(src, str(_PRICING_DIR / "usage.py"), "exec"), usage_mod.__dict__)
+    return usage_mod
+
+
+@pytest.fixture
+def usage(monkeypatch):
+    mod = _load_usage_module()
+    # Reset module state between tests (the module-load order means
+    # state could otherwise leak across cases).
+    mod.usage_today.clear()
+    mod.usage_today.update(mod._empty_today_bucket("2026-05-08"))
+    mod.usage_history.clear()
+    # Pin "today" so tests are deterministic regardless of when CI runs.
+    monkeypatch.setattr(
+        mod, "_kst_now",
+        lambda: datetime(2026, 5, 8, 12, 0, tzinfo=timezone(timedelta(hours=9))),
+    )
+    return mod
+
+
+# ── tests ───────────────────────────────────────────────────────────
+
+
+def test_track_usage_accumulates_top_level(usage):
+    usage.track_usage("claude-fake-xyz", 1_000, 100, reasoning_tokens=500)
+    assert usage.usage_today["input_tokens"] == 1_000
+    assert usage.usage_today["output_tokens"] == 100
+    assert usage.usage_today["reasoning_tokens"] == 500
+    assert usage.usage_today["requests"] == 1
+    # 1000 * $3/M + (100 + 500) * $15/M = $0.012
+    assert usage.usage_today["cost_usd"] == pytest.approx(0.012, rel=1e-6)
+
+
+def test_track_usage_accumulates_by_model(usage):
+    usage.track_usage("claude-fake-a", 100, 10)
+    usage.track_usage("claude-fake-a", 200, 20)
+    usage.track_usage("claude-fake-b", 300, 30)
+    by_model = usage.usage_today["by_model"]
+    assert set(by_model.keys()) == {"claude-fake-a", "claude-fake-b"}
+    assert by_model["claude-fake-a"]["requests"] == 2
+    assert by_model["claude-fake-a"]["input_tokens"] == 300  # 100+200
+    assert by_model["claude-fake-b"]["requests"] == 1
+    # Top-level totals match sum of by_model
+    assert usage.usage_today["requests"] == 3
+    assert usage.usage_today["input_tokens"] == 600
+
+
+def test_normalize_model_collapses_anthropic_prefix(usage):
+    """A by_model split between 'anthropic/foo' and 'foo' was the
+    original PR #24 Wave 2 bug — pin it."""
+    usage.track_usage("anthropic/claude-fake-a", 100, 10)
+    usage.track_usage("claude-fake-a", 200, 20)
+    by_model = usage.usage_today["by_model"]
+    # Both calls land in the same bucket.
+    assert list(by_model.keys()) == ["claude-fake-a"]
+    assert by_model["claude-fake-a"]["requests"] == 2
+
+
+def test_daily_rollover_archives_previous_day(usage, monkeypatch):
+    """When the KST date advances, usage_today resets and the prior
+    day moves into usage_history (when there was actual activity)."""
+    KST = timezone(timedelta(hours=9))
+    monkeypatch.setattr(
+        usage, "_kst_now", lambda: datetime(2026, 5, 8, 23, 50, tzinfo=KST)
+    )
+    usage.track_usage("claude-fake", 1_000, 100)
+    assert usage.usage_today["date"] == "2026-05-08"
+    assert usage.usage_today["requests"] == 1
+    assert len(usage.usage_history) == 0
+
+    # Cross midnight KST.
+    monkeypatch.setattr(
+        usage, "_kst_now", lambda: datetime(2026, 5, 9, 0, 5, tzinfo=KST)
+    )
+    usage.track_usage("claude-fake", 50, 5)
+
+    assert usage.usage_today["date"] == "2026-05-09"
+    assert usage.usage_today["requests"] == 1  # only the new day's call
+    assert len(usage.usage_history) == 1
+    archived = usage.usage_history[0]
+    assert archived["date"] == "2026-05-08"
+    assert archived["requests"] == 1
+
+
+def test_history_cap_at_seven(usage, monkeypatch):
+    """Rotation must drop oldest beyond 7 entries."""
+    KST = timezone(timedelta(hours=9))
+    for day in range(1, 11):  # 10 days
+        monkeypatch.setattr(
+            usage, "_kst_now",
+            lambda d=day: datetime(2026, 5, d, 12, 0, tzinfo=KST),
+        )
+        usage.track_usage("claude-fake", 100, 10)
+    # After 10 distinct days each with 1 request, history holds last 7,
+    # usage_today is the 10th.
+    assert len(usage.usage_history) == 7
+    assert usage.usage_today["date"] == "2026-05-10"
+    # Oldest archived should be day 3 (days 1+2 fell off the front).
+    archived_dates = [h["date"] for h in usage.usage_history]
+    assert archived_dates[0] == "2026-05-03"
+    assert archived_dates[-1] == "2026-05-09"
+
+
+def test_empty_day_not_archived(usage, monkeypatch):
+    """A day with zero requests shouldn't pollute history with an empty bucket."""
+    KST = timezone(timedelta(hours=9))
+    # Day 1: no track_usage calls, stays empty.
+    # Day 2: first track call triggers rollover — but day 1 had no
+    # requests, so it should NOT enter history.
+    monkeypatch.setattr(
+        usage, "_kst_now", lambda: datetime(2026, 5, 9, 0, 5, tzinfo=KST)
+    )
+    usage.track_usage("claude-fake", 100, 10)
+    assert usage.usage_today["date"] == "2026-05-09"
+    assert len(usage.usage_history) == 0  # empty day 5/8 not archived
+
+
+def test_bindings_survive_rollover(usage, monkeypatch):
+    """The whole point of clear+update — `from pricing.usage import
+    usage_today` outside callers must keep seeing fresh data after a
+    rollover, not the snapshot of the old bucket."""
+    KST = timezone(timedelta(hours=9))
+    captured = usage.usage_today  # simulates bot.py's `from ... import usage_today`
+    monkeypatch.setattr(
+        usage, "_kst_now", lambda: datetime(2026, 5, 9, 0, 5, tzinfo=KST)
+    )
+    usage.track_usage("claude-fake", 100, 10)
+    # `captured` is the SAME dict object — clear+update preserves identity.
+    assert captured is usage.usage_today
+    assert captured["date"] == "2026-05-09"
+    assert captured["requests"] == 1


### PR DESCRIPTION
**TL;DR**: bot.py 의 per-day usage 누적 로직(`usage_today`, `usage_history`, `track_usage`)을 [`telegram-bridge/pricing/usage.py`](telegram-bridge/pricing/usage.py) 로 이동. 동작 변화 없음, 7개 회귀 테스트 추가. [Phase A (#86)](https://github.com/devyoon91/az-cliproxy-docker/pull/86) 후속.

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase B. 다음은 `budget/`.

---

## 무엇이 옮겨졌나

| 심볼 | from → to |
|---|---|
| `usage_today` (per-day 집계 dict) | bot.py → pricing/usage.py |
| `usage_history` (최근 7일 list) | bot.py → pricing/usage.py |
| `track_usage(...)` | bot.py → pricing/usage.py |

bot.py 는 위 3개 이름을 re-export — `/usage` handler, daily reporter, dashboard, `_aggregate`, `cmd_today` 등 호출 지점 변경 없음.

## 핵심 디자인 — binding stability (Phase A 와 동일 패턴)

기존 `track_usage` 가 날짜 변경 시 `usage_today = {...}` 로 **재할당**했습니다. import 한 외부에서는 stale 됨:

```python
# 외부 (bot.py)
from pricing.usage import usage_today

# pricing/usage.py 내부
usage_today = {...}   # 재할당 — bot.py 의 binding 은 이전 dict 가리킴
```

`_rotate_if_new_day()` 가 **clear + update** 로 갱신하도록 수정 → dict 객체 identity 유지 → 외부 binding 유효:

```python
usage_today.clear()
usage_today.update(_empty_today_bucket(today_str))
```

`captured is usage.usage_today` (rollover 이후) — `test_bindings_survive_rollover` 가 핀.

## 테스트 7종 ([tests/test_bridge_usage.py](tests/test_bridge_usage.py))

- 누적 (top-level 7개 필드 + cost)
- by_model 누적 (top-level 합계와 일관)
- 모델명 정규화 (`anthropic/foo == foo` — PR #24 W2 회귀)
- 자정 KST 넘으면 archive + reset
- empty day archive 안 됨 (zero-request pollution 방지)
- history 7개 cap
- binding identity preservation (이번 PR 의 핵심 invariant)

## 검증

```
$ ruff check .          # All checks passed!
$ pytest -q             # 32 passed in 0.30s  (25 + 7 신규)

$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge | head
[Cost] Loaded 2706 model prices from LiteLLM
Webhook server started on :8443

$ curl -X POST localhost:8443/track -d '{"model":"claude-sonnet-4-5","input_tokens":1000,"output_tokens":100,"reasoning_tokens":500}'
→ requests=1 cost=$0.012 reasoning=500

$ curl localhost:8443/usage | jq '.today.requests'
→ 1   # bot.py 의 import 가 live 반영 — binding stability 증명
```

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup gap (P0)
- ✅ #77 CI 부트스트랩 (P1)
- ✅ #81 preflight (P3)
- ✅ #79 Phase A — pricing/cost (P2)
- 🔄 **#79 Phase B — pricing/usage ← 본 PR**
- ⏳ #79 Phase C-E (budget, dashboard, tasks, az_client)
- ⏳ #78 GUIDE 재작성 (P1)
- ⏳ #80 plugin manifest (P3)
- ⏳ #82 docs/plugins.md (P3)

## Test plan

- [x] ruff clean
- [x] 32/32 pytest
- [x] bridge container rebuild
- [x] /track POST → /usage GET round-trip 일관
- [x] daily rollover 시뮬레이션 (test 단위 — 자정 직접 트리거 안 함)