### PR TITLE
refactor(bridge): task-JSON 집계 `task_agg/` 분리 + Phase 순서 변경 (#79 Phase D)

### DIFF
--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -10,5 +10,6 @@ RUN pip install --no-cache-dir \
 COPY bot.py .
 COPY pricing/ ./pricing/
 COPY budget/ ./budget/
+COPY task_agg/ ./task_agg/
 
 CMD ["python", "bot.py"]

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -1197,8 +1197,12 @@ async def cmd_backup(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(f"백업 실패: {str(e)}")
 
 
-# ── Task JSON aggregation (issue #1 M2) ──
-TASKS_DIR = "/app/tasks"
+# Task aggregation primitives (TASKS_DIR, _load_task_jsons, _aggregate, …)
+# moved to `task_agg/agg.py` (issue #79 Phase D). Note the package name —
+# we can't call it `tasks/` because docker-compose mounts the AZ task-JSON
+# read-only volume at `/app/tasks`, which would shadow the Python package.
+# Re-export of the names lives below; the constant TASKS_DIR is reachable
+# as `task_agg.agg.TASKS_DIR` for the few places that referenced it directly.
 
 # ── Budget alerts (M5-A · issue #19) ──
 # Persists across restarts via a docker volume mount (/app/data → ./telegram-bridge/data).
@@ -2194,182 +2198,25 @@ async def dashboard_handler(request):
     )
 
 
-def _load_task_jsons() -> list[dict]:
-    """Read every task JSON from the mounted AZ logs dir.
-
-    Returns a list of parsed dicts sorted by `started_at` ascending.
-    Malformed files are skipped silently; they show up in logs once and
-    then get ignored so /today doesn't crash on a single bad file.
-    """
-    if not os.path.isdir(TASKS_DIR):
-        return []
-    items: list[dict] = []
-    for name in os.listdir(TASKS_DIR):
-        if not name.endswith(".json") or name.endswith(".tmp"):
-            continue
-        path = os.path.join(TASKS_DIR, name)
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                items.append(json.load(f))
-        except Exception as e:
-            logger.debug(f"skip bad task json {name}: {e}")
-    items.sort(key=lambda r: r.get("started_at") or "")
-    return items
-
-
-def _aggregate(tasks: list[dict]) -> dict:
-    """Sum totals across a list of tasks, also grouping by model, profile, and status."""
-    agg = {
-        "tasks": len(tasks),
-        "completed": 0,
-        "orphaned": 0,
-        "pending": 0,
-        "tool_calls": 0,
-        "llm_calls": 0,
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "cache_read_tokens": 0,
-        "cache_creation_tokens": 0,
-        "reasoning_tokens": 0,
-        "cost_usd": 0.0,
-        "by_model": {},
-        "by_profile": {},
-    }
-    for t in tasks:
-        reason = t.get("ended_reason", "pending")
-        if reason in agg:
-            agg[reason] += 1
-        totals = t.get("totals") or {}
-        for k in ("tool_calls", "llm_calls", "input_tokens", "output_tokens",
-                  "cache_read_tokens", "cache_creation_tokens",
-                  "reasoning_tokens"):
-            agg[k] += int(totals.get(k, 0) or 0)
-        agg["cost_usd"] += float(totals.get("cost_usd", 0.0) or 0.0)
-
-        # Profile bucket — one task can only have one profile, so we aggregate
-        # the task's own totals (not per-call). Includes tool_calls so the
-        # breakdown can surface which profile is doing the most work, not
-        # just spending the most money.
-        prof = t.get("profile") or "default"
-        pbucket = agg["by_profile"].setdefault(prof, {
-            "tasks": 0, "llm_calls": 0, "tool_calls": 0,
-            "input": 0, "output": 0,
-            "cache_read": 0, "cache_create": 0, "cost": 0.0,
-        })
-        pbucket["tasks"] += 1
-        pbucket["llm_calls"] += int(totals.get("llm_calls", 0) or 0)
-        pbucket["tool_calls"] += int(totals.get("tool_calls", 0) or 0)
-        pbucket["input"] += int(totals.get("input_tokens", 0) or 0)
-        pbucket["output"] += int(totals.get("output_tokens", 0) or 0)
-        pbucket["cache_read"] += int(totals.get("cache_read_tokens", 0) or 0)
-        pbucket["cache_create"] += int(totals.get("cache_creation_tokens", 0) or 0)
-        pbucket["cost"] += float(totals.get("cost_usd", 0.0) or 0.0)
-
-        for c in t.get("llm_calls") or []:
-            m = c.get("model") or "unknown"
-            bucket = agg["by_model"].setdefault(m, {
-                "calls": 0, "input": 0, "output": 0,
-                "cache_read": 0, "cache_create": 0, "cost": 0.0,
-            })
-            bucket["calls"] += 1
-            bucket["input"] += int(c.get("input_tokens", 0) or 0)
-            bucket["output"] += int(c.get("output_tokens", 0) or 0)
-            bucket["cache_read"] += int(c.get("cache_read_tokens", 0) or 0)
-            bucket["cache_create"] += int(c.get("cache_creation_tokens", 0) or 0)
-            bucket["cost"] += float(c.get("cost_usd", 0.0) or 0.0)
-    agg["cost_usd"] = round(agg["cost_usd"], 6)
-    return agg
-
-
-def _is_anthropic_model(model: str) -> bool:
-    """Anthropic models get prompt caching; others (OpenAI, etc.) don't —
-    so cache hit-ratio and `cache_saved_usd` should only count Anthropic
-    rows. Match on "claude" substring plus the explicit anthropic/ prefix,
-    which is broad enough to catch Sonnet/Haiku/Opus variants we use now
-    without hand-maintaining a whitelist."""
-    if not isinstance(model, str):
-        return False
-    m = model.lower()
-    return m.startswith("anthropic/") or "claude" in m
-
-
-def _cache_efficiency(agg: dict) -> dict | None:
-    """Compute Anthropic prompt-cache efficiency from an aggregate.
-
-    Returns `None` when there's no Anthropic traffic in the window —
-    the caller should skip rendering the cache line entirely in that case.
-
-    Fields:
-      anthropic_calls      — number of llm_calls against Anthropic models
-      input_tokens         — sum of prompt_tokens on Anthropic calls
-      cache_read_tokens    — sum of cache_read on Anthropic calls
-      cache_creation       — sum of cache_creation on Anthropic calls
-      hit_ratio            — cache_read / (input + cache_read)
-                             (0..1; None if denominator is 0)
-      saved_usd            — Σ cache_read × (input_rate − cache_read_rate)
-                             per model, using the live LiteLLM price table
-
-    Ratio interpretation (from issue #22):
-      ≥0.70  ✅ healthy cache reuse
-      0.40..0.70  ⚠️ prompt likely drifting between calls
-      <0.40  🚨 cache busted (system prompt / tool schema changing)
-    """
-    anthropic_calls = 0
-    total_input = 0
-    total_cache_read = 0
-    total_cache_create = 0
-    saved = 0.0
-    for model, b in (agg.get("by_model") or {}).items():
-        if not _is_anthropic_model(model):
-            continue
-        anthropic_calls += b["calls"]
-        total_input += b["input"]
-        total_cache_read += b["cache_read"]
-        total_cache_create += b["cache_create"]
-        if b["cache_read"] > 0:
-            info = _model_info(model)
-            in_rate = info.get("input_cost_per_token", 0.000003)
-            read_rate = info.get("cache_read_input_token_cost", in_rate * 0.10)
-            # What we WOULD have paid at full input rate minus what we DID
-            # pay at cache-read rate = the caching savings for this model.
-            saved += b["cache_read"] * max(in_rate - read_rate, 0.0)
-    if anthropic_calls == 0:
-        return None
-    denom = total_input + total_cache_read
-    hit_ratio = (total_cache_read / denom) if denom > 0 else None
-    return {
-        "anthropic_calls": anthropic_calls,
-        "input_tokens": total_input,
-        "cache_read_tokens": total_cache_read,
-        "cache_creation_tokens": total_cache_create,
-        "hit_ratio": hit_ratio,
-        "saved_usd": saved,
-    }
-
-
-def _format_cache_line(ce: dict) -> str:
-    """One-line cache efficiency summary, Telegram-friendly.
-
-    Shape: `🧠 캐시: 78% ✅ (117k/150k read · 절감 $2.81)`
-    """
-    ratio = ce.get("hit_ratio")
-    if ratio is None:
-        emoji = "❔"
-        ratio_str = "N/A"
-    else:
-        if ratio >= 0.70:
-            emoji = "✅"
-        elif ratio >= 0.40:
-            emoji = "⚠️"
-        else:
-            emoji = "🚨"
-        ratio_str = f"{ratio * 100:.0f}%"
-    read_k = ce["cache_read_tokens"] / 1000.0
-    denom_k = (ce["input_tokens"] + ce["cache_read_tokens"]) / 1000.0
-    return (
-        f"🧠 캐시: {ratio_str} {emoji} "
-        f"({read_k:.0f}k/{denom_k:.0f}k read · 절감 ${ce['saved_usd']:.4f})"
-    )
+# Task-JSON load + aggregate + format primitives moved to `tasks/agg.py`
+# (issue #79 Phase D — pivoted ahead of dashboard so dashboard's
+# `_build_stats` and budget's `_compute_window_cost` can both consume
+# from a single source). Re-exported here so existing callers (cmd_today,
+# cmd_week, cmd_tasks, daily_usage_reporter, _build_stats,
+# _compute_window_cost) keep working without prefix changes.
+from task_agg.agg import (  # noqa: F401  (re-export)
+    _aggregate,
+    _cache_efficiency,
+    _data_quality_summary,
+    _filter_date_range,
+    _format_agg_block,
+    _format_cache_line,
+    _format_model_breakdown,
+    _format_profile_breakdown,
+    _is_anthropic_model,
+    _load_task_jsons,
+    _quality_banner,
+)
 
 
 def _parse_by_flag(args) -> str | None:
@@ -2393,160 +2240,6 @@ def _parse_by_flag(args) -> str | None:
     if a in ("by:profile", "profile", "by:profiles", "profiles"):
         return "profile"
     return None
-
-
-def _format_model_breakdown(agg: dict, *, title: str = "모델별") -> list[str]:
-    """Detailed model table — used by `/today by:model` and `/week by:model`.
-
-    Includes zero-cost rows (call count only) per issue #20 acceptance.
-    """
-    by_model = agg.get("by_model") or {}
-    if not by_model:
-        return [f"🤖 {title}: (데이터 없음)"]
-    lines = [f"🤖 {title}:"]
-    # Sort by cost desc, secondary by call count so free models don't jumble.
-    for model, b in sorted(
-        by_model.items(),
-        key=lambda kv: (kv[1]["cost"], kv[1]["calls"]),
-        reverse=True,
-    ):
-        cache = (
-            f" | cache r:{b['cache_read']:,} c:{b['cache_create']:,}"
-            if (b["cache_read"] or b["cache_create"]) else ""
-        )
-        lines.append(
-            f"  • {model}: {b['calls']}× "
-            f"in {b['input']:,} out {b['output']:,}{cache} → ${b['cost']:.4f}"
-        )
-    return lines
-
-
-def _format_profile_breakdown(agg: dict, *, title: str = "프로파일별") -> list[str]:
-    """Detailed profile table — used by `/today by:profile` / `/week by:profile`.
-
-    Profile-level aggregates task counts, tools, and LLM calls in addition
-    to cost — profiles differ by agent behavior, so tool volume is often
-    the more informative signal than raw cost.
-    """
-    by_profile = agg.get("by_profile") or {}
-    if not by_profile:
-        return [f"👤 {title}: (데이터 없음)"]
-    lines = [f"👤 {title}:"]
-    for prof, b in sorted(
-        by_profile.items(),
-        key=lambda kv: (kv[1]["cost"], kv[1]["tasks"]),
-        reverse=True,
-    ):
-        lines.append(
-            f"  • {prof}: {b['tasks']}태스크 · "
-            f"LLM {b['llm_calls']} · 도구 {b['tool_calls']} "
-            f"→ ${b['cost']:.4f}"
-        )
-    return lines
-
-
-def _filter_date_range(tasks: list[dict], start, end) -> list[dict]:
-    """Filter tasks whose `started_at` (ISO, UTC) falls in [start, end).
-
-    `start` and `end` are naive `datetime` objects treated as **KST wall clock**.
-    AZ writes started_at in UTC with +00:00 offset; we convert each task's
-    UTC instant to KST before comparing, so "today" means "today in KST"
-    regardless of the container OS timezone.
-    """
-    out = []
-    for t in tasks:
-        started = t.get("started_at")
-        if not started:
-            continue
-        try:
-            # fromisoformat handles "+00:00"
-            ts = datetime.fromisoformat(started)
-        except Exception:
-            continue
-        # Normalize to KST wall-clock for date-boundary comparison.
-        if ts.tzinfo:
-            ts_local = ts.astimezone(KST).replace(tzinfo=None)
-        else:
-            ts_local = ts  # assume caller already passed KST-naive
-        if start <= ts_local < end:
-            out.append(t)
-    return out
-
-
-def _data_quality_summary(tasks: list[dict]) -> dict:
-    """Scan a task list for known observability gaps (M1/M2/M3 evolution).
-
-    These gaps mean the per-task cost / token numbers drift from Anthropic
-    Console reality. We surface the counts in /today and /week so the user
-    knows when to trust the number.
-
-    Returns:
-        {
-          "total":       total tasks in window,
-          "legacy_cost": tasks without totals.cost_usd (pre-M3 schema),
-          "approximate": tasks with any approximate-token LLM call (pre-M2 str
-                         response bug),
-        }
-    """
-    legacy_cost = 0
-    approximate = 0
-    for t in tasks:
-        totals = t.get("totals") or {}
-        if "cost_usd" not in totals:
-            legacy_cost += 1
-        for c in t.get("llm_calls") or []:
-            if c.get("tokens_approximate"):
-                approximate += 1
-                break
-    return {
-        "total": len(tasks),
-        "legacy_cost": legacy_cost,
-        "approximate": approximate,
-    }
-
-
-def _quality_banner(dq: dict) -> str | None:
-    """Return a one-line caveat if any data quality gap is present, else None."""
-    if dq["legacy_cost"] == 0 and dq["approximate"] == 0:
-        return None
-    parts = []
-    if dq["legacy_cost"]:
-        parts.append(f"M3 이전 {dq['legacy_cost']}건")
-    if dq["approximate"]:
-        parts.append(f"근사 토큰 {dq['approximate']}건")
-    return (
-        "⚠️ 신뢰도: " + " / ".join(parts)
-        + " — Anthropic 대시보드와 차이 있을 수 있음"
-    )
-
-
-def _format_agg_block(title: str, agg: dict) -> list[str]:
-    """Render an aggregate dict as a Telegram-friendly block."""
-    lines = [
-        f"📊 {title}",
-        f"  태스크: {agg['tasks']}건 "
-        f"(✅{agg['completed']} ⚠️{agg['orphaned']} ⏳{agg['pending']})",
-    ]
-    if agg["tasks"] == 0:
-        return lines
-    lines.append(
-        f"  LLM 호출: {agg['llm_calls']}건 · 도구: {agg['tool_calls']}건"
-    )
-    lines.append(
-        f"  토큰: in {agg['input_tokens']:,} · out {agg['output_tokens']:,}"
-    )
-    if agg["cache_read_tokens"] or agg["cache_creation_tokens"]:
-        lines.append(
-            f"  캐시: read {agg['cache_read_tokens']:,} · "
-            f"create {agg['cache_creation_tokens']:,}"
-        )
-    rt = agg.get("reasoning_tokens", 0)
-    if rt:
-        # Reasoning / extended-thinking tokens — already folded into cost
-        # via output rate, shown separately so the breakdown is honest.
-        lines.append(f"  사고 토큰: {rt:,} (출력 요율 청구)")
-    lines.append(f"  💰 ${agg['cost_usd']:.4f}")
-    return lines
 
 
 async def cmd_today(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/telegram-bridge/task_agg/__init__.py
+++ b/telegram-bridge/task_agg/__init__.py
@@ -1,0 +1,53 @@
+"""Task-JSON aggregation — Phase D carve from bot.py (issue #79).
+
+Reads agent-zero/logs/tasks/*.json (mounted at /app/tasks) and turns
+them into windowed aggregates that drive `/today`, `/week`, `/tasks`,
+the bridge web dashboard's `_build_stats`, and the budget engine's
+`_compute_window_cost`. All four were duplicating roughly the same
+load → filter → aggregate pipeline before this carve, with subtle
+divergence risk (the `daily_usage_reporter` even reached straight
+into `usage_today` and would miss in-progress tasks). Single source of
+truth now lives here.
+
+Package name is `task_agg`, not `tasks`, because docker-compose mounts
+the read-only AZ task-JSON volume at `/app/tasks` — naming a Python
+package `tasks/` had the bind-mount silently shadow our code at
+runtime, and the bridge crashed at module load with
+`ModuleNotFoundError: No module named 'tasks.agg'` even though the
+files were in the image. `task_agg` is short for "task aggregation
+primitives" and avoids the collision.
+"""
+
+from .agg import (
+    KST,
+    TASKS_DIR,
+    _aggregate,
+    _cache_efficiency,
+    _data_quality_summary,
+    _filter_date_range,
+    _format_agg_block,
+    _format_cache_line,
+    _format_model_breakdown,
+    _format_profile_breakdown,
+    _is_anthropic_model,
+    _kst_now,
+    _load_task_jsons,
+    _quality_banner,
+)
+
+__all__ = [
+    "KST",
+    "TASKS_DIR",
+    "_aggregate",
+    "_cache_efficiency",
+    "_data_quality_summary",
+    "_filter_date_range",
+    "_format_agg_block",
+    "_format_cache_line",
+    "_format_model_breakdown",
+    "_format_profile_breakdown",
+    "_is_anthropic_model",
+    "_kst_now",
+    "_load_task_jsons",
+    "_quality_banner",
+]

--- a/telegram-bridge/task_agg/agg.py
+++ b/telegram-bridge/task_agg/agg.py
@@ -1,0 +1,388 @@
+"""Task-JSON load + aggregate + format primitives.
+
+Phase D carve from bot.py (issue #79). All callers (`/today`, `/week`,
+`/tasks`, dashboard `_build_stats`, budget `_compute_window_cost`) now
+funnel through this module so windowed numbers stay consistent.
+
+What's here:
+
+- `_load_task_jsons()` — read every `.json` under TASKS_DIR, sorted.
+- `_filter_date_range(tasks, start, end)` — KST wall-clock filter.
+- `_aggregate(tasks)` — sum totals + group by model + group by profile.
+- `_is_anthropic_model(model)` / `_cache_efficiency(agg)` /
+  `_format_cache_line(ce)` — Anthropic prompt-cache reporting.
+- `_format_model_breakdown` / `_format_profile_breakdown` /
+  `_format_agg_block` — Telegram-friendly text renders.
+- `_data_quality_summary` / `_quality_banner` — observability gap warnings.
+- `KST` + `_kst_now()` — time helpers used by aggregation. Currently
+  duplicated with `pricing/usage.py` (Phase B). When carve-out
+  stabilizes, dedupe via a `timeutil.py` shared by both — leaving the
+  duplication for now to keep this PR focused.
+
+What's NOT here (lives in bot.py for now):
+- `_parse_by_flag` — Telegram command-arg parser, not aggregation.
+- `cmd_today` / `cmd_week` / `cmd_tasks` — Telegram handlers.
+- The dashboard's `_build_stats` and the budget's `_compute_window_cost`
+  CALL into here but stay in bot.py because they own HTTP / async-
+  alerting concerns. Likely move in Phase E when their callers move.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from pricing.cost import _model_info
+
+logger = logging.getLogger(__name__)
+
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def _kst_now() -> datetime:
+    """Return current naive KST wall-clock time.
+
+    Naive on purpose: the existing `_filter_date_range` comparison logic
+    was written against naive datetimes treated as KST wall clock. Going
+    aware here would require updating every call site. Mirrored in
+    `pricing/usage.py` for the same reason — see Phase B notes.
+    """
+    return datetime.now(KST).replace(tzinfo=None)
+
+
+# Mounted from `agent-zero/logs/tasks/` per docker-compose.yml. Kept as a
+# module-level binding so tests can monkeypatch it onto a tmp dir.
+TASKS_DIR = "/app/tasks"
+
+
+def _load_task_jsons() -> list[dict]:
+    """Read every task JSON from the mounted AZ logs dir.
+
+    Returns a list of parsed dicts sorted by `started_at` ascending.
+    Malformed files are skipped silently; they show up in logs once and
+    then get ignored so /today doesn't crash on a single bad file.
+    """
+    if not os.path.isdir(TASKS_DIR):
+        return []
+    items: list[dict] = []
+    for name in os.listdir(TASKS_DIR):
+        if not name.endswith(".json") or name.endswith(".tmp"):
+            continue
+        path = os.path.join(TASKS_DIR, name)
+        try:
+            with open(path, encoding="utf-8") as f:
+                items.append(json.load(f))
+        except Exception as e:
+            logger.debug(f"skip bad task json {name}: {e}")
+    items.sort(key=lambda r: r.get("started_at") or "")
+    return items
+
+
+def _filter_date_range(tasks: list[dict], start, end) -> list[dict]:
+    """Filter tasks whose `started_at` (ISO, UTC) falls in [start, end).
+
+    `start` and `end` are naive `datetime` objects treated as **KST wall clock**.
+    AZ writes started_at in UTC with +00:00 offset; we convert each task's
+    UTC instant to KST before comparing, so "today" means "today in KST"
+    regardless of the container OS timezone.
+    """
+    out = []
+    for t in tasks:
+        started = t.get("started_at")
+        if not started:
+            continue
+        try:
+            ts = datetime.fromisoformat(started)
+        except Exception:
+            continue
+        if ts.tzinfo:
+            ts_local = ts.astimezone(KST).replace(tzinfo=None)
+        else:
+            ts_local = ts
+        if start <= ts_local < end:
+            out.append(t)
+    return out
+
+
+def _aggregate(tasks: list[dict]) -> dict:
+    """Sum totals across a list of tasks, also grouping by model, profile, and status."""
+    agg = {
+        "tasks": len(tasks),
+        "completed": 0,
+        "orphaned": 0,
+        "pending": 0,
+        "tool_calls": 0,
+        "llm_calls": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "reasoning_tokens": 0,
+        "cost_usd": 0.0,
+        "by_model": {},
+        "by_profile": {},
+    }
+    for t in tasks:
+        reason = t.get("ended_reason", "pending")
+        if reason in agg:
+            agg[reason] += 1
+        totals = t.get("totals") or {}
+        for k in ("tool_calls", "llm_calls", "input_tokens", "output_tokens",
+                  "cache_read_tokens", "cache_creation_tokens",
+                  "reasoning_tokens"):
+            agg[k] += int(totals.get(k, 0) or 0)
+        agg["cost_usd"] += float(totals.get("cost_usd", 0.0) or 0.0)
+
+        # Profile bucket — one task can only have one profile, so we aggregate
+        # the task's own totals (not per-call). Includes tool_calls so the
+        # breakdown can surface which profile is doing the most work, not
+        # just spending the most money.
+        prof = t.get("profile") or "default"
+        pbucket = agg["by_profile"].setdefault(prof, {
+            "tasks": 0, "llm_calls": 0, "tool_calls": 0,
+            "input": 0, "output": 0,
+            "cache_read": 0, "cache_create": 0, "cost": 0.0,
+        })
+        pbucket["tasks"] += 1
+        pbucket["llm_calls"] += int(totals.get("llm_calls", 0) or 0)
+        pbucket["tool_calls"] += int(totals.get("tool_calls", 0) or 0)
+        pbucket["input"] += int(totals.get("input_tokens", 0) or 0)
+        pbucket["output"] += int(totals.get("output_tokens", 0) or 0)
+        pbucket["cache_read"] += int(totals.get("cache_read_tokens", 0) or 0)
+        pbucket["cache_create"] += int(totals.get("cache_creation_tokens", 0) or 0)
+        pbucket["cost"] += float(totals.get("cost_usd", 0.0) or 0.0)
+
+        for c in t.get("llm_calls") or []:
+            m = c.get("model") or "unknown"
+            bucket = agg["by_model"].setdefault(m, {
+                "calls": 0, "input": 0, "output": 0,
+                "cache_read": 0, "cache_create": 0, "cost": 0.0,
+            })
+            bucket["calls"] += 1
+            bucket["input"] += int(c.get("input_tokens", 0) or 0)
+            bucket["output"] += int(c.get("output_tokens", 0) or 0)
+            bucket["cache_read"] += int(c.get("cache_read_tokens", 0) or 0)
+            bucket["cache_create"] += int(c.get("cache_creation_tokens", 0) or 0)
+            bucket["cost"] += float(c.get("cost_usd", 0.0) or 0.0)
+    agg["cost_usd"] = round(agg["cost_usd"], 6)
+    return agg
+
+
+def _is_anthropic_model(model: str) -> bool:
+    """Anthropic models get prompt caching; others (OpenAI, etc.) don't —
+    so cache hit-ratio and `cache_saved_usd` should only count Anthropic
+    rows. Match on "claude" substring plus the explicit anthropic/ prefix,
+    which is broad enough to catch Sonnet/Haiku/Opus variants we use now
+    without hand-maintaining a whitelist."""
+    if not isinstance(model, str):
+        return False
+    m = model.lower()
+    return m.startswith("anthropic/") or "claude" in m
+
+
+def _cache_efficiency(agg: dict) -> dict | None:
+    """Compute Anthropic prompt-cache efficiency from an aggregate.
+
+    Returns `None` when there's no Anthropic traffic in the window —
+    the caller should skip rendering the cache line entirely in that case.
+
+    Fields:
+      anthropic_calls      — number of llm_calls against Anthropic models
+      input_tokens         — sum of prompt_tokens on Anthropic calls
+      cache_read_tokens    — sum of cache_read on Anthropic calls
+      cache_creation       — sum of cache_creation on Anthropic calls
+      hit_ratio            — cache_read / (input + cache_read)
+                             (0..1; None if denominator is 0)
+      saved_usd            — Σ cache_read × (input_rate − cache_read_rate)
+                             per model, using the live LiteLLM price table
+
+    Ratio interpretation (from issue #22):
+      ≥0.70  ✅ healthy cache reuse
+      0.40..0.70  ⚠️ prompt likely drifting between calls
+      <0.40  🚨 cache busted (system prompt / tool schema changing)
+    """
+    anthropic_calls = 0
+    total_input = 0
+    total_cache_read = 0
+    total_cache_create = 0
+    saved = 0.0
+    for model, b in (agg.get("by_model") or {}).items():
+        if not _is_anthropic_model(model):
+            continue
+        anthropic_calls += b["calls"]
+        total_input += b["input"]
+        total_cache_read += b["cache_read"]
+        total_cache_create += b["cache_create"]
+        if b["cache_read"] > 0:
+            info = _model_info(model)
+            in_rate = info.get("input_cost_per_token", 0.000003)
+            read_rate = info.get("cache_read_input_token_cost", in_rate * 0.10)
+            # What we WOULD have paid at full input rate minus what we DID
+            # pay at cache-read rate = the caching savings for this model.
+            saved += b["cache_read"] * max(in_rate - read_rate, 0.0)
+    if anthropic_calls == 0:
+        return None
+    denom = total_input + total_cache_read
+    hit_ratio = (total_cache_read / denom) if denom > 0 else None
+    return {
+        "anthropic_calls": anthropic_calls,
+        "input_tokens": total_input,
+        "cache_read_tokens": total_cache_read,
+        "cache_creation_tokens": total_cache_create,
+        "hit_ratio": hit_ratio,
+        "saved_usd": saved,
+    }
+
+
+def _format_cache_line(ce: dict) -> str:
+    """One-line cache efficiency summary, Telegram-friendly.
+
+    Shape: `🧠 캐시: 78% ✅ (117k/150k read · 절감 $2.81)`
+    """
+    ratio = ce.get("hit_ratio")
+    if ratio is None:
+        emoji = "❔"
+        ratio_str = "N/A"
+    else:
+        if ratio >= 0.70:
+            emoji = "✅"
+        elif ratio >= 0.40:
+            emoji = "⚠️"
+        else:
+            emoji = "🚨"
+        ratio_str = f"{ratio * 100:.0f}%"
+    read_k = ce["cache_read_tokens"] / 1000.0
+    denom_k = (ce["input_tokens"] + ce["cache_read_tokens"]) / 1000.0
+    return (
+        f"🧠 캐시: {ratio_str} {emoji} "
+        f"({read_k:.0f}k/{denom_k:.0f}k read · 절감 ${ce['saved_usd']:.4f})"
+    )
+
+
+def _format_model_breakdown(agg: dict, *, title: str = "모델별") -> list[str]:
+    """Detailed model table — used by `/today by:model` and `/week by:model`.
+
+    Includes zero-cost rows (call count only) per issue #20 acceptance.
+    """
+    by_model = agg.get("by_model") or {}
+    if not by_model:
+        return [f"🤖 {title}: (데이터 없음)"]
+    lines = [f"🤖 {title}:"]
+    # Sort by cost desc, secondary by call count so free models don't jumble.
+    for model, b in sorted(
+        by_model.items(),
+        key=lambda kv: (kv[1]["cost"], kv[1]["calls"]),
+        reverse=True,
+    ):
+        cache = (
+            f" | cache r:{b['cache_read']:,} c:{b['cache_create']:,}"
+            if (b["cache_read"] or b["cache_create"]) else ""
+        )
+        lines.append(
+            f"  • {model}: {b['calls']}× "
+            f"in {b['input']:,} out {b['output']:,}{cache} → ${b['cost']:.4f}"
+        )
+    return lines
+
+
+def _format_profile_breakdown(agg: dict, *, title: str = "프로파일별") -> list[str]:
+    """Detailed profile table — used by `/today by:profile` / `/week by:profile`.
+
+    Profile-level aggregates task counts, tools, and LLM calls in addition
+    to cost — profiles differ by agent behavior, so tool volume is often
+    the more informative signal than raw cost.
+    """
+    by_profile = agg.get("by_profile") or {}
+    if not by_profile:
+        return [f"👤 {title}: (데이터 없음)"]
+    lines = [f"👤 {title}:"]
+    for prof, b in sorted(
+        by_profile.items(),
+        key=lambda kv: (kv[1]["cost"], kv[1]["tasks"]),
+        reverse=True,
+    ):
+        lines.append(
+            f"  • {prof}: {b['tasks']}태스크 · "
+            f"LLM {b['llm_calls']} · 도구 {b['tool_calls']} "
+            f"→ ${b['cost']:.4f}"
+        )
+    return lines
+
+
+def _data_quality_summary(tasks: list[dict]) -> dict:
+    """Scan a task list for known observability gaps (M1/M2/M3 evolution).
+
+    These gaps mean the per-task cost / token numbers drift from Anthropic
+    Console reality. We surface the counts in /today and /week so the user
+    knows when to trust the number.
+
+    Returns:
+        {
+          "total":       total tasks in window,
+          "legacy_cost": tasks without totals.cost_usd (pre-M3 schema),
+          "approximate": tasks with any approximate-token LLM call (pre-M2 str
+                         response bug),
+        }
+    """
+    legacy_cost = 0
+    approximate = 0
+    for t in tasks:
+        totals = t.get("totals") or {}
+        if "cost_usd" not in totals:
+            legacy_cost += 1
+        for c in t.get("llm_calls") or []:
+            if c.get("tokens_approximate"):
+                approximate += 1
+                break
+    return {
+        "total": len(tasks),
+        "legacy_cost": legacy_cost,
+        "approximate": approximate,
+    }
+
+
+def _quality_banner(dq: dict) -> str | None:
+    """Return a one-line caveat if any data quality gap is present, else None."""
+    if dq["legacy_cost"] == 0 and dq["approximate"] == 0:
+        return None
+    parts = []
+    if dq["legacy_cost"]:
+        parts.append(f"M3 이전 {dq['legacy_cost']}건")
+    if dq["approximate"]:
+        parts.append(f"근사 토큰 {dq['approximate']}건")
+    return (
+        "⚠️ 신뢰도: " + " / ".join(parts)
+        + " — Anthropic 대시보드와 차이 있을 수 있음"
+    )
+
+
+def _format_agg_block(title: str, agg: dict) -> list[str]:
+    """Render an aggregate dict as a Telegram-friendly block."""
+    lines = [
+        f"📊 {title}",
+        f"  태스크: {agg['tasks']}건 "
+        f"(✅{agg['completed']} ⚠️{agg['orphaned']} ⏳{agg['pending']})",
+    ]
+    if agg["tasks"] == 0:
+        return lines
+    lines.append(
+        f"  LLM 호출: {agg['llm_calls']}건 · 도구: {agg['tool_calls']}건"
+    )
+    lines.append(
+        f"  토큰: in {agg['input_tokens']:,} · out {agg['output_tokens']:,}"
+    )
+    if agg["cache_read_tokens"] or agg["cache_creation_tokens"]:
+        lines.append(
+            f"  캐시: read {agg['cache_read_tokens']:,} · "
+            f"create {agg['cache_creation_tokens']:,}"
+        )
+    rt = agg.get("reasoning_tokens", 0)
+    if rt:
+        # Reasoning / extended-thinking tokens — already folded into cost
+        # via output rate, shown separately so the breakdown is honest.
+        lines.append(f"  사고 토큰: {rt:,} (출력 요율 청구)")
+    lines.append(f"  💰 ${agg['cost_usd']:.4f}")
+    return lines

--- a/tests/test_bridge_tasks_agg.py
+++ b/tests/test_bridge_tasks_agg.py
@@ -1,0 +1,303 @@
+"""Pin telegram-bridge/tasks/agg.py — Phase D carve.
+
+These primitives feed `/today`, `/week`, `/tasks`, the dashboard's
+`_build_stats`, and the budget engine's `_compute_window_cost`. A drift
+between any two callers used to mean `/today` and the dashboard would
+disagree — single source of truth now lives in agg.py and pinning it
+catches regressions before they show up as user-visible inconsistency.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+_TASKS_DIR_FILE = (
+    Path(__file__).resolve().parent.parent / "telegram-bridge" / "task_agg" / "agg.py"
+)
+_PRICING_DIR = (
+    Path(__file__).resolve().parent.parent / "telegram-bridge" / "pricing"
+)
+
+
+def _load_agg_module(tmp_path):
+    """Spec-load `tasks.agg` after wiring up its `pricing.cost` dependency.
+
+    Same trick as `test_bridge_usage` and `test_bridge_budget`: register
+    the package in sys.modules under a unique name so relative imports
+    inside agg.py (`from pricing.cost import _model_info`) resolve.
+    """
+    # pricing.cost first — agg.py imports from it.
+    pricing_pkg = types.ModuleType("pricing")
+    pricing_pkg.__path__ = [str(_PRICING_DIR)]  # type: ignore[attr-defined]
+    sys.modules["pricing"] = pricing_pkg
+
+    cost_spec = importlib.util.spec_from_file_location(
+        "pricing.cost", _PRICING_DIR / "cost.py"
+    )
+    assert cost_spec and cost_spec.loader
+    cost_mod = importlib.util.module_from_spec(cost_spec)
+    sys.modules["pricing.cost"] = cost_mod
+    cost_spec.loader.exec_module(cost_mod)
+
+    # Now tasks.agg.
+    tasks_pkg = types.ModuleType("task_agg")
+    tasks_pkg.__path__ = [str(_TASKS_DIR_FILE.parent)]  # type: ignore[attr-defined]
+    sys.modules["task_agg"] = tasks_pkg
+
+    spec = importlib.util.spec_from_file_location("task_agg.agg", _TASKS_DIR_FILE)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["task_agg.agg"] = mod
+    spec.loader.exec_module(mod)
+
+    # Redirect TASKS_DIR for IO tests.
+    mod.TASKS_DIR = str(tmp_path)
+    return mod
+
+
+@pytest.fixture
+def agg(tmp_path):
+    return _load_agg_module(tmp_path)
+
+
+def _write_task(tmp_path: Path, task_id: str, started_at: str, payload: dict) -> None:
+    payload = {"task_id": task_id, "started_at": started_at, **payload}
+    (tmp_path / f"{task_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ── _aggregate ─────────────────────────────────────────────────────────
+
+
+def test_aggregate_empty(agg):
+    out = agg._aggregate([])
+    assert out["tasks"] == 0
+    assert out["cost_usd"] == 0.0
+    assert out["by_model"] == {}
+    assert out["by_profile"] == {}
+
+
+def test_aggregate_single_task(agg):
+    task = {
+        "task_id": "t1",
+        "ended_reason": "completed",
+        "profile": "ecs-lead",
+        "totals": {
+            "tool_calls": 3, "llm_calls": 4,
+            "input_tokens": 1000, "output_tokens": 200,
+            "cache_read_tokens": 800, "cache_creation_tokens": 100,
+            "reasoning_tokens": 50,
+            "cost_usd": 0.12,
+        },
+        "llm_calls": [
+            {"model": "claude-sonnet-4-5", "input_tokens": 800, "output_tokens": 150,
+             "cache_read_tokens": 700, "cache_creation_tokens": 100, "cost_usd": 0.10},
+            {"model": "claude-haiku-4-5", "input_tokens": 200, "output_tokens": 50,
+             "cache_read_tokens": 100, "cache_creation_tokens": 0, "cost_usd": 0.02},
+        ],
+    }
+    out = agg._aggregate([task])
+    assert out["tasks"] == 1
+    assert out["completed"] == 1
+    assert out["llm_calls"] == 4
+    assert out["cost_usd"] == pytest.approx(0.12)
+    assert out["reasoning_tokens"] == 50
+    # by_model populated by per-call iteration (note llm_calls list, not totals)
+    assert set(out["by_model"].keys()) == {"claude-sonnet-4-5", "claude-haiku-4-5"}
+    assert out["by_model"]["claude-sonnet-4-5"]["calls"] == 1
+    # by_profile aggregated from totals
+    assert "ecs-lead" in out["by_profile"]
+    assert out["by_profile"]["ecs-lead"]["tool_calls"] == 3
+
+
+def test_aggregate_status_buckets(agg):
+    tasks = [
+        {"ended_reason": "completed", "totals": {}, "llm_calls": []},
+        {"ended_reason": "completed", "totals": {}, "llm_calls": []},
+        {"ended_reason": "orphaned", "totals": {}, "llm_calls": []},
+        {"ended_reason": "pending", "totals": {}, "llm_calls": []},
+    ]
+    out = agg._aggregate(tasks)
+    assert out["completed"] == 2
+    assert out["orphaned"] == 1
+    assert out["pending"] == 1
+
+
+# ── _filter_date_range ─────────────────────────────────────────────────
+
+
+def test_filter_date_range_inclusive_start_exclusive_end(agg):
+    """Start-inclusive, end-exclusive — pinned because date-range bugs are
+    classic and silently miss the boundary task."""
+    tasks = [
+        {"task_id": "before", "started_at": "2026-05-07T23:59:59+00:00"},
+        {"task_id": "start", "started_at": "2026-05-08T00:00:00+00:00"},
+        {"task_id": "during", "started_at": "2026-05-08T12:30:00+00:00"},
+        {"task_id": "edge_end", "started_at": "2026-05-09T00:00:00+00:00"},
+        {"task_id": "after", "started_at": "2026-05-09T00:00:01+00:00"},
+    ]
+    # Window: 2026-05-08 09:00 KST → 2026-05-09 09:00 KST (a "day" in KST)
+    # 2026-05-08T00:00:00+00:00 → 09:00 KST → AT the start, included.
+    # 2026-05-09T00:00:00+00:00 → 09:00 KST → AT end (exclusive), excluded.
+    start = datetime(2026, 5, 8, 9, 0)
+    end = datetime(2026, 5, 9, 9, 0)
+    ids = [t["task_id"] for t in agg._filter_date_range(tasks, start, end)]
+    assert "before" not in ids
+    assert "start" in ids
+    assert "during" in ids
+    assert "edge_end" not in ids  # exclusive end
+    assert "after" not in ids
+
+
+def test_filter_date_range_drops_no_started_at(agg):
+    tasks = [
+        {"task_id": "ok", "started_at": "2026-05-08T12:00:00+00:00"},
+        {"task_id": "missing"},
+        {"task_id": "junk", "started_at": "this is not a timestamp"},
+    ]
+    out = agg._filter_date_range(tasks, datetime(2026, 1, 1), datetime(2027, 1, 1))
+    ids = [t["task_id"] for t in out]
+    assert ids == ["ok"]
+
+
+# ── _is_anthropic_model ────────────────────────────────────────────────
+
+
+def test_is_anthropic_model(agg):
+    assert agg._is_anthropic_model("claude-sonnet-4-5") is True
+    assert agg._is_anthropic_model("anthropic/claude-haiku-4-5") is True
+    assert agg._is_anthropic_model("Claude-Sonnet-4-5") is True  # case-insensitive
+    assert agg._is_anthropic_model("gpt-4o") is False
+    assert agg._is_anthropic_model("") is False
+    assert agg._is_anthropic_model(None) is False  # type: ignore[arg-type]
+
+
+# ── _cache_efficiency ──────────────────────────────────────────────────
+
+
+def test_cache_efficiency_no_anthropic_returns_none(agg):
+    a = {"by_model": {"gpt-4o": {"calls": 1, "input": 100, "cache_read": 0,
+                                  "cache_create": 0, "output": 50, "cost": 0.1}}}
+    assert agg._cache_efficiency(a) is None
+
+
+def test_cache_efficiency_hit_ratio_math(agg):
+    a = {"by_model": {
+        "claude-sonnet-4-5": {"calls": 10, "input": 100_000, "cache_read": 700_000,
+                              "cache_create": 50_000, "output": 5_000, "cost": 1.0},
+    }}
+    ce = agg._cache_efficiency(a)
+    assert ce is not None
+    assert ce["anthropic_calls"] == 10
+    # hit_ratio = 700k / (100k + 700k) = 0.875
+    assert ce["hit_ratio"] == pytest.approx(0.875)
+
+
+# ── _format_cache_line ─────────────────────────────────────────────────
+
+
+def test_format_cache_line_emoji_branches(agg):
+    base = {"input_tokens": 100, "cache_read_tokens": 100, "saved_usd": 0.5}
+    # Healthy
+    healthy = agg._format_cache_line({**base, "hit_ratio": 0.85})
+    assert "✅" in healthy
+    # Warning
+    warning = agg._format_cache_line({**base, "hit_ratio": 0.55})
+    assert "⚠️" in warning
+    # Busted
+    busted = agg._format_cache_line({**base, "hit_ratio": 0.20})
+    assert "🚨" in busted
+    # No data
+    none = agg._format_cache_line({**base, "hit_ratio": None})
+    assert "❔" in none
+
+
+# ── data quality ───────────────────────────────────────────────────────
+
+
+def test_data_quality_summary_clean(agg):
+    tasks = [
+        {"totals": {"cost_usd": 0.1}, "llm_calls": [{"model": "x"}]},
+    ]
+    dq = agg._data_quality_summary(tasks)
+    assert dq == {"total": 1, "legacy_cost": 0, "approximate": 0}
+
+
+def test_data_quality_legacy_cost_and_approximate(agg):
+    tasks = [
+        {"totals": {}, "llm_calls": []},  # no cost_usd → legacy
+        {"totals": {"cost_usd": 0.01}, "llm_calls": [{"tokens_approximate": True}]},
+    ]
+    dq = agg._data_quality_summary(tasks)
+    assert dq["legacy_cost"] == 1
+    assert dq["approximate"] == 1
+
+
+def test_quality_banner_clean_returns_none(agg):
+    assert agg._quality_banner({"legacy_cost": 0, "approximate": 0}) is None
+
+
+def test_quality_banner_dirty_includes_count(agg):
+    text = agg._quality_banner({"legacy_cost": 3, "approximate": 5})
+    assert "M3 이전 3건" in text
+    assert "근사 토큰 5건" in text
+
+
+# ── _load_task_jsons ───────────────────────────────────────────────────
+
+
+def test_load_task_jsons_reads_sorted(agg, tmp_path):
+    _write_task(tmp_path, "later", "2026-05-08T15:00:00+00:00", {})
+    _write_task(tmp_path, "earlier", "2026-05-08T09:00:00+00:00", {})
+    out = agg._load_task_jsons()
+    assert [t["task_id"] for t in out] == ["earlier", "later"]
+
+
+def test_load_task_jsons_skips_bad_files(agg, tmp_path):
+    (tmp_path / "good.json").write_text(
+        json.dumps({"task_id": "g", "started_at": "2026-05-08T00:00:00+00:00"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "broken.json").write_text("{not-json", encoding="utf-8")
+    (tmp_path / "ignored.tmp").write_text("ignored", encoding="utf-8")
+    (tmp_path / "not-json.txt").write_text("nope", encoding="utf-8")
+    out = agg._load_task_jsons()
+    assert [t["task_id"] for t in out] == ["g"]
+
+
+def test_load_task_jsons_missing_dir_returns_empty(agg, tmp_path):
+    agg.TASKS_DIR = str(tmp_path / "does-not-exist")
+    assert agg._load_task_jsons() == []
+
+
+# ── _format_agg_block ──────────────────────────────────────────────────
+
+
+def test_format_agg_block_zero_tasks(agg):
+    a = {"tasks": 0, "completed": 0, "orphaned": 0, "pending": 0,
+         "llm_calls": 0, "tool_calls": 0,
+         "input_tokens": 0, "output_tokens": 0,
+         "cache_read_tokens": 0, "cache_creation_tokens": 0,
+         "reasoning_tokens": 0, "cost_usd": 0.0}
+    lines = agg._format_agg_block("오늘", a)
+    # When zero tasks, only the title + status row.
+    assert len(lines) == 2
+    assert "0건" in lines[1]
+
+
+def test_format_agg_block_with_reasoning(agg):
+    a = {"tasks": 5, "completed": 5, "orphaned": 0, "pending": 0,
+         "llm_calls": 30, "tool_calls": 12,
+         "input_tokens": 100_000, "output_tokens": 5_000,
+         "cache_read_tokens": 80_000, "cache_creation_tokens": 5_000,
+         "reasoning_tokens": 2_000, "cost_usd": 0.45}
+    lines = agg._format_agg_block("오늘", a)
+    full = "\n".join(lines)
+    assert "사고 토큰: 2,000" in full
+    assert "💰 $0.4500" in full
+    assert "캐시:" in full


### PR DESCRIPTION
**TL;DR**: bot.py 의 task-JSON 로드 + 집계 + 포매터 12종을 [`telegram-bridge/task_agg/agg.py`](telegram-bridge/task_agg/agg.py) 로 이동. 18개 회귀 테스트 추가. 동작 변화 없음.

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase D — **이슈 순서 변경**: 원래 dashboard 가 Phase C 였으나, dashboard 의 `_build_stats` 와 budget 의 `_compute_window_cost` 가 모두 `_aggregate` 등을 호출. dashboard 먼저 carve 시 순환 의존 발생 → tasks 를 foundation 으로 먼저 carve.

---

## 무엇이 옮겨졌나 (12개)

| 카테고리 | 심볼 |
|---|---|
| 상수 | `TASKS_DIR`, `KST` |
| 시간 | `_kst_now` |
| IO | `_load_task_jsons`, `_filter_date_range` |
| 집계 | `_aggregate` |
| 캐시 분석 | `_is_anthropic_model`, `_cache_efficiency`, `_format_cache_line` |
| 포매터 | `_format_model_breakdown`, `_format_profile_breakdown`, `_format_agg_block` |
| 관측 | `_data_quality_summary`, `_quality_banner` |

bot.py 는 위 모두 re-export. 호출 지점 (`cmd_today`, `cmd_week`, `cmd_tasks`, `_build_stats`, `_compute_window_cost`, `daily_usage_reporter`) 변경 없음.

## 패키지명: `tasks/` ❌ → `task_agg/` ✓

첫 시도는 `tasks/` 였습니다. 로컬 pytest 통과, **컨테이너 부팅 시 module-load 단계에서 `ModuleNotFoundError: No module named 'tasks.agg'` 크래시**.

원인: [`docker-compose.yml`](docker-compose.yml) 이 `./agent-zero/logs/tasks:/app/tasks:ro` 로 task-JSON 읽기 마운트를 `/app/tasks` 에 걸어놓음. Python 패키지 `/app/tasks/` 가 bind-mount 에 의해 silent 하게 가려짐.

```
이미지 내부 (Dockerfile COPY 결과):
  /app/tasks/__init__.py   ← Python 패키지
  /app/tasks/agg.py

런타임 (compose mount 적용 후):
  /app/tasks/  ← bind mount: agent-zero/logs/tasks/*.json (Python 코드 사라짐)
```

`task_agg/` 로 rename 하여 충돌 해소. 패키지 docstring 에 다음 contributor 가 같은 실수 안 하도록 코멘트 추가.

## 남겨둔 것 (다음 phase)

- `_parse_by_flag` — Telegram 명령 파서, 집계 아님
- `cmd_today` / `cmd_week` / `cmd_tasks` — Telegram 핸들러
- `_build_stats` / `_compute_window_cost` — 새 모듈을 호출하지만 HTTP / async 알림 의존이라 미루어둠

## 테스트 18종 ([tests/test_bridge_tasks_agg.py](tests/test_bridge_tasks_agg.py))

| 영역 | 케이스 |
|---|---|
| `_aggregate` | empty / single task / status buckets |
| `_filter_date_range` | start-inclusive / end-exclusive 경계, 잘못된 started_at drop |
| `_is_anthropic_model` | case-insensitive, prefix, fallback |
| `_cache_efficiency` | None when no Anthropic, hit_ratio math |
| `_format_cache_line` | 4 emoji 분기 |
| `_data_quality_summary` / `_quality_banner` | clean / legacy_cost / approximate |
| `_load_task_jsons` | 정렬 / 잘못된 파일 skip / 디렉토리 없음 |
| `_format_agg_block` | zero tasks / reasoning_tokens 포함 |

## 검증

```
$ ruff check .          # All checks passed!
$ pytest -q             # 63 passed in 0.39s  (45 + 18 신규)

$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge | head
[Cost] Loaded 2706 model prices from LiteLLM
[budget] loaded day=$None week=$10.0
Webhook server started on :8443

$ curl -X POST localhost:8443/track -d '{"input_tokens":1000,"output_tokens":100,"reasoning_tokens":500,...}'
→ requests=1 cost=$0.012

$ curl 'localhost:8443/api/stats?range=7d&token=...' | jq '.totals.tasks, (.daily | length)'
→ 58, 7    # _aggregate 가 새 모듈에서 동작, 실제 task JSON 처리 확인
```

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup / #77 CI / #81 preflight
- ✅ #79 Phase A (pricing/cost) / B (pricing/usage) / C (budget/core)
- 🔄 **#79 Phase D — task_agg ← 본 PR**
- ⏳ #79 Phase E — dashboard (이제 깨끗하게 carve 가능)
- ⏳ #79 Phase F — 나머지 (az_client, render)
- ⏳ #78 GUIDE 재작성 / #80 plugin manifest / #82 docs/plugins.md

## Test plan

- [x] ruff clean / 63/63 pytest
- [x] bridge container rebuild + 시작
- [x] /track + /api/stats round-trip 확인
- [x] 패키지 이름 충돌 회피 확인 (task_agg/, NOT tasks/)