### PR TITLE
refactor(bridge): format_monitor_message + short_id `render/monitor.py` 분리 (#79 Phase J)

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -84,24 +84,13 @@ from az_client.session import (  # noqa: E402
 )
 
 
-def _short_id(ctx_id: str | None, max_len: int = 12) -> str:
-    """Render a context ID for display.
-
-    AZ's `helpers.guids.generate_id` defaults to length=8, so today's IDs
-    are already 8 chars total. The previous code did `id[:8] + "..."`
-    which was a UX lie — the ellipsis suggested truncation when nothing
-    had been truncated, and users couldn't tell where the ID ended.
-
-    Behavior:
-      - empty / None → "없음"
-      - len(id) <= max_len → return as-is, no ellipsis
-      - longer → truncate to max_len + "..." (real truncation, real marker)
-    """
-    if not ctx_id:
-        return "없음"
-    if len(ctx_id) <= max_len:
-        return ctx_id
-    return ctx_id[:max_len] + "..."
+# `_short_id` and `format_monitor_message` moved to `render/monitor.py`
+# (issue #79 Phase J). Re-exported for the call sites still in bot.py
+# (cmd_chats, cmd_switch, cmd_new, monitor_agent_zero, etc.). The new
+# `format_monitor_message` is pure — callers pass `verbose=monitor_verbose`
+# explicitly instead of the function reaching for the global.
+from render.monitor import format_monitor_message  # noqa: E402, F401
+from render.monitor import short_id as _short_id  # noqa: E402
 
 
 # Markdown → Telegram-HTML rendering moved to `render/markdown.py`
@@ -381,7 +370,9 @@ async def monitor_agent_zero():
                         await flush_pending()
                         _stream_reset(stream_key)
 
-                    formatted = format_monitor_message(log_type, heading, content)
+                    formatted = format_monitor_message(
+                        log_type, heading, content, verbose=monitor_verbose,
+                    )
                     if formatted:
                         pending.append(formatted)
 
@@ -396,48 +387,6 @@ async def monitor_agent_zero():
             continue
 
         await asyncio.sleep(3)
-
-
-def format_monitor_message(log_type: str, heading: str, content: str) -> str | None:
-    """로그 타입에 따라 Telegram 메시지 포맷.
-
-    Quiet mode (default, `monitor_verbose=False`): only `user` log types
-    echo through. The user-facing answer + metrics card are sent at task
-    completion via `task_report.py`'s `_post_task_response` /
-    `_post_task_summary`, so the in-progress monitor doesn't need to
-    repeat what's coming anyway.
-
-    Verbose mode (`monitor_verbose=True`, toggled via /verbose_on): every
-    log type formats and forwards as before — useful when debugging an
-    AZ profile or a stuck task.
-    """
-    if not content and not heading:
-        return None
-
-    if log_type == "user":
-        return f"👤 사용자: {content}"
-
-    if not monitor_verbose:
-        # Quiet path — let task completion drive the actual answer + metrics.
-        return None
-
-    if log_type in ("response", "ai", "agent"):
-        if len(content) > 2000:
-            content = content[:2000] + "\n...(생략)"
-        return f"🤖 Agent Zero:\n{content}"
-    elif log_type == "code_exe":
-        code_preview = content[:500] if content else ""
-        return f"⚙️ 코드 실행: {heading}\n```\n{code_preview}\n```"
-    elif log_type == "tool":
-        return f"🔧 도구: {heading}\n{content[:500] if content else ''}"
-    elif log_type == "info":
-        return f"ℹ️ {heading}: {content[:500] if content else ''}"
-    elif log_type == "error":
-        return f"❌ 오류: {heading}\n{content[:500] if content else ''}"
-    elif log_type == "warning":
-        return f"⚠️ 경고: {heading}\n{content[:500] if content else ''}"
-
-    return None
 
 
 # ── Agent Zero API: Telegram에서 직접 메시지 전송 ──

--- a/telegram-bridge/render/__init__.py
+++ b/telegram-bridge/render/__init__.py
@@ -6,5 +6,6 @@ Phase F carve from bot.py (issue #79). Currently exports the markdown
 """
 
 from .markdown import md_to_telegram_html
+from .monitor import format_monitor_message, short_id
 
-__all__ = ["md_to_telegram_html"]
+__all__ = ["md_to_telegram_html", "format_monitor_message", "short_id"]

--- a/telegram-bridge/render/monitor.py
+++ b/telegram-bridge/render/monitor.py
@@ -1,0 +1,86 @@
+"""Monitor-feed message formatting.
+
+Phase J carve from bot.py (issue #79). Two pure helpers used by the
+monitor loop and a handful of cmd handlers:
+
+- `format_monitor_message(log_type, heading, content, *, verbose)` —
+  one-line / multi-line Telegram render of a single AZ log entry.
+  Quiet mode (default): only `user` lines echo through. Verbose mode
+  surfaces every log type — useful when debugging a stuck task.
+- `short_id(ctx_id, max_len=12)` — trim AZ context IDs for display.
+
+Verbose state used to be a `monitor_verbose` global read inside the
+function. After the carve the function is pure: callers pass
+`verbose=monitor_verbose` explicitly.
+"""
+from __future__ import annotations
+
+
+def short_id(ctx_id: str | None, max_len: int = 12) -> str:
+    """Render a context ID for display.
+
+    AZ's `helpers.guids.generate_id` defaults to length=8, so today's IDs
+    are already 8 chars total. The previous code did `id[:8] + "..."`
+    which was a UX lie — the ellipsis suggested truncation when nothing
+    had been truncated, and users couldn't tell where the ID ended.
+
+    Behavior:
+      - empty / None → "없음"
+      - len(id) <= max_len → return as-is, no ellipsis
+      - longer → truncate to max_len + "..." (real truncation, real marker)
+    """
+    if not ctx_id:
+        return "없음"
+    if len(ctx_id) <= max_len:
+        return ctx_id
+    return ctx_id[:max_len] + "..."
+
+
+def format_monitor_message(
+    log_type: str,
+    heading: str,
+    content: str,
+    *,
+    verbose: bool = False,
+) -> str | None:
+    """Format one AZ log entry for the Telegram monitor feed.
+
+    Quiet mode (`verbose=False`, default): only `user` log types echo
+    through. The user-facing answer + metrics card are sent at task
+    completion via `task_report.py`'s `_post_task_response` /
+    `_post_task_summary`, so the in-progress monitor doesn't need to
+    repeat what's coming anyway.
+
+    Verbose mode (`verbose=True`, toggled via /verbose_on): every log
+    type formats and forwards as before — useful when debugging an AZ
+    profile or a stuck task.
+
+    Returns the formatted text or `None` to skip this entry entirely.
+    """
+    if not content and not heading:
+        return None
+
+    if log_type == "user":
+        return f"👤 사용자: {content}"
+
+    if not verbose:
+        # Quiet path — let task completion drive the actual answer + metrics.
+        return None
+
+    if log_type in ("response", "ai", "agent"):
+        if len(content) > 2000:
+            content = content[:2000] + "\n...(생략)"
+        return f"🤖 Agent Zero:\n{content}"
+    if log_type == "code_exe":
+        code_preview = content[:500] if content else ""
+        return f"⚙️ 코드 실행: {heading}\n```\n{code_preview}\n```"
+    if log_type == "tool":
+        return f"🔧 도구: {heading}\n{content[:500] if content else ''}"
+    if log_type == "info":
+        return f"ℹ️ {heading}: {content[:500] if content else ''}"
+    if log_type == "error":
+        return f"❌ 오류: {heading}\n{content[:500] if content else ''}"
+    if log_type == "warning":
+        return f"⚠️ 경고: {heading}\n{content[:500] if content else ''}"
+
+    return None

--- a/tests/test_bridge_render_monitor.py
+++ b/tests/test_bridge_render_monitor.py
@@ -1,0 +1,151 @@
+"""Pin telegram-bridge/render/monitor.py — Phase J carve.
+
+Two pure helpers, both worth pinning per branch:
+
+- `short_id` — UX-relevant truncation that has been wrong before
+  (`id[:8] + "..."` wrongly suggesting truncation that hadn't happened).
+- `format_monitor_message` — every log_type branch matters. Quiet
+  mode hides everything except `user`; verbose mode passes 6 distinct
+  log types through with different prefixes/wrapping. A regression
+  here changes what users see during a task.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MON_PATH = (
+    Path(__file__).resolve().parent.parent / "telegram-bridge" / "render" / "monitor.py"
+)
+
+
+@pytest.fixture(scope="module")
+def mon():
+    spec = importlib.util.spec_from_file_location("bridge_render_monitor", _MON_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── short_id ────────────────────────────────────────────────────────
+
+
+def test_short_id_empty(mon):
+    assert mon.short_id("") == "없음"
+    assert mon.short_id(None) == "없음"
+
+
+def test_short_id_already_short(mon):
+    """If ID is already <= max_len, no ellipsis is appended (the
+    original UX-bug fix)."""
+    assert mon.short_id("abc12345") == "abc12345"  # 8 chars at default max_len=12
+
+
+def test_short_id_truncates_with_marker(mon):
+    long_id = "abcdefghijklmnopqrstuvwxyz"
+    out = mon.short_id(long_id, max_len=10)
+    assert out == "abcdefghij..."
+    assert out.endswith("...")
+
+
+# ── format_monitor_message: quiet (default) ─────────────────────────
+
+
+def test_quiet_user_passes_through(mon):
+    assert mon.format_monitor_message("user", "X", "안녕") == "👤 사용자: 안녕"
+
+
+def test_quiet_response_suppressed(mon):
+    """Quiet mode: anything other than `user` returns None — task
+    completion handler is the source of truth for the actual answer."""
+    assert mon.format_monitor_message("response", "X", "answer") is None
+
+
+def test_quiet_tool_suppressed(mon):
+    assert mon.format_monitor_message("tool", "code_execution", "...") is None
+
+
+def test_quiet_info_suppressed(mon):
+    assert mon.format_monitor_message("info", "loading", "...") is None
+
+
+# ── format_monitor_message: empty payload ───────────────────────────
+
+
+def test_empty_payload_returns_none(mon):
+    """No content AND no heading → skip entirely. Otherwise we'd send
+    naked '👤 사용자: ' lines on stub events."""
+    assert mon.format_monitor_message("user", "", "") is None
+    assert mon.format_monitor_message("info", "", "", verbose=True) is None
+
+
+# ── format_monitor_message: verbose ─────────────────────────────────
+
+
+def test_verbose_response_with_robot_prefix(mon):
+    out = mon.format_monitor_message("response", "h", "the answer", verbose=True)
+    assert out is not None
+    assert out.startswith("🤖 Agent Zero:")
+    assert "the answer" in out
+
+
+def test_verbose_response_truncates_at_2000(mon):
+    big = "x" * 5000
+    out = mon.format_monitor_message("response", "h", big, verbose=True)
+    assert out is not None
+    assert "...(생략)" in out
+    # Original 5000 + truncation marker, but body itself capped at 2000.
+    assert out.count("x") == 2000
+
+
+def test_verbose_code_exe(mon):
+    out = mon.format_monitor_message("code_exe", "exec", "print(1)", verbose=True)
+    assert out is not None
+    assert out.startswith("⚙️ 코드 실행: exec")
+    assert "```" in out
+    assert "print(1)" in out
+
+
+def test_verbose_tool(mon):
+    out = mon.format_monitor_message("tool", "browser", "url=...", verbose=True)
+    assert out is not None
+    assert out.startswith("🔧 도구: browser")
+    assert "url=..." in out
+
+
+def test_verbose_info(mon):
+    out = mon.format_monitor_message("info", "ready", "starting", verbose=True)
+    assert out is not None
+    assert out.startswith("ℹ️ ready:")
+
+
+def test_verbose_error(mon):
+    out = mon.format_monitor_message("error", "fail", "stack", verbose=True)
+    assert out is not None
+    assert out.startswith("❌ 오류: fail")
+
+
+def test_verbose_warning(mon):
+    out = mon.format_monitor_message("warning", "slow", "took 30s", verbose=True)
+    assert out is not None
+    assert out.startswith("⚠️ 경고: slow")
+
+
+def test_verbose_unknown_log_type(mon):
+    """Unknown log_type → None (not a wildcard fall-through to noise)."""
+    assert mon.format_monitor_message("weird_type", "h", "c", verbose=True) is None
+
+
+def test_verbose_truncates_long_secondary_content(mon):
+    """All the verbose branches except `response` cap secondary content at 500
+    chars to keep the monitor feed tight."""
+    big = "Q" * 1000  # non-overlapping with the heading word ("status")
+    out = mon.format_monitor_message("info", "status", big, verbose=True)
+    assert out is not None
+    # The function slices content to first 500 chars.
+    assert out.count("Q") == 500
+    # And the total length is roughly heading + 500, not 1000.
+    assert len(out) < 600


### PR DESCRIPTION
**TL;DR**: bot.py 의 두 순수 presentation helper 를 [`render/monitor.py`](telegram-bridge/render/monitor.py) 로 이동. `format_monitor_message` 는 `monitor_verbose` 글로벌 의존을 `verbose=` 매개변수로 분리해 완전히 pure 로 만듬. 17개 테스트로 모든 log_type 브랜치 핀.

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase J. bot.py 누적: **3,579 → 1,788** (−50%, 절반 돌파).

---

## 옮긴 것 (2)

| 심볼 | 변경 |
|---|---|
| `_short_id` → `short_id` | private → public, 동작 동일 |
| `format_monitor_message` | `monitor_verbose` 글로벌 의존 제거 → `verbose` 매개변수 |

bot.py 는 두 함수 re-export. cmd_chats/switch/new/status, monitor_agent_zero, send_to_agent_zero, check_agent_zero_status 호출 지점 변경 없음.

## 핵심 변경 — verbose 플래그를 매개변수로

**전**:
```python
def format_monitor_message(log_type, heading, content):
    if not monitor_verbose:   # 모듈 글로벌 reach-in
        return None
```

**후**:
```python
def format_monitor_message(log_type, heading, content, *, verbose=False):
    if not verbose:           # 명시적 매개변수
        return None
```

호출자 (`monitor_agent_zero`) 가 `verbose=monitor_verbose` 명시 전달. 함수 자체는 완전히 pure — 같은 입력이 항상 같은 출력. 테스트 시 글로벌 mocking 불필요.

## 테스트 17종 ([tests/test_bridge_render_monitor.py](tests/test_bridge_render_monitor.py))

| 영역 | 케이스 |
|---|---|
| `short_id` (3) | empty → "없음", 이미 짧은 ID 변경 없음, 길면 "..." 마커 |
| 조용 모드 (4) | user 통과, response/tool/info suppressed |
| empty payload (1) | content + heading 없으면 None (verbose 무관) |
| verbose 모드 (8) | response (2000자 truncation), code_exe, tool, info, error, warning, unknown → None, secondary content 500자 cap |
| response 2k 자 | 사용자 보이는 값 핀 |

## 검증

```
$ ruff check .          # All checks passed!
$ pytest -q             # 145 passed in 0.56s  (128 + 17 신규)

$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge | grep started
Webhook server started on :8443
Telegram Bridge Bot started (with monitor + multi-chat)
Application started
```

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup / #77 CI / #81 preflight
- ✅ #79 Phase A-I (10개 모듈)
- 🔄 **#79 Phase J — render/monitor ← 본 PR**
- ⏳ #79 future — monitor state + monitor loop, send_telegram + tg_bot, 나머지 cmd 그룹들
- ⏳ #78 GUIDE 재작성 / #80 plugin manifest / #82 docs/plugins.md

## bot.py 누적

| Phase | 누적 줄수 | Δ |
|---|---|---|
| 시작 | 3,579 | — |
| A → I | 1,839 | -1,740 |
| **J (render/monitor)** | **1,788** | **-51** |

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) acceptance ("bot.py 1,000 lines 이하") 까지 ~788 줄.

## Test plan

- [x] ruff clean / 145/145 pytest
- [x] container rebuild + 시작
- [x] format_monitor_message 의 모든 log_type 브랜치 회귀 핀