### PR TITLE
refactor(bridge): budget 엔진 `budget/engine.py` 분리 (#79 Phase K)

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -956,121 +956,19 @@ from budget.core import alert_key as _alert_key  # noqa: F401  # legacy name
 from budget.core import format_alert as _format_budget_alert  # noqa: F401
 
 
-def _compute_window_cost(window: str) -> dict:
-    """Sum cost over a window from on-disk task JSONs.
-
-    Authoritative source — uses the same `_aggregate` pipeline as /today
-    /week, so budget alerts and dashboards never disagree. Going through
-    `usage_today` (RAM-only) would miss any in-progress task and wouldn't
-    survive a bridge restart.
-
-    Returns:
-        {
-          "cost_usd":  float,
-          "tasks":     int,
-          "top_model": (name, cost) | None,
-          "period_id": str,        # for cooldown key
-          "label":     str,        # human-readable for the alert text
-        }
-    """
-    now = _kst_now()
-    today = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    if window == "day":
-        start = today
-        end = today + timedelta(days=1)
-        period_id = today.strftime("%Y-%m-%d")
-        label = f"오늘 ({period_id} KST)"
-    elif window == "week":
-        start = today - timedelta(days=6)
-        end = today + timedelta(days=1)
-        # ISO week — naturally rotates Mon→Mon, but we just want a stable
-        # bucket for cooldown so 7-day rolling window's date string is fine.
-        period_id = today.strftime("%G-W%V")
-        label = f"최근 7일 ({start.strftime('%m-%d')}~{today.strftime('%m-%d')} KST)"
-    else:
-        raise ValueError(f"unknown window: {window!r}")
-
-    tasks = _filter_date_range(_load_task_jsons(), start, end)
-    agg = _aggregate(tasks)
-    by_model = agg.get("by_model") or {}
-    top = None
-    if by_model:
-        m, b = max(by_model.items(), key=lambda kv: kv[1]["cost"])
-        top = (m, b["cost"])
-    return {
-        "cost_usd": float(agg["cost_usd"]),
-        "tasks": agg["tasks"],
-        "top_model": top,
-        "period_id": period_id,
-        "label": label,
-    }
-
-
-async def _budget_check_window(window: str) -> bool:
-    """Check one window's spend vs its limit. Fires at most ONE alert per
-    call (the highest crossed threshold). Cooldown: per (period_id, window,
-    threshold) — once today's 80% fires, won't fire again today even if
-    spend keeps climbing.
-
-    Returns True if any alert was sent (useful for tests / hourly logging).
-    """
-    limit_key = f"{window}_limit_usd"
-    limit = _budget.get(limit_key)
-    if not limit or limit <= 0:
-        return False
-    info = _compute_window_cost(window)
-    cost = info["cost_usd"]
-    if cost <= 0:
-        return False
-    ratio = cost / float(limit)
-    period_id = info["period_id"]
-
-    fired = _budget.setdefault("alerts_fired", {})
-    sent_any = False
-    # Walk thresholds high-to-low; fire the highest one crossed that hasn't
-    # been fired yet for this period. Mark all lower not-yet-fired thresholds
-    # as fired too so we don't trigger a cascade on the next call.
-    for thresh, level_label, pct_label in BUDGET_THRESHOLDS:
-        key = _alert_key(window, pct_label, period_id)
-        if ratio >= thresh and key not in fired:
-            if not sent_any:
-                msg = _format_budget_alert(window, info, float(limit), level_label, ratio)
-                try:
-                    await send_telegram(msg)
-                    sent_any = True
-                except Exception as e:
-                    logger.warning(f"[budget] alert send failed: {e}")
-                    return False
-            fired[key] = True
-    if sent_any:
-        _save_budget()
-    return sent_any
-
-
-async def budget_check_all() -> None:
-    """Public entrypoint: check both day + week windows. Wired into
-    /track (per-call) and the hourly sweep (catches missed alerts and
-    week-rollover edge cases)."""
-    try:
-        await _budget_check_window("day")
-        await _budget_check_window("week")
-    except Exception as e:
-        logger.warning(f"[budget] sweep error: {e}")
-
-
-async def hourly_budget_sweep() -> None:
-    """Hourly background task. Defensive — `_budget_check_window` is also
-    called from /track, but that path can be skipped if AZ batches /track
-    or fails-quiet. Hourly cadence is plenty for a 24h-budget signal."""
-    logger.info("Hourly budget sweep started")
-    while True:
-        try:
-            await asyncio.sleep(3600)  # 1 hour
-            await budget_check_all()
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            logger.warning(f"[budget] hourly sweep error: {e}")
+# Async budget engine moved to `budget/engine.py` (issue #79 Phase K).
+# Telegram alert callback wired in main() via `budget.engine.configure(
+# send_alert=send_telegram)` so the engine module stays import-clean of
+# the telegram bot. Re-exported below for the existing call sites
+# (`usage_track_handler` → `budget_check_all`, post_init scheduler →
+# `hourly_budget_sweep`, `cmd_budget` → `_budget_check_window`,
+# `_compute_window_cost`).
+from budget.engine import (  # noqa: E402, F401
+    _budget_check_window,
+    _compute_window_cost,
+    budget_check_all,
+    hourly_budget_sweep,
+)
 
 
 # ── Pricing drift detection (M5-C · issue #21) ──
@@ -1744,6 +1642,13 @@ def main():
     # accepting /track requests (which trigger budget_check_all). Otherwise
     # the first /track after restart would use empty defaults and skip alerts.
     _load_budget()
+
+    # Wire the telegram alert callback into the carved-out budget engine
+    # (issue #79 Phase K). Without this, `_budget_check_window` would log
+    # but skip the actual alert send. Done here so it's set before the
+    # webhook server accepts its first /track.
+    import budget.engine
+    budget.engine.configure(send_alert=send_telegram)
 
     app = Application.builder().token(BOT_TOKEN).post_init(post_init).build()
 

--- a/telegram-bridge/budget/__init__.py
+++ b/telegram-bridge/budget/__init__.py
@@ -28,6 +28,13 @@ from .core import (
     alert_key,
     format_alert,
 )
+from .engine import (
+    _budget_check_window,
+    _compute_window_cost,
+    budget_check_all,
+    configure,
+    hourly_budget_sweep,
+)
 
 __all__ = [
     "BUDGET_DIR",
@@ -39,4 +46,9 @@ __all__ = [
     "_save_budget",
     "alert_key",
     "format_alert",
+    "_compute_window_cost",
+    "_budget_check_window",
+    "budget_check_all",
+    "hourly_budget_sweep",
+    "configure",
 ]

--- a/telegram-bridge/budget/engine.py
+++ b/telegram-bridge/budget/engine.py
@@ -1,0 +1,176 @@
+"""Budget engine — windowed cost computation + threshold-crossing alerts.
+
+Phase K carve from bot.py (issue #79). Builds on `budget/core.py`
+(state + persistence + pure formatters, Phase C) and `task_agg/agg.py`
+(load/filter/aggregate, Phase D).
+
+What's here:
+- `_compute_window_cost(window)` — sum cost over "day" or "week" using
+  the same task-JSON aggregate path that drives /today, /week, and the
+  dashboard. Single source of truth so `/budget` and `/today` never
+  disagree.
+- `_budget_check_window(window)` — fire-once-per-period alert with a
+  cooldown key. Walks the threshold ladder (150% / 100% / 80%) and
+  surfaces the highest crossed level.
+- `budget_check_all()` — entrypoint for /track + the hourly sweep.
+- `hourly_budget_sweep()` — 24h background task.
+
+Telegram dependency injection:
+The engine doesn't import `send_telegram` directly — bot.py passes a
+callback once at startup via `configure(send_alert=...)`. Same pattern
+as `pricing/snapshot.py`. Without configure(), alerts are silently
+dropped (handy for tests).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+
+from task_agg.agg import _aggregate, _filter_date_range, _kst_now, _load_task_jsons
+
+from budget.core import (
+    BUDGET_THRESHOLDS,
+    _budget,
+    _save_budget,
+    alert_key,
+    format_alert,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level injection slot for the telegram alert sender. bot.py
+# wires this once at startup via `configure(send_alert=send_telegram)`.
+# Default None disables alerts (useful for tests + smoke runs).
+_send_alert = None
+
+
+def configure(*, send_alert) -> None:
+    """Wire the telegram alert callback. Call once at startup before
+    any /track or sweep runs. Idempotent — last call wins."""
+    global _send_alert
+    _send_alert = send_alert
+
+
+def _compute_window_cost(window: str) -> dict:
+    """Sum cost over a window from on-disk task JSONs.
+
+    Authoritative source — uses the same `_aggregate` pipeline as /today
+    /week, so budget alerts and dashboards never disagree. Going through
+    `usage_today` (RAM-only) would miss any in-progress task and wouldn't
+    survive a bridge restart.
+
+    Returns:
+        {
+          "cost_usd":  float,
+          "tasks":     int,
+          "top_model": (name, cost) | None,
+          "period_id": str,        # for cooldown key
+          "label":     str,        # human-readable for the alert text
+        }
+    """
+    now = _kst_now()
+    today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    if window == "day":
+        start = today
+        end = today + timedelta(days=1)
+        period_id = today.strftime("%Y-%m-%d")
+        label = f"오늘 ({period_id} KST)"
+    elif window == "week":
+        start = today - timedelta(days=6)
+        end = today + timedelta(days=1)
+        # ISO week — naturally rotates Mon→Mon, but we just want a stable
+        # bucket for cooldown so 7-day rolling window's date string is fine.
+        period_id = today.strftime("%G-W%V")
+        label = f"최근 7일 ({start.strftime('%m-%d')}~{today.strftime('%m-%d')} KST)"
+    else:
+        raise ValueError(f"unknown window: {window!r}")
+
+    tasks = _filter_date_range(_load_task_jsons(), start, end)
+    agg = _aggregate(tasks)
+    by_model = agg.get("by_model") or {}
+    top = None
+    if by_model:
+        m, b = max(by_model.items(), key=lambda kv: kv[1]["cost"])
+        top = (m, b["cost"])
+    return {
+        "cost_usd": float(agg["cost_usd"]),
+        "tasks": agg["tasks"],
+        "top_model": top,
+        "period_id": period_id,
+        "label": label,
+    }
+
+
+async def _budget_check_window(window: str) -> bool:
+    """Check one window's spend vs its limit. Fires at most ONE alert per
+    call (the highest crossed threshold). Cooldown: per (period_id, window,
+    threshold) — once today's 80% fires, won't fire again today even if
+    spend keeps climbing.
+
+    Returns True if any alert was sent (useful for tests / hourly logging).
+    """
+    limit_key = f"{window}_limit_usd"
+    limit = _budget.get(limit_key)
+    if not limit or limit <= 0:
+        return False
+    info = _compute_window_cost(window)
+    cost = info["cost_usd"]
+    if cost <= 0:
+        return False
+    ratio = cost / float(limit)
+    period_id = info["period_id"]
+
+    fired = _budget.setdefault("alerts_fired", {})
+    sent_any = False
+    # Walk thresholds high-to-low; fire the highest one crossed that hasn't
+    # been fired yet for this period. Mark all lower not-yet-fired thresholds
+    # as fired too so we don't trigger a cascade on the next call.
+    for thresh, level_label, pct_label in BUDGET_THRESHOLDS:
+        key = alert_key(window, pct_label, period_id)
+        if ratio >= thresh and key not in fired:
+            if not sent_any:
+                msg = format_alert(window, info, float(limit), level_label, ratio)
+                if _send_alert is not None:
+                    try:
+                        await _send_alert(msg)
+                        sent_any = True
+                    except Exception as e:
+                        logger.warning(f"[budget] alert send failed: {e}")
+                        return False
+                else:
+                    # No callback wired (tests, dry-runs). Treat as a successful
+                    # "would-have-sent" so the cooldown still gets marked —
+                    # avoids a tight alert loop on misconfiguration.
+                    sent_any = True
+            fired[key] = True
+    if sent_any:
+        _save_budget()
+    return sent_any
+
+
+async def budget_check_all() -> None:
+    """Public entrypoint: check both day + week windows. Wired into
+    /track (per-call) and the hourly sweep (catches missed alerts and
+    week-rollover edge cases)."""
+    try:
+        await _budget_check_window("day")
+        await _budget_check_window("week")
+    except Exception as e:
+        logger.warning(f"[budget] sweep error: {e}")
+
+
+async def hourly_budget_sweep() -> None:
+    """Hourly background task. Defensive — `_budget_check_window` is also
+    called from /track, but that path can be skipped if AZ batches /track
+    or fails-quiet. Hourly cadence is plenty for a 24h-budget signal."""
+    logger.info("Hourly budget sweep started")
+    while True:
+        try:
+            await asyncio.sleep(3600)  # 1 hour
+            await budget_check_all()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[budget] hourly sweep error: {e}")

--- a/tests/test_bridge_budget_engine.py
+++ b/tests/test_bridge_budget_engine.py
@@ -1,0 +1,266 @@
+"""Pin telegram-bridge/budget/engine.py — Phase K carve.
+
+Pinning the threshold-walk semantics + cooldown-key bookkeeping.
+`_budget_check_window` is the load-bearing piece — its exact behavior
+defines when users get alerted vs not. Two regression-prone properties:
+
+1. Highest crossed threshold fires first; lower ones skipped that call.
+2. Once a (period, threshold) key is in `alerts_fired`, it never fires
+   again that period (avoids spam on every /track).
+
+`_compute_window_cost` is mostly window-math + delegation to task_agg
+which is already pinned. Pin its shape so callers can rely on the
+field names.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent / "telegram-bridge"
+
+
+def _load_engine_module(tmp_path):
+    """Wire pricing.cost + task_agg.agg + budget.core, then load
+    budget.engine against the on-disk file."""
+    pricing_pkg = types.ModuleType("pricing")
+    pricing_pkg.__path__ = [str(_ROOT / "pricing")]  # type: ignore[attr-defined]
+    sys.modules["pricing"] = pricing_pkg
+    cost_spec = importlib.util.spec_from_file_location(
+        "pricing.cost", _ROOT / "pricing" / "cost.py"
+    )
+    assert cost_spec and cost_spec.loader
+    cost_mod = importlib.util.module_from_spec(cost_spec)
+    sys.modules["pricing.cost"] = cost_mod
+    cost_spec.loader.exec_module(cost_mod)
+
+    tasks_pkg = types.ModuleType("task_agg")
+    tasks_pkg.__path__ = [str(_ROOT / "task_agg")]  # type: ignore[attr-defined]
+    sys.modules["task_agg"] = tasks_pkg
+    agg_spec = importlib.util.spec_from_file_location(
+        "task_agg.agg", _ROOT / "task_agg" / "agg.py"
+    )
+    assert agg_spec and agg_spec.loader
+    agg_mod = importlib.util.module_from_spec(agg_spec)
+    sys.modules["task_agg.agg"] = agg_mod
+    agg_spec.loader.exec_module(agg_mod)
+    agg_mod.TASKS_DIR = str(tmp_path / "tasks")
+
+    budget_pkg = types.ModuleType("budget")
+    budget_pkg.__path__ = [str(_ROOT / "budget")]  # type: ignore[attr-defined]
+    sys.modules["budget"] = budget_pkg
+    core_spec = importlib.util.spec_from_file_location(
+        "budget.core", _ROOT / "budget" / "core.py"
+    )
+    assert core_spec and core_spec.loader
+    core_mod = importlib.util.module_from_spec(core_spec)
+    sys.modules["budget.core"] = core_mod
+    core_spec.loader.exec_module(core_mod)
+    core_mod.BUDGET_DIR = str(tmp_path)
+    core_mod.BUDGET_PATH = str(tmp_path / "budget.json")
+
+    eng_spec = importlib.util.spec_from_file_location(
+        "budget.engine", _ROOT / "budget" / "engine.py"
+    )
+    assert eng_spec and eng_spec.loader
+    eng = importlib.util.module_from_spec(eng_spec)
+    sys.modules["budget.engine"] = eng
+    eng_spec.loader.exec_module(eng)
+    return eng, core_mod, agg_mod
+
+
+def _write_task(tasks_dir: Path, task_id: str, started_iso: str, cost: float) -> None:
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps({
+            "task_id": task_id,
+            "started_at": started_iso,
+            "ended_reason": "completed",
+            "totals": {"cost_usd": cost, "tool_calls": 0, "llm_calls": 1},
+            "llm_calls": [{"model": "claude-sonnet-4-5", "cost_usd": cost}],
+        }),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def engine(tmp_path, monkeypatch):
+    eng, core, agg = _load_engine_module(tmp_path)
+    # Reset state between tests.
+    core._budget.clear()
+    core._budget.update(core._budget_default())
+    eng._send_alert = None
+    # Pin "now" so windowed maths is deterministic.
+    KST = timezone(timedelta(hours=9))
+    fixed_now = datetime(2026, 5, 8, 12, 0, tzinfo=KST).replace(tzinfo=None)
+    monkeypatch.setattr(eng, "_kst_now", lambda: fixed_now)
+    return {"eng": eng, "core": core, "agg": agg, "tmp": tmp_path}
+
+
+# ── _compute_window_cost ─────────────────────────────────────────────
+
+
+def test_compute_window_cost_day_shape(engine):
+    """All five contract fields present, regardless of task data."""
+    info = engine["eng"]._compute_window_cost("day")
+    assert set(info.keys()) == {"cost_usd", "tasks", "top_model", "period_id", "label"}
+    assert info["period_id"] == "2026-05-08"
+    assert "오늘" in info["label"]
+    assert info["cost_usd"] == 0.0
+    assert info["tasks"] == 0
+    assert info["top_model"] is None
+
+
+def test_compute_window_cost_week_label(engine):
+    info = engine["eng"]._compute_window_cost("week")
+    assert "최근 7일" in info["label"]
+    # period_id is the ISO week string (G-W format)
+    assert info["period_id"].startswith("2026-W")
+
+
+def test_compute_window_cost_unknown_window_raises(engine):
+    with pytest.raises(ValueError, match="unknown window"):
+        engine["eng"]._compute_window_cost("month")
+
+
+def test_compute_window_cost_picks_top_model(engine):
+    """When tasks contain LLM calls, top_model returns (name, cost) of
+    the highest-cost model in the window."""
+    started = "2026-05-08T08:00:00+00:00"  # 17:00 KST 2026-05-08, in window
+    _write_task(engine["tmp"] / "tasks", "t1", started, 1.0)
+    info = engine["eng"]._compute_window_cost("day")
+    assert info["tasks"] == 1
+    assert info["cost_usd"] == pytest.approx(1.0)
+    assert info["top_model"] is not None
+    name, cost = info["top_model"]
+    assert name == "claude-sonnet-4-5"
+    assert cost == pytest.approx(1.0)
+
+
+# ── _budget_check_window ─────────────────────────────────────────────
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_check_window_no_limit_returns_false(engine):
+    """No limit configured → no alert ever fires."""
+    engine["core"]._budget["day_limit_usd"] = None
+    sent = _run(engine["eng"]._budget_check_window("day"))
+    assert sent is False
+
+
+def test_check_window_no_cost_returns_false(engine):
+    """Limit set, but no spend in window → no alert."""
+    engine["core"]._budget["day_limit_usd"] = 5.0
+    sent = _run(engine["eng"]._budget_check_window("day"))
+    assert sent is False
+
+
+def test_check_window_fires_highest_crossed(engine):
+    """When 100% is crossed (and 80% is also crossed implicitly), the
+    HIGHEST level fires; lower thresholds also marked fired so they
+    don't cascade on the next call. Test calls fake send_alert."""
+    engine["core"]._budget["day_limit_usd"] = 5.0
+    started = "2026-05-08T08:00:00+00:00"  # in window
+    _write_task(engine["tmp"] / "tasks", "t1", started, 5.5)  # 110% of limit
+
+    sent_msgs = []
+
+    async def fake_send(msg):
+        sent_msgs.append(msg)
+
+    engine["eng"]._send_alert = fake_send
+    sent = _run(engine["eng"]._budget_check_window("day"))
+    assert sent is True
+    # Exactly ONE telegram message — the 100% (highest crossed) one.
+    assert len(sent_msgs) == 1
+    assert "❌ 초과" in sent_msgs[0]  # 100% level_label
+
+    # Both 80% and 100% keys marked fired (so next /track doesn't re-trigger).
+    fired = engine["core"]._budget["alerts_fired"]
+    assert "2026-05-08:day:80%" in fired
+    assert "2026-05-08:day:100%" in fired
+
+
+def test_check_window_cooldown_blocks_repeat(engine):
+    """After the first alert fires, a second call same-period must NOT
+    re-send even if spend keeps climbing."""
+    engine["core"]._budget["day_limit_usd"] = 5.0
+    started = "2026-05-08T08:00:00+00:00"
+    _write_task(engine["tmp"] / "tasks", "t1", started, 4.5)  # 90% — crosses 80%
+
+    sent_msgs = []
+
+    async def fake_send(msg):
+        sent_msgs.append(msg)
+
+    engine["eng"]._send_alert = fake_send
+
+    # First call: 80% fires (warning level).
+    assert _run(engine["eng"]._budget_check_window("day")) is True
+    assert len(sent_msgs) == 1
+    assert "⚠️ 주의" in sent_msgs[0]
+    assert "2026-05-08:day:80%" in engine["core"]._budget["alerts_fired"]
+
+    # Second call same-period: cooldown blocks it even though still over 80%.
+    assert _run(engine["eng"]._budget_check_window("day")) is False
+    assert len(sent_msgs) == 1  # unchanged
+
+
+def test_check_window_higher_threshold_after_lower(engine):
+    """Realistic scenario: cost ramps from 80% to 110% across two
+    calls. First call fires 80%, second fires 100% (since 100% wasn't
+    yet in fired-set)."""
+    engine["core"]._budget["day_limit_usd"] = 5.0
+    sent_msgs = []
+
+    async def fake_send(msg):
+        sent_msgs.append(msg)
+
+    engine["eng"]._send_alert = fake_send
+
+    # First call: at 90% spend → 80% (warning) level fires.
+    _write_task(engine["tmp"] / "tasks", "t1", "2026-05-08T08:00:00+00:00", 4.5)
+    _run(engine["eng"]._budget_check_window("day"))
+    assert "⚠️ 주의" in sent_msgs[0]
+
+    # More spending pushes to 110%. Second call fires 100% (next-up
+    # threshold that wasn't yet in fired-set).
+    _write_task(engine["tmp"] / "tasks", "t2", "2026-05-08T08:30:00+00:00", 1.0)
+    _run(engine["eng"]._budget_check_window("day"))
+    assert len(sent_msgs) == 2
+    assert "❌ 초과" in sent_msgs[1]
+
+
+def test_configure_sets_send_alert(engine):
+    """`configure(send_alert=...)` is the one public way to wire
+    the callback. Without it, alerts log but don't propagate."""
+    cb_calls = []
+
+    async def cb(msg):
+        cb_calls.append(msg)
+
+    engine["eng"].configure(send_alert=cb)
+    assert engine["eng"]._send_alert is cb
+
+
+def test_check_window_no_callback_marks_cooldown_anyway(engine):
+    """When no `_send_alert` is wired, the threshold still marks the
+    cooldown — otherwise a misconfigured deploy would alert on every
+    single /track in a tight loop."""
+    engine["core"]._budget["day_limit_usd"] = 5.0
+    _write_task(engine["tmp"] / "tasks", "t1", "2026-05-08T08:00:00+00:00", 4.5)
+    engine["eng"]._send_alert = None
+
+    sent = _run(engine["eng"]._budget_check_window("day"))
+    assert sent is True
+    assert "2026-05-08:day:80%" in engine["core"]._budget["alerts_fired"]


### PR DESCRIPTION
**TL;DR**: bot.py 의 async budget 엔진 (윈도우 비용 계산 + 임계 알림 + cooldown + hourly sweep)을 [`budget/engine.py`](telegram-bridge/budget/engine.py) 로 이동. send_telegram 콜백 주입. 11개 테스트로 임계 walk + cooldown invariant 핀.

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase K. bot.py 누적: **3,579 → 1,693** (−53%).

---

## 옮긴 것 (4)

| 심볼 | 역할 |
|---|---|
| `_compute_window_cost(window)` | 윈도우(day/week) task JSON 집계 |
| `_budget_check_window(window)` | 임계 walk + 단일 알림 + cooldown |
| `budget_check_all()` | day + week 양쪽 검사, /track + sweep 진입점 |
| `hourly_budget_sweep()` | 24h 백그라운드 루프 |

bot.py 는 4개 모두 re-export. /track handler, /budget cmd, post_init scheduler 호출 지점 변경 없음.

## 핵심 디자인 — telegram 콜백 주입

기존 `_budget_check_window` 가 `send_telegram` 직접 호출 → 모듈 분리 시 telegram 의존 따라옴.

[`pricing/snapshot.py`](telegram-bridge/pricing/snapshot.py) 와 동일 패턴 — 모듈 레벨 콜백 슬롯 + `configure()`:

```python
# budget/engine.py
_send_alert = None

def configure(*, send_alert):
    global _send_alert
    _send_alert = send_alert
```

bot.py main() 에서 한 번 wire:
```python
import budget.engine
budget.engine.configure(send_alert=send_telegram)
```

콜백 미설정 시에도 cooldown 마킹 → misconfigured 배포가 tight loop 알림 안 함 (방어적 처리, `test_check_window_no_callback_marks_cooldown_anyway` 가 핀).

## 테스트 11종 ([tests/test_bridge_budget_engine.py](tests/test_bridge_budget_engine.py))

**`_compute_window_cost`** (4):
- 5개 필드 contract
- day vs week label / period_id
- 알 수 없는 window → ValueError
- top_model 픽 (cost 최대 모델)

**`_budget_check_window`** (5):
- 한도 없음 → False
- 비용 없음 → False
- 110% 지출 시 highest level (100%) 만 발화, 80% 도 fired-set 마킹
- 같은 period 재호출 cooldown blocking (load-bearing invariant)
- 90% → 110% 점진 상승 시 80% 첫 발화, 100% 다음 호출에서 발화

**메타** (2):
- `configure(send_alert=)` 콜백 wiring
- 콜백 미설정 시 cooldown 마킹 (tight-loop 방어)

## 검증

```
$ ruff check .          # All checks passed!
$ pytest -q             # 156 passed in 0.80s  (145 + 11 신규)

$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge | grep budget
budget.engine - INFO - Hourly budget sweep started
                       ^^^^^^^^^^^^^^^^ 새 모듈에서 sweep 동작
```

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup / #77 CI / #81 preflight
- ✅ #79 Phase A-J (11개 모듈)
- 🔄 **#79 Phase K — budget/engine ← 본 PR**
- ⏳ #79 future — monitor state + monitor loop, send_telegram + tg_bot, 나머지 cmd 그룹들, webhook handlers
- ⏳ #78 GUIDE 재작성 / #80 plugin manifest / #82 docs/plugins.md

## bot.py 누적

| Phase | 누적 줄수 | Δ |
|---|---|---|
| 시작 | 3,579 | — |
| A → J | 1,788 | -1,791 |
| **K (budget engine)** | **1,693** | **-95** |

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) acceptance ("bot.py 1,000 lines 이하") 까지 ~693 줄.

## Test plan

- [x] ruff clean / 156/156 pytest
- [x] container rebuild + 시작
- [x] `budget.engine` 로거가 sweep 시작 로그 발생 (carved module 동작 증거)