### PR TITLE
refactor(bridge): send_telegram `notify/telegram.py` 분리 (#79 Phase L)

### DIFF
--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -15,5 +15,6 @@ COPY dashboard/ ./dashboard/
 COPY render/ ./render/
 COPY az_client/ ./az_client/
 COPY telegram_handlers/ ./telegram_handlers/
+COPY notify/ ./notify/
 
 CMD ["python", "bot.py"]

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -201,60 +201,12 @@ from pricing.usage import (
 )
 
 
-# ── Telegram 메시지 전송 헬퍼 ──
-async def send_telegram(
-    text: str,
-    parse_mode: str | None = None,
-    fallback_text: str | None = None,
-):
-    """Send `text` to Telegram with optional `parse_mode` (HTML / Markdown).
-
-    `fallback_text` (recommended when parse_mode is set): a plain-text
-    version sent if Telegram rejects the formatted payload with a parse
-    error. Useful when AZ output produces malformed HTML/markdown despite
-    our converter — better the user gets the raw text than nothing.
-
-    Long messages (>4000 chars) are split. The fallback is only retried
-    for the chunk that actually failed parsing; other chunks aren't
-    re-sent so the user doesn't get duplicates.
-    """
-    if not tg_bot or not text.strip():
-        return
-
-    chunks = (
-        [text[i : i + 4000] for i in range(0, len(text), 4000)]
-        if len(text) > 4000 else [text]
-    )
-    fallback_chunks = None
-    if fallback_text and len(text) > 4000:
-        fallback_chunks = [
-            fallback_text[i : i + 4000] for i in range(0, len(fallback_text), 4000)
-        ]
-
-    for idx, chunk in enumerate(chunks):
-        try:
-            await tg_bot.send_message(
-                chat_id=CHAT_ID, text=chunk, parse_mode=parse_mode
-            )
-        except Exception as e:
-            err = str(e).lower()
-            # Telegram returns "Bad Request: can't parse entities" on bad
-            # HTML/Markdown. Retry the SAME chunk in plain mode.
-            if parse_mode and ("can't parse" in err or "parse entities" in err):
-                fb = (
-                    fallback_chunks[idx] if fallback_chunks
-                    else (fallback_text if fallback_text and len(chunks) == 1 else chunk)
-                )
-                logger.warning(
-                    f"[telegram] parse_mode={parse_mode} rejected, "
-                    f"retrying chunk {idx} as plain"
-                )
-                try:
-                    await tg_bot.send_message(chat_id=CHAT_ID, text=fb)
-                except Exception as e2:
-                    logger.error(f"[telegram] plain fallback also failed: {e2}")
-            else:
-                logger.error(f"[telegram] send failed: {e}")
+# `send_telegram` moved to `notify/telegram.py` (issue #79 Phase L).
+# Re-exported here for the ~30 call sites still in bot.py (cmd handlers,
+# monitor loop, streaming-edit path, webhook handlers). The Bot instance
+# + CHAT_ID get wired into the carved-out module from `post_init` once
+# Application.bot is available — search for `notify.telegram.configure`.
+from notify.telegram import send_telegram  # noqa: E402, F401
 
 
 # `fetch_chat_list` and `sync_log_version` moved to
@@ -1624,6 +1576,14 @@ async def daily_usage_reporter():
 async def post_init(application: Application):
     global tg_bot
     tg_bot = application.bot
+
+    # Wire the Bot instance into the carved-out send_telegram module
+    # (issue #79 Phase L). bot.py keeps its own `tg_bot` global pointing
+    # at the SAME Bot object for the streaming + cmd_logs/docs/backup
+    # paths that still reach for `tg_bot.send_document` etc.
+    import notify.telegram
+    notify.telegram.configure(bot=application.bot, chat_id=CHAT_ID)
+
     asyncio.create_task(monitor_agent_zero())
     asyncio.create_task(daily_usage_reporter())
     # M5-A: hourly budget sweep — defensive double-check on top of the

--- a/telegram-bridge/notify/__init__.py
+++ b/telegram-bridge/notify/__init__.py
@@ -1,0 +1,15 @@
+"""Telegram notification helpers — Phase L carve from bot.py (issue #79).
+
+Currently houses `send_telegram(text, parse_mode, fallback_text)` —
+the long-message-aware sender with parse-error fallback. bot.py wires
+the `Bot` instance + chat ID once at startup via
+`notify.telegram.configure(bot=..., chat_id=...)`.
+
+Kept as a package even with one file so future additions (e.g.
+typing-indicator helper, document-send wrappers, multi-chat router)
+can grow alongside it without renaming.
+"""
+
+from .telegram import configure, send_telegram
+
+__all__ = ["configure", "send_telegram"]

--- a/telegram-bridge/notify/telegram.py
+++ b/telegram-bridge/notify/telegram.py
@@ -1,0 +1,94 @@
+"""`send_telegram` — long-aware Telegram sender with parse-error fallback.
+
+Phase L carve from bot.py (issue #79). The function used to read the
+module-level `tg_bot` and `CHAT_ID` globals from bot.py directly.
+After the carve it relies on a small `configure()` injection so the
+module stays import-clean of the bot.py state surface (same pattern
+as `pricing/snapshot.py:take_pricing_snapshot` and
+`budget/engine.py`).
+
+Why a configure() slot rather than passing bot+chat_id every call:
+the function fans out across ~30 call sites (cmd_*, handlers, monitor
+loop, budget engine via callback, etc.). Threading the bot reference
+through every one of those would balloon this PR. configure() runs
+exactly once at startup right after `application.bot` becomes
+available, and the call sites stay one-arg.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level injection slots. bot.py's main() / post_init wires
+# these once via `configure(bot=tg_bot, chat_id=CHAT_ID)`. Until then,
+# `send_telegram` is a no-op (handy for tests + early-boot calls
+# during the wiring window).
+_bot = None
+_chat_id: int | None = None
+
+
+def configure(*, bot, chat_id: int) -> None:
+    """Wire the Telegram `Bot` instance + chat ID. Call once during
+    `main()` after `Application.builder().build()` produces the bot
+    object. Idempotent — last call wins.
+    """
+    global _bot, _chat_id
+    _bot = bot
+    _chat_id = int(chat_id)
+
+
+async def send_telegram(
+    text: str,
+    parse_mode: str | None = None,
+    fallback_text: str | None = None,
+) -> None:
+    """Send `text` to Telegram with optional `parse_mode` (HTML / Markdown).
+
+    `fallback_text` (recommended when parse_mode is set): a plain-text
+    version sent if Telegram rejects the formatted payload with a parse
+    error. Useful when AZ output produces malformed HTML/markdown despite
+    our converter — better the user gets the raw text than nothing.
+
+    Long messages (>4000 chars) are split. The fallback is only retried
+    for the chunk that actually failed parsing; other chunks aren't
+    re-sent so the user doesn't get duplicates.
+    """
+    if _bot is None or _chat_id is None or not text.strip():
+        return
+
+    chunks = (
+        [text[i : i + 4000] for i in range(0, len(text), 4000)]
+        if len(text) > 4000 else [text]
+    )
+    fallback_chunks = None
+    if fallback_text and len(text) > 4000:
+        fallback_chunks = [
+            fallback_text[i : i + 4000] for i in range(0, len(fallback_text), 4000)
+        ]
+
+    for idx, chunk in enumerate(chunks):
+        try:
+            await _bot.send_message(
+                chat_id=_chat_id, text=chunk, parse_mode=parse_mode,
+            )
+        except Exception as e:
+            err = str(e).lower()
+            # Telegram returns "Bad Request: can't parse entities" on bad
+            # HTML/Markdown. Retry the SAME chunk in plain mode.
+            if parse_mode and ("can't parse" in err or "parse entities" in err):
+                fb = (
+                    fallback_chunks[idx] if fallback_chunks
+                    else (fallback_text if fallback_text and len(chunks) == 1 else chunk)
+                )
+                logger.warning(
+                    f"[telegram] parse_mode={parse_mode} rejected, "
+                    f"retrying chunk {idx} as plain"
+                )
+                try:
+                    await _bot.send_message(chat_id=_chat_id, text=fb)
+                except Exception as e2:
+                    logger.error(f"[telegram] plain fallback also failed: {e2}")
+            else:
+                logger.error(f"[telegram] send failed: {e}")

--- a/tests/test_bridge_notify_telegram.py
+++ b/tests/test_bridge_notify_telegram.py
@@ -1,0 +1,194 @@
+"""Pin telegram-bridge/notify/telegram.py — Phase L carve.
+
+`send_telegram` is the bridge's only outbound telegram path. Its
+behaviors with regression history:
+
+- Long-message chunking at 4000 chars (telegram's hard cap is 4096;
+  we leave headroom for the formatter)
+- parse_mode fallback to plain text on "can't parse entities"
+- No-op when bot/chat_id unconfigured (early-boot calls before wiring)
+- Empty / whitespace-only text → no-op
+- fallback_text only used for the chunk that actually failed parsing
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_PATH = (
+    Path(__file__).resolve().parent.parent / "telegram-bridge" / "notify" / "telegram.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("bridge_notify_tg", _PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def tg():
+    mod = _load()
+    # Reset state between tests.
+    mod._bot = None
+    mod._chat_id = None
+    return mod
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ── Fake Bot ──────────────────────────────────────────────────────────
+
+
+class _FakeBot:
+    """Records every send_message call. Optionally raises a parse-error
+    exception on the first attempt for a given chunk index."""
+
+    def __init__(self, raise_on_first_chunk: bool = False, raise_msg: str = ""):
+        self.calls = []
+        self.raise_on_first_chunk = raise_on_first_chunk
+        self.raise_msg = raise_msg
+        self._first_done = False
+
+    async def send_message(self, chat_id, text, parse_mode=None):
+        # Raise once on the first chunk; subsequent (incl. fallback) succeed.
+        if self.raise_on_first_chunk and not self._first_done:
+            self._first_done = True
+            self.calls.append({"chat_id": chat_id, "text": text,
+                               "parse_mode": parse_mode, "raised": True})
+            raise Exception(self.raise_msg)
+        self.calls.append({"chat_id": chat_id, "text": text,
+                           "parse_mode": parse_mode, "raised": False})
+
+
+# ── no-op paths ───────────────────────────────────────────────────────
+
+
+def test_no_bot_configured_is_noop(tg):
+    """Early-boot calls before configure() must not crash."""
+    _run(tg.send_telegram("hello"))
+    # No exception is the assertion.
+
+
+def test_empty_text_is_noop(tg):
+    bot = _FakeBot()
+    tg.configure(bot=bot, chat_id=42)
+    _run(tg.send_telegram(""))
+    _run(tg.send_telegram("   \n  "))
+    assert bot.calls == []
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+def test_short_message_one_call(tg):
+    bot = _FakeBot()
+    tg.configure(bot=bot, chat_id=42)
+    _run(tg.send_telegram("안녕하세요", parse_mode="HTML"))
+    assert len(bot.calls) == 1
+    c = bot.calls[0]
+    assert c["chat_id"] == 42
+    assert c["text"] == "안녕하세요"
+    assert c["parse_mode"] == "HTML"
+
+
+def test_chat_id_coerced_to_int(tg):
+    """configure() accepts str chat_id from env and coerces; later
+    sends use the int form."""
+    bot = _FakeBot()
+    tg.configure(bot=bot, chat_id="123")  # type: ignore[arg-type]
+    _run(tg.send_telegram("x"))
+    assert bot.calls[0]["chat_id"] == 123
+
+
+# ── chunking ──────────────────────────────────────────────────────────
+
+
+def test_chunked_when_over_4000(tg):
+    bot = _FakeBot()
+    tg.configure(bot=bot, chat_id=42)
+    big = "x" * 9000  # 3 chunks: 4000 + 4000 + 1000
+    _run(tg.send_telegram(big))
+    assert len(bot.calls) == 3
+    assert len(bot.calls[0]["text"]) == 4000
+    assert len(bot.calls[1]["text"]) == 4000
+    assert len(bot.calls[2]["text"]) == 1000
+
+
+def test_exactly_4000_one_chunk(tg):
+    bot = _FakeBot()
+    tg.configure(bot=bot, chat_id=42)
+    _run(tg.send_telegram("y" * 4000))
+    assert len(bot.calls) == 1
+    assert len(bot.calls[0]["text"]) == 4000
+
+
+# ── parse_mode fallback ───────────────────────────────────────────────
+
+
+def test_parse_error_falls_back_to_plain(tg):
+    """When telegram returns "can't parse entities", retry the SAME
+    chunk in plain mode (no parse_mode)."""
+    bot = _FakeBot(raise_on_first_chunk=True, raise_msg="Bad Request: can't parse entities")
+    tg.configure(bot=bot, chat_id=42)
+    _run(tg.send_telegram("<b>broken", parse_mode="HTML",
+                          fallback_text="<b>broken (plain)"))
+    # 2 calls — first raised (HTML), second succeeded (plain fallback).
+    assert len(bot.calls) == 2
+    assert bot.calls[0]["raised"] is True
+    assert bot.calls[0]["parse_mode"] == "HTML"
+    assert bot.calls[1]["raised"] is False
+    assert bot.calls[1]["parse_mode"] is None  # plain mode
+    assert bot.calls[1]["text"] == "<b>broken (plain)"
+
+
+def test_non_parse_error_does_not_retry(tg):
+    """Network errors / other failures don't trigger the parse-fallback path."""
+    bot = _FakeBot(raise_on_first_chunk=True, raise_msg="Connection refused")
+    tg.configure(bot=bot, chat_id=42)
+    _run(tg.send_telegram("hi", parse_mode="HTML"))
+    assert len(bot.calls) == 1  # raised once, no retry
+
+
+def test_no_parse_mode_no_retry(tg):
+    """If there's no parse_mode, parse-error retry doesn't fire either."""
+    bot = _FakeBot(raise_on_first_chunk=True, raise_msg="Bad Request: can't parse")
+    tg.configure(bot=bot, chat_id=42)
+    _run(tg.send_telegram("plain"))  # no parse_mode
+    assert len(bot.calls) == 1
+
+
+def test_fallback_text_per_chunk_indexing(tg):
+    """When the message is chunked AND parse fails on chunk N, the
+    fallback for THAT chunk index is used (not the whole fallback_text)."""
+    big = "x" * 9000  # 3 chunks
+    fallback_big = "y" * 9000  # 3 fallback chunks
+    bot = _FakeBot()
+    tg.configure(bot=bot, chat_id=42)
+    _run(tg.send_telegram(big, parse_mode="HTML", fallback_text=fallback_big))
+    # No parse errors, so all 3 chunks send normally — fallback isn't touched.
+    assert len(bot.calls) == 3
+    for c in bot.calls:
+        assert "x" in c["text"]
+        assert "y" not in c["text"]
+
+
+# ── configure() ───────────────────────────────────────────────────────
+
+
+def test_configure_idempotent_last_wins(tg):
+    bot1 = _FakeBot()
+    bot2 = _FakeBot()
+    tg.configure(bot=bot1, chat_id=1)
+    tg.configure(bot=bot2, chat_id=2)
+    _run(tg.send_telegram("hi"))
+    assert bot1.calls == []
+    assert len(bot2.calls) == 1
+    assert bot2.calls[0]["chat_id"] == 2


### PR DESCRIPTION
**TL;DR**: bot.py 의 `send_telegram` (~55줄, 메시지 청킹 + parse_mode fallback) 을 [`notify/telegram.py`](telegram-bridge/notify/telegram.py) 로 이동. configure() 콜백 주입 패턴. 11개 테스트로 chunking + fallback + no-op invariant 핀.

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase L. bot.py 누적: **3,579 → 1,653** (−54%).

---

## 옮긴 것

| 심볼 | 이전 → 이후 |
|---|---|
| `send_telegram(text, parse_mode, fallback_text)` | `bot.py` → `notify/telegram.py` |

bot.py 는 re-export. 30여 호출 지점 (cmd 핸들러, monitor 루프, streaming-edit 경로, webhook handlers, budget engine via callback) 변경 없음.

## 핵심 디자인 — `configure()` 콜백 주입

기존 `send_telegram` 이 `tg_bot`, `CHAT_ID` 글로벌 직접 참조 → 모듈 분리 시 의존 따라옴.

[`pricing/snapshot.py`](telegram-bridge/pricing/snapshot.py), [`budget/engine.py`](telegram-bridge/budget/engine.py) 와 동일 패턴 — 모듈 레벨 슬롯 + `configure()`:

```python
# notify/telegram.py
_bot = None
_chat_id: int | None = None

def configure(*, bot, chat_id):
    global _bot, _chat_id
    _bot = bot
    _chat_id = int(chat_id)
```

bot.py `post_init` 에서 wire (Application.bot 사용 가능 시점):
```python
import notify.telegram
notify.telegram.configure(bot=application.bot, chat_id=CHAT_ID)
```

callback 미설정 시 `send_telegram` no-op — 부팅 초기 wiring window 안전.

## 남겨둔 것 (다음 phase)

bot.py 의 `tg_bot` 글로벌 그대로 유지. 다음 use:
- `_stream_extend` 의 `tg_bot.edit_message_text`
- `cmd_logs` / `cmd_docs` / `cmd_backup` 의 `tg_bot.send_document`

streaming state + document-send paths 는 향후 phase 에서 함께 carve.

## 테스트 11종 ([tests/test_bridge_notify_telegram.py](tests/test_bridge_notify_telegram.py))

| 영역 | 케이스 |
|---|---|
| No-op | configure() 전 호출, 빈/공백 텍스트 |
| Happy path | 짧은 메시지, chat_id str→int 변환 |
| Chunking | 9000자 → 3 청크, 정확히 4000자 → 1 청크 |
| parse_mode fallback | "can't parse entities" → plain 재시도 |
| Non-parse 에러 | 재시도 안 함 (네트워크 에러는 그대로) |
| parse_mode 없음 | 재시도 경로 비활성 |
| fallback per-chunk | chunked 메시지 정상 시 fallback_text 손 안 댐 |
| configure() 멱등성 | last-call wins |

## 검증

```
$ ruff check .          # All checks passed!
$ pytest -q             # 167 passed in 0.66s  (156 + 11 신규)

$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge | grep started
Webhook server started on :8443
Telegram Bridge Bot started (with monitor + multi-chat)
budget.engine - INFO - Hourly budget sweep started
Application started
```

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup / #77 CI / #81 preflight
- ✅ #79 Phase A-K (12개 모듈)
- 🔄 **#79 Phase L — notify/telegram ← 본 PR**
- ⏳ #79 future — streaming + 모니터 루프, document-send 경로, webhook handlers, 나머지 cmd 그룹들

## bot.py 누적

| Phase | 누적 줄수 | Δ |
|---|---|---|
| 시작 | 3,579 | — |
| A → K | 1,693 | -1,886 |
| **L (notify/telegram)** | **1,653** | **-40** |

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) acceptance ("bot.py 1,000 lines 이하") 까지 ~653 줄.

## Test plan

- [x] ruff clean / 167/167 pytest
- [x] container rebuild + 시작
- [x] post_init 에서 `notify.telegram.configure` 주입 동작 확인 (모니터 + sweep + scheduler 정상 시작)