### PR TITLE
refactor(bridge): budget state/persistence 분리 (#79 Phase C)

### DIFF
--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -9,5 +9,6 @@ RUN pip install --no-cache-dir \
 
 COPY bot.py .
 COPY pricing/ ./pricing/
+COPY budget/ ./budget/
 
 CMD ["python", "bot.py"]

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -1202,74 +1202,22 @@ TASKS_DIR = "/app/tasks"
 
 # ── Budget alerts (M5-A · issue #19) ──
 # Persists across restarts via a docker volume mount (/app/data → ./telegram-bridge/data).
-BUDGET_DIR = "/app/data"
-BUDGET_PATH = os.path.join(BUDGET_DIR, "budget.json")
-
-# Threshold ladder. Order matters — _budget_check_window iterates highest first
-# so the strongest crossed level fires (and the lower ones are recorded as
-# already-fired so they don't follow-up next call).
-BUDGET_THRESHOLDS = [
-    (1.50, "🚨 심각", "150%"),
-    (1.00, "❌ 초과", "100%"),
-    (0.80, "⚠️ 주의", "80%"),
-]
-
-
-def _budget_default() -> dict:
-    """Empty budget shape. `alerts_fired` keys self-rotate by date —
-    yesterday's keys are simply never queried again."""
-    return {
-        "day_limit_usd": None,
-        "week_limit_usd": None,
-        "alerts_fired": {},  # "YYYY-MM-DD:day:80" -> True (presence = fired)
-    }
-
-
-_budget: dict = _budget_default()
-
-
-def _load_budget() -> None:
-    """Read budget.json once at startup. Missing file is fine — defaults stand.
-    Corrupt file logs once and resets to defaults so the bot keeps running."""
-    global _budget
-    try:
-        if os.path.isfile(BUDGET_PATH):
-            with open(BUDGET_PATH, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            # Merge into defaults to tolerate older/partial schemas.
-            base = _budget_default()
-            base.update({k: v for k, v in data.items() if k in base})
-            if not isinstance(base.get("alerts_fired"), dict):
-                base["alerts_fired"] = {}
-            _budget = base
-            logger.info(
-                f"[budget] loaded day=${_budget['day_limit_usd']} "
-                f"week=${_budget['week_limit_usd']}"
-            )
-        else:
-            logger.info("[budget] no saved budget — using defaults (no limits)")
-    except Exception as e:
-        logger.warning(f"[budget] load failed, using defaults: {e}")
-        _budget = _budget_default()
-
-
-def _save_budget() -> None:
-    """Best-effort write. Never propagate exceptions — a budget save failure
-    must not crash a /budget command or the hourly sweep."""
-    try:
-        os.makedirs(BUDGET_DIR, exist_ok=True)
-        tmp = BUDGET_PATH + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(_budget, f, ensure_ascii=False, indent=2)
-        os.replace(tmp, BUDGET_PATH)
-    except Exception as e:
-        logger.warning(f"[budget] save failed: {e}")
-
-
-def _alert_key(window: str, threshold_pct: str, period_id: str) -> str:
-    """`period_id` is 'YYYY-MM-DD' for day, 'YYYY-Www' for week — naturally
-    self-rotating, so old entries never fire again."""
-    return f"{period_id}:{window}:{threshold_pct}"
+# Budget state, persistence, threshold ladder, pure formatters — moved
+# to `budget/core.py` (issue #79 Phase C). Re-exported below so the
+# async engine (_budget_check_window, hourly_budget_sweep) and the
+# /budget command handler keep the existing names. A future phase can
+# rename callers to use the public surface (alert_key, format_alert).
+from budget.core import (
+    BUDGET_DIR,
+    BUDGET_PATH,
+    BUDGET_THRESHOLDS,
+    _budget,
+    _budget_default,
+    _load_budget,
+    _save_budget,
+)
+from budget.core import alert_key as _alert_key  # noqa: F401  # legacy name
+from budget.core import format_alert as _format_budget_alert  # noqa: F401
 
 
 def _compute_window_cost(window: str) -> dict:
@@ -1320,27 +1268,6 @@ def _compute_window_cost(window: str) -> dict:
         "period_id": period_id,
         "label": label,
     }
-
-
-def _format_budget_alert(window: str, info: dict, limit: float, level_label: str, ratio: float) -> str:
-    """Render the threshold-crossed alert. Spec from issue #19."""
-    cost = info["cost_usd"]
-    remaining = limit - cost
-    pct = ratio * 100
-    period_word = "일간" if window == "day" else "주간"
-    lines = [
-        f"{level_label} {period_word} 예산 {pct:.0f}% 도달",
-        f"{info['label']}",
-        f"비용: ${cost:.4f} / ${limit:.2f} 한도",
-    ]
-    if remaining >= 0:
-        lines.append(f"남은 예산: ${remaining:.4f}")
-    else:
-        lines.append(f"초과: ${abs(remaining):.4f}")
-    if info.get("top_model"):
-        m, mc = info["top_model"]
-        lines.append(f"주요 소비 모델: {m} (${mc:.4f})")
-    return "\n".join(lines)
 
 
 async def _budget_check_window(window: str) -> bool:

--- a/telegram-bridge/budget/__init__.py
+++ b/telegram-bridge/budget/__init__.py
@@ -1,0 +1,42 @@
+"""Spend-budget engine for the Telegram bridge.
+
+Phase C carve-out from bot.py (issue #79). What lives here:
+
+- The threshold ladder (80% / 100% / 150%) and the JSON state file at
+  `/app/data/budget.json` (mounted read-write per docker-compose).
+- Pure helpers: empty-shape default, cooldown-key formatter, alert
+  text renderer.
+- Load + save IO with crash-safe atomic write.
+
+What's NOT here (lives in bot.py):
+- `_compute_window_cost()` — depends on task-JSON aggregation, due
+  to be carved in Phase D.
+- `_budget_check_window()`, `budget_check_all()`, `hourly_budget_sweep()` —
+  async, depend on `send_telegram()`. Pure decision logic could be split
+  out cleanly, but for Phase C minimum the threshold loop stays caller-side.
+- `cmd_budget` — Telegram command handler.
+"""
+
+from .core import (
+    BUDGET_DIR,
+    BUDGET_PATH,
+    BUDGET_THRESHOLDS,
+    _budget,
+    _budget_default,
+    _load_budget,
+    _save_budget,
+    alert_key,
+    format_alert,
+)
+
+__all__ = [
+    "BUDGET_DIR",
+    "BUDGET_PATH",
+    "BUDGET_THRESHOLDS",
+    "_budget",
+    "_budget_default",
+    "_load_budget",
+    "_save_budget",
+    "alert_key",
+    "format_alert",
+]

--- a/telegram-bridge/budget/core.py
+++ b/telegram-bridge/budget/core.py
@@ -1,0 +1,126 @@
+"""Budget state + persistence + pure formatters.
+
+Phase C carve-out from bot.py (issue #79). The async budget engine
+(`_budget_check_window`, `hourly_budget_sweep`) stays in bot.py for now
+because it depends on `send_telegram()` and `_compute_window_cost()`
+(task-JSON aggregation, Phase D's territory).
+
+Binding stability:
+The `_budget` state dict is mutated in place (`clear()` + `update()`)
+in `_load_budget()` instead of being reassigned, so a `from budget.core
+import _budget` binding in bot.py keeps pointing at the right object
+across reloads. Same pattern as `pricing.cost._model_cost_map` and
+`pricing.usage.usage_today`.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+BUDGET_DIR = "/app/data"
+BUDGET_PATH = os.path.join(BUDGET_DIR, "budget.json")
+
+# Threshold ladder. Order matters — `_budget_check_window` iterates
+# highest first so the strongest crossed level fires (and the lower ones
+# are recorded as already-fired so they don't follow-up next call).
+BUDGET_THRESHOLDS = [
+    (1.50, "🚨 심각", "150%"),
+    (1.00, "❌ 초과", "100%"),
+    (0.80, "⚠️ 주의", "80%"),
+]
+
+
+def _budget_default() -> dict:
+    """Empty budget shape. `alerts_fired` keys self-rotate by date —
+    yesterday's keys are simply never queried again."""
+    return {
+        "day_limit_usd": None,
+        "week_limit_usd": None,
+        "alerts_fired": {},  # "YYYY-MM-DD:day:80" -> True (presence = fired)
+    }
+
+
+# Module-level state. Mutated in place (clear+update) — see file docstring.
+_budget: dict = _budget_default()
+
+
+def _load_budget() -> None:
+    """Read budget.json once at startup. Missing file is fine — defaults stand.
+    Corrupt file logs once and resets to defaults so the bot keeps running.
+    """
+    try:
+        if os.path.isfile(BUDGET_PATH):
+            with open(BUDGET_PATH, encoding="utf-8") as f:
+                data = json.load(f)
+            # Merge into defaults to tolerate older/partial schemas.
+            base = _budget_default()
+            base.update({k: v for k, v in data.items() if k in base})
+            if not isinstance(base.get("alerts_fired"), dict):
+                base["alerts_fired"] = {}
+            _budget.clear()
+            _budget.update(base)
+            logger.info(
+                f"[budget] loaded day=${_budget['day_limit_usd']} "
+                f"week=${_budget['week_limit_usd']}"
+            )
+        else:
+            logger.info("[budget] no saved budget — using defaults (no limits)")
+    except Exception as e:
+        logger.warning(f"[budget] load failed, using defaults: {e}")
+        _budget.clear()
+        _budget.update(_budget_default())
+
+
+def _save_budget() -> None:
+    """Best-effort write. Never propagate exceptions — a budget save failure
+    must not crash a /budget command or the hourly sweep.
+    """
+    try:
+        os.makedirs(BUDGET_DIR, exist_ok=True)
+        tmp = BUDGET_PATH + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(_budget, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, BUDGET_PATH)
+    except Exception as e:
+        logger.warning(f"[budget] save failed: {e}")
+
+
+def alert_key(window: str, threshold_pct: str, period_id: str) -> str:
+    """Build the cooldown key for one (window, threshold, period).
+
+    `period_id` is "YYYY-MM-DD" for day, "YYYY-Www" for week — naturally
+    self-rotating, so old entries never fire again. Renamed from the
+    private `_alert_key` to mark it part of the public module API.
+    """
+    return f"{period_id}:{window}:{threshold_pct}"
+
+
+def format_alert(
+    window: str,
+    info: dict,
+    limit: float,
+    level_label: str,
+    ratio: float,
+) -> str:
+    """Render the threshold-crossed alert text. Spec from issue #19."""
+    cost = info["cost_usd"]
+    remaining = limit - cost
+    pct = ratio * 100
+    period_word = "일간" if window == "day" else "주간"
+    lines = [
+        f"{level_label} {period_word} 예산 {pct:.0f}% 도달",
+        f"{info['label']}",
+        f"비용: ${cost:.4f} / ${limit:.2f} 한도",
+    ]
+    if remaining >= 0:
+        lines.append(f"남은 예산: ${remaining:.4f}")
+    else:
+        lines.append(f"초과: ${abs(remaining):.4f}")
+    if info.get("top_model"):
+        m, mc = info["top_model"]
+        lines.append(f"주요 소비 모델: {m} (${mc:.4f})")
+    return "\n".join(lines)

--- a/tests/test_bridge_budget.py
+++ b/tests/test_bridge_budget.py
@@ -1,0 +1,195 @@
+"""Pin telegram-bridge/budget/core.py — Phase C carve.
+
+What's pinned here:
+
+1. Default shape (`_budget_default()`).
+2. Threshold ladder is high-to-low (the iteration order is load-bearing
+   in the engine's "fire highest crossed level only" logic).
+3. `alert_key` cooldown formatter.
+4. `format_alert` text rendering with each branch covered.
+5. Round-trip: save → load preserves user limits + alerts_fired.
+6. Load tolerates missing file, corrupt file, partial schema.
+7. `_budget` dict identity survives `_load_budget()` (clear+update,
+   not reassignment — the binding-stability invariant from Phase A/B).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_CORE_PATH = (
+    Path(__file__).resolve().parent.parent / "telegram-bridge" / "budget" / "core.py"
+)
+
+
+def _load_budget_module(tmp_path):
+    """Load `budget.core` with BUDGET_DIR pointed at a tmp dir so the
+    on-disk JSON tests don't touch /app/data."""
+    # Same trick as test_bridge_usage: put the package on sys.modules.
+    pkg = types.ModuleType("bridge_budget")
+    pkg.__path__ = [str(_CORE_PATH.parent)]  # type: ignore[attr-defined]
+    sys.modules["bridge_budget"] = pkg
+
+    spec = importlib.util.spec_from_file_location("bridge_budget.core", _CORE_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["bridge_budget.core"] = mod
+    spec.loader.exec_module(mod)
+
+    # Redirect persistence to tmp.
+    mod.BUDGET_DIR = str(tmp_path)
+    mod.BUDGET_PATH = str(tmp_path / "budget.json")
+    return mod
+
+
+@pytest.fixture
+def budget(tmp_path):
+    mod = _load_budget_module(tmp_path)
+    # Reset state between tests.
+    mod._budget.clear()
+    mod._budget.update(mod._budget_default())
+    return mod
+
+
+# ── pure helpers ────────────────────────────────────────────────────
+
+
+def test_default_shape(budget):
+    d = budget._budget_default()
+    assert d == {"day_limit_usd": None, "week_limit_usd": None, "alerts_fired": {}}
+
+
+def test_thresholds_high_to_low(budget):
+    """Ladder iteration order is load-bearing: highest first so only
+    the strongest crossed level fires. If someone sorts ascending by
+    accident, a 90% spend would fire 80% before 100%, 100% before 150%."""
+    thresholds = [t[0] for t in budget.BUDGET_THRESHOLDS]
+    assert thresholds == sorted(thresholds, reverse=True)
+    # And the human labels match the percentages.
+    for thresh, _label, pct_label in budget.BUDGET_THRESHOLDS:
+        assert pct_label == f"{int(thresh * 100)}%"
+
+
+def test_alert_key_format(budget):
+    assert budget.alert_key("day", "80%", "2026-05-08") == "2026-05-08:day:80%"
+    assert budget.alert_key("week", "150%", "2026-W19") == "2026-W19:week:150%"
+
+
+def test_format_alert_under_budget(budget):
+    info = {
+        "cost_usd": 4.50,
+        "label": "오늘 (2026-05-08 KST)",
+        "top_model": ("claude-sonnet-4-5", 4.20),
+    }
+    text = budget.format_alert("day", info, limit=5.0, level_label="⚠️ 주의", ratio=0.90)
+    assert "⚠️ 주의" in text
+    assert "일간 예산 90% 도달" in text
+    assert "$4.5000 / $5.00" in text
+    assert "남은 예산: $0.5000" in text
+    assert "claude-sonnet-4-5" in text
+    assert "초과:" not in text
+
+
+def test_format_alert_over_budget(budget):
+    info = {"cost_usd": 7.50, "label": "오늘", "top_model": None}
+    text = budget.format_alert("day", info, limit=5.0, level_label="🚨 심각", ratio=1.50)
+    assert "초과: $2.5000" in text
+    assert "남은 예산:" not in text
+    # No top_model → no "주요 소비 모델" line.
+    assert "주요 소비 모델" not in text
+
+
+def test_format_alert_week_label(budget):
+    info = {"cost_usd": 25.0, "label": "최근 7일", "top_model": None}
+    text = budget.format_alert("week", info, limit=30.0, level_label="❌ 초과", ratio=0.83)
+    assert "주간" in text
+    assert "일간" not in text
+
+
+# ── persistence ──────────────────────────────────────────────────────
+
+
+def test_save_then_load_round_trip(budget):
+    budget._budget["day_limit_usd"] = 5.0
+    budget._budget["week_limit_usd"] = 30.0
+    budget._budget["alerts_fired"]["2026-05-08:day:80%"] = True
+
+    budget._save_budget()
+    # Confirm file written.
+    raw = json.loads(Path(budget.BUDGET_PATH).read_text(encoding="utf-8"))
+    assert raw["day_limit_usd"] == 5.0
+    assert raw["alerts_fired"]["2026-05-08:day:80%"] is True
+
+    # Wipe in-memory and reload.
+    budget._budget.clear()
+    budget._budget.update(budget._budget_default())
+    budget._load_budget()
+    assert budget._budget["day_limit_usd"] == 5.0
+    assert budget._budget["week_limit_usd"] == 30.0
+    assert budget._budget["alerts_fired"]["2026-05-08:day:80%"] is True
+
+
+def test_load_missing_file_uses_defaults(budget):
+    # No file written; load is a no-op except for state guarantee.
+    budget._load_budget()
+    assert budget._budget == budget._budget_default()
+
+
+def test_load_corrupt_file_resets(budget):
+    Path(budget.BUDGET_PATH).write_text("not-valid-json{", encoding="utf-8")
+    # Pollute state to verify the reset.
+    budget._budget["day_limit_usd"] = 999.0
+    budget._load_budget()
+    assert budget._budget == budget._budget_default()
+
+
+def test_load_partial_schema_tolerated(budget):
+    """Old/partial JSON missing a key shouldn't crash. Defaults fill in."""
+    Path(budget.BUDGET_PATH).write_text(
+        json.dumps({"day_limit_usd": 5.0}),  # missing week + alerts_fired
+        encoding="utf-8",
+    )
+    budget._load_budget()
+    assert budget._budget["day_limit_usd"] == 5.0
+    assert budget._budget["week_limit_usd"] is None
+    assert budget._budget["alerts_fired"] == {}
+
+
+def test_load_alerts_fired_wrong_type_normalized(budget):
+    """A pre-existing JSON with `alerts_fired: null` shouldn't leave the
+    field non-dict — engine assumes dict semantics later."""
+    Path(budget.BUDGET_PATH).write_text(
+        json.dumps({"day_limit_usd": 5.0, "alerts_fired": None}),
+        encoding="utf-8",
+    )
+    budget._load_budget()
+    assert isinstance(budget._budget["alerts_fired"], dict)
+
+
+def test_budget_dict_identity_preserved_through_load(budget):
+    """The whole point of clear+update over reassignment — bot.py's
+    `from budget.core import _budget` binding must reflect post-load
+    contents, not the empty pre-load dict."""
+    captured = budget._budget  # simulates the import binding
+    budget._budget["day_limit_usd"] = 999.0  # would be wiped by reassignment
+    budget._save_budget()
+    budget._load_budget()
+    # `captured` is still the same dict object, with the loaded values.
+    assert captured is budget._budget
+    assert captured["day_limit_usd"] == 999.0
+
+
+def test_save_creates_dir(budget, tmp_path):
+    """First save must create BUDGET_DIR if it doesn't exist."""
+    nested = tmp_path / "nested" / "data"
+    budget.BUDGET_DIR = str(nested)
+    budget.BUDGET_PATH = str(nested / "budget.json")
+    assert not nested.exists()
+    budget._budget["day_limit_usd"] = 1.0
+    budget._save_budget()
+    assert (nested / "budget.json").exists()


### PR DESCRIPTION
**TL;DR**: bot.py 의 budget 상태 + JSON 영속 + 순수 포매터를 [`telegram-bridge/budget/core.py`](telegram-bridge/budget/core.py) 로 이동. 동작 변화 없음, 13개 테스트 추가. async 엔진 (`_budget_check_window`, `hourly_budget_sweep`) 은 `send_telegram` + task-JSON 집계 의존이라 bot.py 에 남김.

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase C. 다음은 `dashboard/` (Phase D).

---

## 무엇이 옮겨졌나

| 심볼 | from → to |
|---|---|
| `BUDGET_DIR`, `BUDGET_PATH`, `BUDGET_THRESHOLDS` | bot.py → budget/core.py |
| `_budget` (상태 dict) | bot.py → budget/core.py |
| `_budget_default()` | bot.py → budget/core.py |
| `_load_budget()`, `_save_budget()` | bot.py → budget/core.py |
| `_alert_key` → `alert_key` | bot.py → budget/core.py (public 이름으로 변경) |
| `_format_budget_alert` → `format_alert` | bot.py → budget/core.py (public 이름으로 변경) |

bot.py 는 위 모든 이름 + legacy 별칭(`_alert_key`, `_format_budget_alert`) 을 re-export — async 엔진과 `/budget` 명령 핸들러는 변경 없이 동작.

## 남겨둔 것 (다음 phase)

- `_compute_window_cost` — task-JSON 집계 의존 (Phase D)
- `_budget_check_window`, `budget_check_all`, `hourly_budget_sweep` — async + `send_telegram` 의존
- `cmd_budget` — Telegram 명령 핸들러

## 핵심 디자인 — binding stability (Phase A/B 와 동일)

기존 `_load_budget` 이 `_budget = base` 로 **재할당**했음. `from budget.core import _budget` 한 외부 모듈은 빈 초기 dict 가리킴 → 한도 설정 후 stale.

clear + update 로 변경:

```python
# 전: 재할당 — bot.py 의 binding stale
_budget = base

# 후: in-place — 모든 importer 가 같은 dict 객체 공유
_budget.clear()
_budget.update(base)
```

`captured is _budget` (load 이후) — `test_budget_dict_identity_preserved_through_load` 가 핀.

## 테스트 13종 ([tests/test_bridge_budget.py](tests/test_bridge_budget.py))

**순수 helpers**:
- 기본 shape
- 임계 ladder 순서 (highest-first — 90% 지출 시 80% 가 100% 보다 먼저 발화하면 안 됨)
- `alert_key` 포맷
- `format_alert`: under / over / week 케이스 분기

**영속**:
- save → load 라운드트립 (한도 + alerts_fired 보존)
- 파일 없음 / 깨진 JSON / 부분 스키마 / 잘못된 타입 → 모두 fallback 안전
- `_budget` 객체 identity 가 load 통과 후에도 유지
- `BUDGET_DIR` 없으면 save 시 자동 생성

## 검증

```
$ ruff check .          # All checks passed!
$ pytest -q             # 45 passed in 0.32s  (32 + 13 신규)

$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge | grep '\[budget\]'
2026-05-08 16:25:27 - budget.core - INFO - [budget] loaded day=$None week=$10.0
                       ^^^^^^^^^^^ 새 모듈에서 로드, 이전 영속 데이터 정상 복원
```

영속 데이터 복원 확인됨 — `/app/data/budget.json` 의 `week_limit_usd: 10.0` 이 컨테이너 재생성 후에도 살아있음 ([#76 백업 정책](https://github.com/devyoon91/az-cliproxy-docker/pull/83) 으로 보호 중).

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup gap (P0)
- ✅ #77 CI 부트스트랩 (P1)
- ✅ #81 preflight (P3)
- ✅ #79 Phase A — pricing/cost (P2)
- ✅ #79 Phase B — pricing/usage (P2)
- 🔄 **#79 Phase C — budget/core ← 본 PR**
- ⏳ #79 Phase D (dashboard, task aggregation)
- ⏳ #79 Phase E (az_client, render)
- ⏳ #78 GUIDE 재작성 (P1)
- ⏳ #80 plugin manifest (P3)
- ⏳ #82 docs/plugins.md (P3)

## Test plan

- [x] ruff clean
- [x] 45/45 pytest
- [x] bridge container rebuild + 시작
- [x] 영속 budget.json 데이터 정상 복원 (`week=$10.0`)