### PR TITLE
refactor(bridge): AZ HTTP client `az_client/` 분리 (#79 Phase H)

### DIFF
--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -13,5 +13,6 @@ COPY budget/ ./budget/
 COPY task_agg/ ./task_agg/
 COPY dashboard/ ./dashboard/
 COPY render/ ./render/
+COPY az_client/ ./az_client/
 
 CMD ["python", "bot.py"]

--- a/telegram-bridge/az_client/__init__.py
+++ b/telegram-bridge/az_client/__init__.py
@@ -1,0 +1,32 @@
+"""Agent Zero HTTP client for the Telegram bridge.
+
+Phase H carve from bot.py (issue #79). Owns the aiohttp session +
+CSRF token lifecycle and the read-only AZ poll endpoints. Stateful
+orchestrators (`send_to_agent_zero`, `check_agent_zero_status`) and
+the monitor loop stay in bot.py because they entangle with monitor
+state globals and `send_telegram` — those move in a later phase.
+"""
+
+from .session import (
+    AZ_API_PREFIX,
+    AZ_API_URL,
+    cached_contexts,
+    close_az_session,
+    fetch_chat_list,
+    get_az_session,
+    get_csrf_token,
+    get_headers,
+    sync_log_version,
+)
+
+__all__ = [
+    "AZ_API_PREFIX",
+    "AZ_API_URL",
+    "cached_contexts",
+    "close_az_session",
+    "fetch_chat_list",
+    "get_az_session",
+    "get_csrf_token",
+    "get_headers",
+    "sync_log_version",
+]

--- a/telegram-bridge/az_client/session.py
+++ b/telegram-bridge/az_client/session.py
@@ -1,0 +1,190 @@
+"""Agent Zero HTTP session + CSRF + the few read-only poll endpoints.
+
+Phase H carve from bot.py (issue #79). Includes:
+
+- `AZ_API_URL` / `AZ_API_PREFIX` env constants used by every AZ HTTP
+  call site. Read at import time, same as bot.py used to.
+- The shared `aiohttp.ClientSession` + cookie jar + CSRF token, kept
+  via `get_az_session()` / `close_az_session()` — these are the public
+  accessors; the internal `_az_session` global never gets touched
+  directly outside this module.
+- `get_headers()` — adds the v1.8 `Origin` bypass + the cached CSRF
+  token. Every AZ POST uses this.
+- `fetch_chat_list()` / `sync_log_version()` — read-only AZ poll
+  helpers used by the monitor loop and the /chats command. Pure HTTP,
+  no telegram or monitor-state side effects, so they're safe to live
+  here.
+- `cached_contexts` — shared mutable list of the most recent AZ context
+  list. Mutated in place (clear+extend) so importers can hold stable
+  bindings across `fetch_chat_list()` calls — same pattern as
+  `pricing.cost._model_cost_map` etc.
+
+What's NOT here:
+- `send_to_agent_zero()`, `check_agent_zero_status()`, the monitor
+  loop. Those write to monitor state (`monitor_context`, `monitor_log_version`,
+  `monitor_enabled`) which still lives in bot.py. Carving them needs
+  the monitor state to move first.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+import aiohttp
+from aiohttp import CookieJar
+
+logger = logging.getLogger(__name__)
+
+
+# Env-driven endpoints. Match what bot.py used to read. The `/api`
+# default for AZ_API_PREFIX matters: AZ v1.8+ exposes its endpoints
+# under that prefix (so /csrf_token is actually at /api/csrf_token).
+# Defaulting to "" silently breaks every AZ HTTP call with a 404.
+AZ_API_URL = os.environ.get("AZ_API_URL", "http://agent-zero:80")
+AZ_API_PREFIX = os.environ.get("AZ_API_PREFIX", "/api")
+
+
+# Module-level state. _az_session is rebound (None ↔ ClientSession),
+# so it's deliberately private — public access is via `get_az_session()`.
+# csrf_token is a string; rebinding is fine because no one imports it
+# directly (callers use `get_headers()` or `get_csrf_token()`).
+_az_session: aiohttp.ClientSession | None = None
+_csrf_token: str = ""
+
+
+# Mutated-in-place shared list. Callers (monitor loop, /chats command)
+# import this binding and read the current snapshot; updaters
+# (`fetch_chat_list`, monitor's poll path) clear+extend rather than
+# rebind, so the binding stays valid.
+cached_contexts: list = []
+
+
+def get_csrf_token() -> str:
+    """Return the most recently acquired CSRF token (empty string if
+    no session has been opened yet). Exists so callers don't have to
+    import the private `_csrf_token` global."""
+    return _csrf_token
+
+
+async def get_az_session() -> aiohttp.ClientSession:
+    """Open or reuse the AZ-side aiohttp session and refresh CSRF.
+
+    AZ v1.8+ checks the `Origin` header on POST and gates write
+    endpoints behind a CSRF token; both have to be in place before
+    any subsequent call. We fetch the token on first session creation
+    and stash it for `get_headers()` to consume.
+    """
+    global _az_session, _csrf_token
+
+    if _az_session and not _az_session.closed:
+        return _az_session
+
+    jar = CookieJar(unsafe=True)
+    _az_session = aiohttp.ClientSession(cookie_jar=jar)
+
+    try:
+        async with _az_session.get(
+            f"{AZ_API_URL}{AZ_API_PREFIX}/csrf_token",
+            headers={"Origin": "http://localhost:50001"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                _csrf_token = data.get("token", "")
+                logger.info(f"CSRF token acquired: {_csrf_token[:10]}...")
+            else:
+                logger.warning(f"CSRF token request failed: {resp.status}")
+    except Exception as e:
+        logger.error(f"Failed to get CSRF token: {e}")
+
+    return _az_session
+
+
+async def close_az_session() -> None:
+    """Close the active AZ session. The next `get_az_session()` will
+    open a fresh one with a new CSRF token. Used by the 403-retry
+    path in `send_to_agent_zero`."""
+    global _az_session
+    if _az_session and not _az_session.closed:
+        await _az_session.close()
+        _az_session = None
+
+
+def get_headers() -> dict:
+    """Headers that every AZ POST must carry: Origin (v1.8 bypass) +
+    the cached CSRF token (when one's been acquired)."""
+    headers = {
+        "Origin": "http://localhost:50001",
+    }
+    if _csrf_token:
+        headers["X-CSRF-Token"] = _csrf_token
+    return headers
+
+
+# ── Read-only poll helpers ──────────────────────────────────────────
+
+
+async def fetch_chat_list() -> list:
+    """Fetch the active chat (context) list from AZ.
+
+    Updates the shared `cached_contexts` list in place so importers
+    keep a stable binding. Returns the list as well for the synchronous
+    caller convention.
+    """
+    try:
+        session = await get_az_session()
+        headers = get_headers()
+
+        poll_payload = {
+            "log_from": 0,
+            "context": None,
+            "timezone": "Asia/Seoul",
+        }
+
+        async with session.post(
+            f"{AZ_API_URL}{AZ_API_PREFIX}/poll",
+            json=poll_payload,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            if resp.status != 200:
+                return []
+            poll_data = await resp.json()
+
+        contexts = poll_data.get("contexts", [])
+        cached_contexts.clear()
+        cached_contexts.extend(contexts)
+        return contexts
+
+    except Exception as e:
+        logger.error(f"Failed to fetch chat list: {e}")
+        return []
+
+
+async def sync_log_version(ctx: str) -> int:
+    """Quietly fetch the current `log_version` for a context without
+    pulling any history. Used by the monitor to skip past everything
+    that already happened before the user pointed it at this chat —
+    we only want to surface NEW activity, not replay the backlog.
+    """
+    try:
+        session = await get_az_session()
+        headers = get_headers()
+        poll_payload = {
+            "log_from": 999_999_999,  # huge → server returns no logs, just version
+            "context": ctx or None,
+            "timezone": "Asia/Seoul",
+        }
+        async with session.post(
+            f"{AZ_API_URL}{AZ_API_PREFIX}/poll",
+            json=poll_payload,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as resp:
+            if resp.status != 200:
+                return 0
+            data = await resp.json()
+        return int(data.get("log_version", 0) or 0)
+    except Exception as e:
+        logger.error(f"Failed to sync log_version: {e}")
+        return 0

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 import aiohttp
 from telegram import Update, Bot
 from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
-from aiohttp import web, CookieJar
+from aiohttp import web
 
 # ── Timezone ──
 # 모든 /today /week /tasks 날짜 경계와 daily-usage reset 은 KST 로 정규화한다.
@@ -43,15 +43,13 @@ logger = logging.getLogger(__name__)
 # ── Config ──
 BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
 CHAT_ID = int(os.environ["TELEGRAM_CHAT_ID"])
-AZ_API_URL = os.environ.get("AZ_API_URL", "http://agent-zero:80")
-AZ_API_PREFIX = os.environ.get("AZ_API_PREFIX", "/api")  # v1.8+: /api prefix
+
+# AZ HTTP session + URL constants moved to `az_client/session.py`
+# (issue #79 Phase H). Re-exported below so existing call sites and
+# direct constant references keep working.
 
 # Agent Zero context ID (세션 유지)
 az_context = ""
-
-# 세션 유지 (CSRF 토큰 + 쿠키)
-az_session: aiohttp.ClientSession | None = None
-csrf_token: str = ""
 
 # 모니터링 상태
 monitor_enabled = True
@@ -70,8 +68,20 @@ monitor_verbose = False
 # Telegram Bot 인스턴스 (모니터에서 사용)
 tg_bot: Bot | None = None
 
-# 채팅 목록 캐시
-cached_contexts: list = []
+# AZ HTTP client surface — re-exported from az_client.session.
+# `cached_contexts` is the same list object, mutated in place by
+# `fetch_chat_list`, so direct reads in bot.py (cmd_chats, monitor)
+# stay live without extra plumbing.
+from az_client.session import (  # noqa: E402
+    AZ_API_PREFIX,
+    AZ_API_URL,
+    cached_contexts,
+    close_az_session,
+    fetch_chat_list,
+    get_az_session,
+    get_headers,
+    sync_log_version,
+)
 
 
 def _short_id(ctx_id: str | None, max_len: int = 12) -> str:
@@ -202,51 +212,6 @@ from pricing.usage import (
 )
 
 
-async def get_az_session() -> aiohttp.ClientSession:
-    """Agent Zero 세션 가져오기 (CSRF 토큰 포함)"""
-    global az_session, csrf_token
-
-    if az_session and not az_session.closed:
-        return az_session
-
-    jar = CookieJar(unsafe=True)
-    az_session = aiohttp.ClientSession(cookie_jar=jar)
-
-    try:
-        async with az_session.get(
-            f"{AZ_API_URL}{AZ_API_PREFIX}/csrf_token",
-            headers={"Origin": "http://localhost:50001"},
-            timeout=aiohttp.ClientTimeout(total=10),
-        ) as resp:
-            if resp.status == 200:
-                data = await resp.json()
-                csrf_token = data.get("token", "")
-                logger.info(f"CSRF token acquired: {csrf_token[:10]}...")
-            else:
-                logger.warning(f"CSRF token request failed: {resp.status}")
-    except Exception as e:
-        logger.error(f"Failed to get CSRF token: {e}")
-
-    return az_session
-
-
-async def close_az_session():
-    """세션 닫기"""
-    global az_session
-    if az_session and not az_session.closed:
-        await az_session.close()
-        az_session = None
-
-
-def get_headers() -> dict:
-    headers = {
-        "Origin": "http://localhost:50001",  # v1.8 origin check bypass
-    }
-    if csrf_token:
-        headers["X-CSRF-Token"] = csrf_token
-    return headers
-
-
 # ── Telegram 메시지 전송 헬퍼 ──
 async def send_telegram(
     text: str,
@@ -303,69 +268,16 @@ async def send_telegram(
                 logger.error(f"[telegram] send failed: {e}")
 
 
-# ── 채팅 목록 조회 ──
-async def fetch_chat_list() -> list:
-    """Agent Zero의 활성 채팅(컨텍스트) 목록 조회"""
-    global cached_contexts
-    try:
-        session = await get_az_session()
-        headers = get_headers()
-
-        poll_payload = {
-            "log_from": 0,
-            "context": None,
-            "timezone": "Asia/Seoul",
-        }
-
-        async with session.post(
-            f"{AZ_API_URL}{AZ_API_PREFIX}/poll",
-            json=poll_payload,
-            headers=headers,
-            timeout=aiohttp.ClientTimeout(total=15),
-        ) as resp:
-            if resp.status != 200:
-                return []
-            poll_data = await resp.json()
-
-        contexts = poll_data.get("contexts", [])
-        cached_contexts = contexts
-        return contexts
-
-    except Exception as e:
-        logger.error(f"Failed to fetch chat list: {e}")
-        return []
-
-
-# ── 현재 시점 log_version 가져오기 (히스토리 스킵용) ──
-async def sync_log_version(ctx: str) -> int:
-    """특정 컨텍스트의 현재 log_version만 조용히 가져옴 (알림 없이 스킵)"""
-    try:
-        session = await get_az_session()
-        headers = get_headers()
-        poll_payload = {
-            "log_from": 999999999,  # 큰 수 → 로그 0건 반환, version만 획득
-            "context": ctx or None,
-            "timezone": "Asia/Seoul",
-        }
-        async with session.post(
-            f"{AZ_API_URL}{AZ_API_PREFIX}/poll",
-            json=poll_payload,
-            headers=headers,
-            timeout=aiohttp.ClientTimeout(total=10),
-        ) as resp:
-            if resp.status == 200:
-                data = await resp.json()
-                return data.get("log_version", 0)
-    except Exception as e:
-        logger.error(f"sync_log_version error: {e}")
-    return 0
+# `fetch_chat_list` and `sync_log_version` moved to
+# `az_client/session.py` (issue #79 Phase H). Re-exported at the top
+# of this file alongside the session helpers.
 
 
 # ── Agent Zero 웹 채팅 모니터 ──
 async def monitor_agent_zero():
     """Agent Zero의 모든 대화를 백그라운드로 모니터링하여 Telegram에 전달"""
     global monitor_log_version, monitor_context, monitor_log_guid
-    global monitor_enabled, monitor_auto_follow, cached_contexts
+    global monitor_enabled, monitor_auto_follow
 
     logger.info("Agent Zero monitor started")
     await asyncio.sleep(10)
@@ -404,10 +316,12 @@ async def monitor_agent_zero():
                     continue
                 poll_data = await resp.json()
 
-            # 채팅 목록 캐시 업데이트
+            # 채팅 목록 캐시 업데이트 — clear+extend so the binding shared
+            # with cmd_chats and az_client.session stays the same list object.
             contexts = poll_data.get("contexts", [])
             if contexts:
-                cached_contexts = contexts
+                cached_contexts.clear()
+                cached_contexts.extend(contexts)
 
             # 컨텍스트 동기화
             new_context = poll_data.get("context", "")
@@ -529,7 +443,7 @@ def format_monitor_message(log_type: str, heading: str, content: str) -> str | N
 # ── Agent Zero API: Telegram에서 직접 메시지 전송 ──
 async def send_to_agent_zero(message: str) -> str:
     """Agent Zero /message_async API로 메시지 전송"""
-    global az_context, csrf_token, monitor_context, monitor_log_version
+    global az_context, monitor_context, monitor_log_version
 
     payload = {
         "text": message,

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -130,8 +130,13 @@ def _stub_aiohttp() -> None:
         def get(self, *a, **k):
             raise NotImplementedError("aiohttp stub — fetch path not exercised in unit tests")
 
+    class _FakeCookieJar:
+        def __init__(self, *a, **k):
+            pass
+
     aiohttp.ClientTimeout = _FakeClientTimeout
     aiohttp.ClientSession = _FakeClientSession
+    aiohttp.CookieJar = _FakeCookieJar
 
 
 def _stub_pdf_render_deps() -> None:

--- a/tests/test_bridge_az_client.py
+++ b/tests/test_bridge_az_client.py
@@ -1,0 +1,127 @@
+"""Pin telegram-bridge/az_client/session.py — Phase H carve.
+
+Pinning the small synchronous surface:
+- `get_headers()` — Origin always present, X-CSRF-Token only when token cached
+- `get_csrf_token()` — empty string when no session opened, populated otherwise
+- `cached_contexts` binding stability through `fetch_chat_list`
+- `AZ_API_URL` / `AZ_API_PREFIX` env defaults
+
+Async paths (`get_az_session`, `fetch_chat_list`, `sync_log_version`)
+need a real aiohttp test harness to cover meaningfully — out of scope
+for this PR. They're light wrappers over `aiohttp.ClientSession.post`
+which is itself well-tested upstream; the carve preserved the request
+shapes byte-for-byte.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent / "telegram-bridge" / "az_client"
+
+
+def _load_session_module():
+    """Spec-load `az_client.session` against the on-disk file."""
+    pkg = types.ModuleType("az_client")
+    pkg.__path__ = [str(_ROOT)]  # type: ignore[attr-defined]
+    sys.modules["az_client"] = pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "az_client.session", _ROOT / "session.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["az_client.session"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def session_mod():
+    mod = _load_session_module()
+    # Reset module state between tests.
+    mod._csrf_token = ""
+    mod.cached_contexts.clear()
+    return mod
+
+
+# ── env defaults ────────────────────────────────────────────────────
+
+
+def test_env_defaults_when_unset(session_mod):
+    """Without AZ_API_URL/AZ_API_PREFIX in env, sane defaults stand."""
+    # We can't easily reload the module to test env-driven values, but
+    # we can verify the constants are the documented defaults under the
+    # current test environment (which doesn't set these vars).
+    import os
+    if "AZ_API_URL" not in os.environ:
+        assert session_mod.AZ_API_URL == "http://agent-zero:80"
+    if "AZ_API_PREFIX" not in os.environ:
+        # AZ v1.8+ requires the /api prefix; defaulting to "" silently
+        # 404s every endpoint. Pin the right default.
+        assert session_mod.AZ_API_PREFIX == "/api"
+
+
+# ── get_headers ─────────────────────────────────────────────────────
+
+
+def test_get_headers_origin_always_present(session_mod):
+    h = session_mod.get_headers()
+    assert h["Origin"] == "http://localhost:50001"
+
+
+def test_get_headers_no_csrf_when_unset(session_mod):
+    """Until the session is opened (which fetches CSRF), the header
+    must be absent — sending an empty token would invalidate the
+    request more loudly than just omitting the header."""
+    session_mod._csrf_token = ""
+    h = session_mod.get_headers()
+    assert "X-CSRF-Token" not in h
+
+
+def test_get_headers_includes_csrf_when_set(session_mod):
+    session_mod._csrf_token = "abc123"
+    h = session_mod.get_headers()
+    assert h["X-CSRF-Token"] == "abc123"
+
+
+# ── get_csrf_token ──────────────────────────────────────────────────
+
+
+def test_get_csrf_token_returns_empty_when_unset(session_mod):
+    session_mod._csrf_token = ""
+    assert session_mod.get_csrf_token() == ""
+
+
+def test_get_csrf_token_returns_current(session_mod):
+    session_mod._csrf_token = "live-token"
+    assert session_mod.get_csrf_token() == "live-token"
+
+
+# ── cached_contexts binding stability ───────────────────────────────
+
+
+def test_cached_contexts_binding_survives_clear_extend(session_mod):
+    """The whole point of the clear+extend pattern in `fetch_chat_list`
+    and the monitor loop — bot.py's import binding has to stay valid
+    when the list contents are replaced. Simulate: capture a reference,
+    do clear+extend, ensure same list identity + new contents."""
+    captured = session_mod.cached_contexts
+    captured.append("old-ctx")
+    # Simulate fetch_chat_list's clear+extend (without actually doing HTTP).
+    new_contexts = [{"id": "ctx1"}, {"id": "ctx2"}]
+    session_mod.cached_contexts.clear()
+    session_mod.cached_contexts.extend(new_contexts)
+    # Same list object (binding valid) but new contents.
+    assert captured is session_mod.cached_contexts
+    assert captured == new_contexts
+
+
+def test_cached_contexts_starts_empty(session_mod):
+    """Module load should leave the list empty — the monitor and
+    /chats command rely on this on cold start."""
+    assert session_mod.cached_contexts == []


### PR DESCRIPTION
**TL;DR**: bot.py 의 aiohttp 세션 / CSRF / 읽기 전용 AZ poll 헬퍼를 [`telegram-bridge/az_client/`](telegram-bridge/az_client/) 패키지로 분리. 8개 테스트 추가. 회귀 1건 발견·수정 (`AZ_API_PREFIX` 기본값).

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase H. bot.py 누적: **3,579 → 2,039** (−43%).

---

## 옮긴 것

| 카테고리 | 심볼 |
|---|---|
| 상수 | `AZ_API_URL`, `AZ_API_PREFIX` |
| 세션 상태 | `_az_session`, `_csrf_token` (private), `cached_contexts` |
| 세션 lifecycle | `get_az_session`, `close_az_session`, `get_headers`, `get_csrf_token` |
| 읽기 전용 AZ HTTP | `fetch_chat_list`, `sync_log_version` |

bot.py 는 위 모두 re-export. 호출 지점 (cmd_chats, monitor_agent_zero, send_to_agent_zero 등) 변경 없음.

## 남겨둔 것

- `send_to_agent_zero` / `check_agent_zero_status` — `monitor_context`, `monitor_log_version`, `monitor_enabled` 같은 monitor state 글로벌과 얽혀있음. monitor 상태 먼저 carve 후 이동.
- `monitor_agent_zero` 루프 — telegram-bound (formats + sends).

## 회귀 1건 발견·수정

**버그**: 첫 carve 시 `AZ_API_PREFIX` 기본값을 `os.environ.get("AZ_API_PREFIX", "")` 로 옮김. bot.py 원본 기본값은 `/api` (AZ v1.8+ 가 모든 엔드포인트를 그 prefix 아래 노출).

증상: 모든 AZ HTTP 호출이 silent 404. 컨테이너 재기동 후 로그:
```
az_client.session - ERROR - Failed to get CSRF token: ... Server disconnected
```

**수정**: `AZ_API_PREFIX = os.environ.get("AZ_API_PREFIX", "/api")`. 동일 회귀 차단을 위해 `test_env_defaults_when_unset` 가 `/api` 기본값을 핀.

## binding stability — `cached_contexts`

`fetch_chat_list` (옮긴 함수) + `monitor_agent_zero` (bot.py 잔류) 모두 `cached_contexts` 를 갱신. 기존 패턴 `cached_contexts = contexts` 는 reassignment → bot.py 의 import binding stale.

clear+extend 로 변경:
```python
cached_contexts.clear()
cached_contexts.extend(contexts)
```

`pricing.cost._model_cost_map`, `pricing.usage.usage_today`, `budget.core._budget` 와 동일 패턴. test_cached_contexts_binding_survives_clear_extend 가 핀.

## 테스트 8종 ([tests/test_bridge_az_client.py](tests/test_bridge_az_client.py))

- env 기본값 (1) — `AZ_API_URL` / `AZ_API_PREFIX` (위 회귀 차단)
- `get_headers` (3) — Origin 항상 present, CSRF 미설정 시 헤더 부재, 설정 시 포함
- `get_csrf_token` (2) — 미설정 → "", 설정 후 반영
- `cached_contexts` (2) — clear+extend identity 보존, 초기 빈 list

stubs.py: aiohttp stub 에 CookieJar 추가.

## 라이브 검증

```
$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge
2026-05-08 17:44:10 - az_client.session - INFO - CSRF token acquired: oGnmQKDCOt...
                       ^^^^^^^^^^^^^^^^ 새 모듈 hot path 동작
$ ruff check .                # All checks passed!
$ pytest -q                   # 122 passed in 0.57s  (114 + 8 신규)
```

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup / #77 CI / #81 preflight
- ✅ #79 Phase A-G (pricing/cost, pricing/usage, budget/core, task_agg, dashboard, render, pricing/snapshot)
- 🔄 **#79 Phase H — az_client ← 본 PR**
- ⏳ #79 future — monitor state + monitor loop, telegram cmd handlers
- ⏳ #78 GUIDE 재작성 / #80 plugin manifest / #82 docs/plugins.md

## bot.py 누적

| Phase | 누적 줄수 | Δ |
|---|---|---|
| 시작 | 3,579 | — |
| A → G | 2,125 | -1,454 |
| **H (az_client)** | **2,039** | **-86** |

남은 큰 덩어리: monitor 상태 + 루프 (~440줄), Telegram cmd handlers (~1,000줄+).

## Test plan

- [x] ruff clean / 122/122 pytest
- [x] container rebuild + AZ CSRF 정상 acquisition (회귀 차단 확인)
- [x] cached_contexts binding identity 테스트