### PR TITLE
refactor(bridge): webhook 핸들러 `webhooks/handlers.py` 분리 (#79 Phase M)

### DIFF
--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -16,5 +16,6 @@ COPY render/ ./render/
 COPY az_client/ ./az_client/
 COPY telegram_handlers/ ./telegram_handlers/
 COPY notify/ ./notify/
+COPY webhooks/ ./webhooks/
 
 CMD ["python", "bot.py"]

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -1409,130 +1409,15 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 # ── Notification & Usage webhook ──
-async def webhook_handler(request):
-    """HTTP POST → Telegram forwarding.
-
-    Payload:
-      {
-        "text": "...",
-        "markdown": true,        # optional — convert text from markdown to
-                                 # Telegram-safe HTML before sending
-        "parse_mode": "HTML",    # optional — sent verbatim if you've
-                                 # already-formatted HTML/MarkdownV2
-        "kind": "task_response"  # optional — adds a UI prefix emoji
-                                 # AFTER markdown conversion so leading
-                                 # `## header` / `| table |` aren't
-                                 # displaced from line-start
-      }
-
-    `markdown: true` is the easy path: senders write plain markdown
-    (```code```, **bold**, etc.) and the bridge handles conversion +
-    fallback to plain text on parse failure. AZ's task_report uses this
-    with kind="task_response" so the 🤖 emoji lands AFTER conversion.
-    """
-    # Map of `kind` → UI prefix emoji + space. Keep tiny; this is purely
-    # presentation. Empty/unknown kind → no prefix.
-    KIND_PREFIX = {
-        "task_response": "🤖 ",
-    }
-    try:
-        data = await request.json()
-        raw_text = data.get("text", data.get("message", str(data)))
-        parse_mode = data.get("parse_mode")
-        kind = data.get("kind")
-        prefix = KIND_PREFIX.get(kind, "")
-
-        if data.get("markdown"):
-            # Convert THEN prefix — order matters. If we prefixed first,
-            # leading "## header" would no longer be at line-start, breaking
-            # the converter's `^#` regex. Same goes for table rows
-            # starting with `|`.
-            converted = md_to_telegram_html(raw_text)
-            if prefix:
-                converted = f"{prefix}{converted}"
-                fallback = f"{prefix}{raw_text}"
-            else:
-                fallback = raw_text
-            await send_telegram(
-                converted,
-                parse_mode="HTML",
-                fallback_text=fallback,
-            )
-        else:
-            text = f"{prefix}{raw_text}" if prefix else raw_text
-            await send_telegram(text, parse_mode=parse_mode)
-        return web.json_response({"ok": True})
-    except Exception as e:
-        return web.json_response({"ok": False, "error": str(e)}, status=500)
-
-
-async def usage_track_handler(request):
-    """HTTP POST로 토큰 사용량 기록 (cache + reasoning 토큰 포함).
-
-    Payload: {
-        "model": "anthropic/claude-sonnet-4-6",
-        "input_tokens": 1500,
-        "output_tokens": 500,
-        "cache_read_tokens": 0,        # optional (Anthropic prompt caching)
-        "cache_creation_tokens": 0,    # optional
-        "reasoning_tokens": 0          # optional (Claude 4.x extended thinking,
-                                       #          OpenAI o-series; billed at output rate)
-    }
-    """
-    try:
-        data = await request.json()
-        model = data.get("model", "unknown")
-        input_tokens = int(data.get("input_tokens", 0))
-        output_tokens = int(data.get("output_tokens", 0))
-        cache_read = int(data.get("cache_read_tokens", 0))
-        cache_creation = int(data.get("cache_creation_tokens", 0))
-        reasoning = int(data.get("reasoning_tokens", 0))
-        track_usage(
-            model, input_tokens, output_tokens,
-            cache_read, cache_creation, reasoning,
-        )
-        # Budget check fires AFTER track_usage so the cumulative cost in the
-        # on-disk task JSONs has caught up. Fire-and-forget — never let a
-        # failed alert reject the /track request itself.
-        try:
-            await budget_check_all()
-        except Exception as e:
-            logger.warning(f"[budget] post-track check failed: {e}")
-        return web.json_response({
-            "ok": True,
-            "today": usage_today,
-        })
-    except Exception as e:
-        return web.json_response({"ok": False, "error": str(e)}, status=500)
-
-
-async def usage_get_handler(request):
-    """GET 현재 사용량 조회"""
-    return web.json_response({
-        "today": usage_today,
-        "history": usage_history[-7:],
-    })
-
-
-async def run_webhook_server():
-    app = web.Application()
-    app.router.add_post("/notify", webhook_handler)
-    app.router.add_post("/track", usage_track_handler)
-    app.router.add_get("/usage", usage_get_handler)
-    # M5-E: web dashboard (issue #23). Both routes 404 when DASHBOARD_TOKEN
-    # is unset, so registering them is harmless when disabled.
-    app.router.add_get("/api/stats", stats_api_handler)
-    app.router.add_get("/dashboard", dashboard_handler)
-    runner = web.AppRunner(app)
-    await runner.setup()
-    site = web.TCPSite(runner, "0.0.0.0", 8443)
-    await site.start()
-    routes_msg = "/notify, /track, /usage"
-    if DASHBOARD_TOKEN:
-        routes_msg += ", /dashboard, /api/stats (token-protected)"
-    else:
-        routes_msg += " (dashboard disabled — set DASHBOARD_TOKEN to enable)"
-    logger.info(f"Webhook server started on :8443 ({routes_msg})")
+# 4 aiohttp handlers + run_webhook_server moved to `webhooks/handlers.py`
+# (issue #79 Phase M). Re-exported below so `post_init`'s
+# `asyncio.create_task(run_webhook_server())` keeps working unchanged.
+from webhooks.handlers import (  # noqa: E402, F401
+    run_webhook_server,
+    usage_get_handler,
+    usage_track_handler,
+    webhook_handler,
+)
 
 
 # ── 일일 사용량 리포트 스케줄러 ──

--- a/telegram-bridge/webhooks/__init__.py
+++ b/telegram-bridge/webhooks/__init__.py
@@ -1,0 +1,29 @@
+"""HTTP webhook handlers — Phase M carve from bot.py (issue #79).
+
+Houses the four aiohttp handlers behind the bridge's `:8443` server:
+
+- `webhook_handler` — `POST /notify` (Agent Zero → Telegram forwarding)
+- `usage_track_handler` — `POST /track` (token usage accumulator)
+- `usage_get_handler` — `GET /usage` (current usage snapshot)
+- `run_webhook_server` — wires the routes + starts the aiohttp app
+  on port 8443
+
+After previous carves, all dependencies (`md_to_telegram_html`,
+`send_telegram`, `track_usage`, `budget_check_all`, `usage_today`,
+`usage_history`, dashboard handlers) live in their own modules, so
+this carve is pure code motion — no new injection slots needed.
+"""
+
+from .handlers import (
+    run_webhook_server,
+    usage_get_handler,
+    usage_track_handler,
+    webhook_handler,
+)
+
+__all__ = [
+    "webhook_handler",
+    "usage_track_handler",
+    "usage_get_handler",
+    "run_webhook_server",
+]

--- a/telegram-bridge/webhooks/handlers.py
+++ b/telegram-bridge/webhooks/handlers.py
@@ -1,0 +1,155 @@
+"""aiohttp handlers for the bridge's `:8443` HTTP server.
+
+Phase M carve from bot.py (issue #79). Pure code motion — every
+dependency was carved earlier, so the handlers themselves now read
+identical to what bot.py served, just from a smaller module.
+"""
+from __future__ import annotations
+
+import logging
+
+from aiohttp import web
+from budget.engine import budget_check_all
+from dashboard import DASHBOARD_TOKEN, dashboard_handler, stats_api_handler
+from notify.telegram import send_telegram
+from pricing.usage import track_usage, usage_history, usage_today
+from render import md_to_telegram_html
+
+logger = logging.getLogger(__name__)
+
+
+# Map of `kind` → UI prefix emoji + space. Keep tiny; this is purely
+# presentation. Empty/unknown kind → no prefix.
+_KIND_PREFIX = {
+    "task_response": "🤖 ",
+}
+
+
+async def webhook_handler(request):
+    """HTTP POST → Telegram forwarding.
+
+    Payload:
+      {
+        "text": "...",
+        "markdown": true,        # optional — convert text from markdown to
+                                 # Telegram-safe HTML before sending
+        "parse_mode": "HTML",    # optional — sent verbatim if you've
+                                 # already-formatted HTML/MarkdownV2
+        "kind": "task_response"  # optional — adds a UI prefix emoji
+                                 # AFTER markdown conversion so leading
+                                 # `## header` / `| table |` aren't
+                                 # displaced from line-start
+      }
+
+    `markdown: true` is the easy path: senders write plain markdown
+    (```code```, **bold**, etc.) and the bridge handles conversion +
+    fallback to plain text on parse failure. AZ's task_report uses this
+    with kind="task_response" so the 🤖 emoji lands AFTER conversion.
+    """
+    try:
+        data = await request.json()
+        raw_text = data.get("text", data.get("message", str(data)))
+        parse_mode = data.get("parse_mode")
+        kind = data.get("kind")
+        prefix = _KIND_PREFIX.get(kind, "")
+
+        if data.get("markdown"):
+            # Convert THEN prefix — order matters. If we prefixed first,
+            # leading "## header" would no longer be at line-start, breaking
+            # the converter's `^#` regex. Same goes for table rows
+            # starting with `|`.
+            converted = md_to_telegram_html(raw_text)
+            if prefix:
+                converted = f"{prefix}{converted}"
+                fallback = f"{prefix}{raw_text}"
+            else:
+                fallback = raw_text
+            await send_telegram(
+                converted,
+                parse_mode="HTML",
+                fallback_text=fallback,
+            )
+        else:
+            text = f"{prefix}{raw_text}" if prefix else raw_text
+            await send_telegram(text, parse_mode=parse_mode)
+        return web.json_response({"ok": True})
+    except Exception as e:
+        return web.json_response({"ok": False, "error": str(e)}, status=500)
+
+
+async def usage_track_handler(request):
+    """HTTP POST 로 토큰 사용량 기록 (cache + reasoning 토큰 포함).
+
+    Payload: {
+        "model": "anthropic/claude-sonnet-4-6",
+        "input_tokens": 1500,
+        "output_tokens": 500,
+        "cache_read_tokens": 0,        # optional (Anthropic prompt caching)
+        "cache_creation_tokens": 0,    # optional
+        "reasoning_tokens": 0          # optional (Claude 4.x extended thinking,
+                                       #          OpenAI o-series; billed at output rate)
+    }
+    """
+    try:
+        data = await request.json()
+        model = data.get("model", "unknown")
+        input_tokens = int(data.get("input_tokens", 0))
+        output_tokens = int(data.get("output_tokens", 0))
+        cache_read = int(data.get("cache_read_tokens", 0))
+        cache_creation = int(data.get("cache_creation_tokens", 0))
+        reasoning = int(data.get("reasoning_tokens", 0))
+        track_usage(
+            model, input_tokens, output_tokens,
+            cache_read, cache_creation, reasoning,
+        )
+        # Budget check fires AFTER track_usage so the cumulative cost in the
+        # on-disk task JSONs has caught up. Fire-and-forget — never let a
+        # failed alert reject the /track request itself.
+        try:
+            await budget_check_all()
+        except Exception as e:
+            logger.warning(f"[budget] post-track check failed: {e}")
+        return web.json_response({
+            "ok": True,
+            "today": usage_today,
+        })
+    except Exception as e:
+        return web.json_response({"ok": False, "error": str(e)}, status=500)
+
+
+async def usage_get_handler(request):
+    """GET 현재 사용량 조회"""
+    return web.json_response({
+        "today": usage_today,
+        "history": usage_history[-7:],
+    })
+
+
+async def run_webhook_server() -> None:
+    """Start the aiohttp app on :8443 with all bridge routes.
+
+    Routes:
+      POST /notify         — webhook_handler (AZ → Telegram)
+      POST /track          — usage_track_handler (cost accounting)
+      GET  /usage          — usage_get_handler (snapshot)
+      GET  /api/stats      — dashboard JSON (token-gated, 404 if disabled)
+      GET  /dashboard      — dashboard HTML (token-gated, 404 if disabled)
+    """
+    app = web.Application()
+    app.router.add_post("/notify", webhook_handler)
+    app.router.add_post("/track", usage_track_handler)
+    app.router.add_get("/usage", usage_get_handler)
+    # M5-E: web dashboard (issue #23). Both routes 404 when DASHBOARD_TOKEN
+    # is unset, so registering them is harmless when disabled.
+    app.router.add_get("/api/stats", stats_api_handler)
+    app.router.add_get("/dashboard", dashboard_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", 8443)
+    await site.start()
+    routes_msg = "/notify, /track, /usage"
+    if DASHBOARD_TOKEN:
+        routes_msg += ", /dashboard, /api/stats (token-protected)"
+    else:
+        routes_msg += " (dashboard disabled — set DASHBOARD_TOKEN to enable)"
+    logger.info(f"Webhook server started on :8443 ({routes_msg})")

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -138,6 +138,64 @@ def _stub_aiohttp() -> None:
     aiohttp.ClientSession = _FakeClientSession
     aiohttp.CookieJar = _FakeCookieJar
 
+    # `aiohttp.web` — webhook handlers + dashboard handlers use it. We
+    # don't actually start a server in tests; we just need the module
+    # surface to satisfy imports + return inspectable Response/json_response
+    # objects so handler tests can read body bytes.
+    web = _ensure_module("aiohttp.web")
+
+    class _FakeResponse:
+        def __init__(self, *, status=200, body=b"", text=None,
+                     content_type=None, charset=None, headers=None):
+            self.status = status
+            self.body = body if isinstance(body, bytes | bytearray) else (
+                (text or "").encode("utf-8")
+            )
+            self.text = text or ""
+            self.content_type = content_type
+            self.charset = charset
+            self.headers = headers or {}
+
+    def _json_response(data=None, *, status=200, headers=None):
+        import json as _json
+        body = _json.dumps(data).encode("utf-8")
+        return _FakeResponse(status=status, body=body, headers=headers)
+
+    class _FakeApp:
+        def __init__(self):
+            self.router = _FakeRouter()
+
+    class _FakeRouter:
+        def __init__(self):
+            self.routes = []
+
+        def add_post(self, path, handler):
+            self.routes.append(("POST", path, handler))
+
+        def add_get(self, path, handler):
+            self.routes.append(("GET", path, handler))
+
+    class _FakeAppRunner:
+        def __init__(self, *a, **k):
+            pass
+
+        async def setup(self):
+            pass
+
+    class _FakeTCPSite:
+        def __init__(self, *a, **k):
+            pass
+
+        async def start(self):
+            pass
+
+    web.Response = _FakeResponse
+    web.json_response = _json_response
+    web.Application = _FakeApp
+    web.AppRunner = _FakeAppRunner
+    web.TCPSite = _FakeTCPSite
+    aiohttp.web = web
+
 
 def _stub_pdf_render_deps() -> None:
     """`chat_pdf_export.render.render` imports jinja2 + markdown_it +

--- a/tests/test_bridge_webhooks.py
+++ b/tests/test_bridge_webhooks.py
@@ -1,0 +1,389 @@
+"""Pin telegram-bridge/webhooks/handlers.py — Phase M carve.
+
+Pure code-motion carve: every dep was carved earlier, so handler
+behavior didn't change. Pinning the JSON I/O contracts each route
+fulfills, since these are what AZ-side code (task_report, probe) is
+written against:
+
+- POST /track  → 200 with current `usage_today` snapshot in body
+- GET  /usage  → 200 with `usage_today` + last 7 entries of history
+- POST /notify → 200 on happy path; calls send_telegram
+
+webhook_handler's markdown→HTML conversion is already covered by
+test_bridge_render_markdown. Here we just confirm the dispatch wiring.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent / "telegram-bridge"
+
+
+_OWN_MODULES = (
+    "render", "render.markdown", "render.monitor",
+    "notify", "notify.telegram",
+    "pricing", "pricing.cost", "pricing.usage",
+    "task_agg", "task_agg.agg",
+    "budget", "budget.core", "budget.engine",
+    "dashboard", "dashboard.auth", "dashboard.stats", "dashboard.handlers",
+    "webhooks", "webhooks.handlers",
+)
+
+
+def _load_webhooks_pkg(tmp_path):
+    """Load handlers.py against fully-wired sibling deps."""
+    # render
+    render_pkg = types.ModuleType("render")
+    render_pkg.__path__ = [str(_ROOT / "render")]  # type: ignore[attr-defined]
+    sys.modules["render"] = render_pkg
+    md_spec = importlib.util.spec_from_file_location(
+        "render.markdown", _ROOT / "render" / "markdown.py"
+    )
+    assert md_spec and md_spec.loader
+    md_mod = importlib.util.module_from_spec(md_spec)
+    sys.modules["render.markdown"] = md_mod
+    md_spec.loader.exec_module(md_mod)
+    mon_spec = importlib.util.spec_from_file_location(
+        "render.monitor", _ROOT / "render" / "monitor.py"
+    )
+    assert mon_spec and mon_spec.loader
+    mon_mod = importlib.util.module_from_spec(mon_spec)
+    sys.modules["render.monitor"] = mon_mod
+    mon_spec.loader.exec_module(mon_mod)
+    render_pkg.md_to_telegram_html = md_mod.md_to_telegram_html  # type: ignore[attr-defined]
+    render_pkg.format_monitor_message = mon_mod.format_monitor_message  # type: ignore[attr-defined]
+    render_pkg.short_id = mon_mod.short_id  # type: ignore[attr-defined]
+
+    # notify
+    notify_pkg = types.ModuleType("notify")
+    notify_pkg.__path__ = [str(_ROOT / "notify")]  # type: ignore[attr-defined]
+    sys.modules["notify"] = notify_pkg
+    notify_spec = importlib.util.spec_from_file_location(
+        "notify.telegram", _ROOT / "notify" / "telegram.py"
+    )
+    assert notify_spec and notify_spec.loader
+    notify_mod = importlib.util.module_from_spec(notify_spec)
+    sys.modules["notify.telegram"] = notify_mod
+    notify_spec.loader.exec_module(notify_mod)
+
+    # pricing.cost (transitive dep of usage)
+    pricing_pkg = types.ModuleType("pricing")
+    pricing_pkg.__path__ = [str(_ROOT / "pricing")]  # type: ignore[attr-defined]
+    sys.modules["pricing"] = pricing_pkg
+    cost_spec = importlib.util.spec_from_file_location(
+        "pricing.cost", _ROOT / "pricing" / "cost.py"
+    )
+    assert cost_spec and cost_spec.loader
+    cost_mod = importlib.util.module_from_spec(cost_spec)
+    sys.modules["pricing.cost"] = cost_mod
+    cost_spec.loader.exec_module(cost_mod)
+
+    # pricing.usage
+    usage_spec = importlib.util.spec_from_file_location(
+        "pricing.usage", _ROOT / "pricing" / "usage.py"
+    )
+    assert usage_spec and usage_spec.loader
+    usage_mod = importlib.util.module_from_spec(usage_spec)
+    sys.modules["pricing.usage"] = usage_mod
+    usage_spec.loader.exec_module(usage_mod)
+
+    # task_agg.agg (transitive for budget.engine + dashboard.stats)
+    tasks_pkg = types.ModuleType("task_agg")
+    tasks_pkg.__path__ = [str(_ROOT / "task_agg")]  # type: ignore[attr-defined]
+    sys.modules["task_agg"] = tasks_pkg
+    agg_spec = importlib.util.spec_from_file_location(
+        "task_agg.agg", _ROOT / "task_agg" / "agg.py"
+    )
+    assert agg_spec and agg_spec.loader
+    agg_mod = importlib.util.module_from_spec(agg_spec)
+    sys.modules["task_agg.agg"] = agg_mod
+    agg_spec.loader.exec_module(agg_mod)
+    agg_mod.TASKS_DIR = str(tmp_path / "tasks")
+
+    # budget.core
+    budget_pkg = types.ModuleType("budget")
+    budget_pkg.__path__ = [str(_ROOT / "budget")]  # type: ignore[attr-defined]
+    sys.modules["budget"] = budget_pkg
+    bcore_spec = importlib.util.spec_from_file_location(
+        "budget.core", _ROOT / "budget" / "core.py"
+    )
+    assert bcore_spec and bcore_spec.loader
+    bcore_mod = importlib.util.module_from_spec(bcore_spec)
+    sys.modules["budget.core"] = bcore_mod
+    bcore_spec.loader.exec_module(bcore_mod)
+    bcore_mod.BUDGET_DIR = str(tmp_path)
+    bcore_mod.BUDGET_PATH = str(tmp_path / "budget.json")
+
+    # budget.engine
+    beng_spec = importlib.util.spec_from_file_location(
+        "budget.engine", _ROOT / "budget" / "engine.py"
+    )
+    assert beng_spec and beng_spec.loader
+    beng_mod = importlib.util.module_from_spec(beng_spec)
+    sys.modules["budget.engine"] = beng_mod
+    beng_spec.loader.exec_module(beng_mod)
+
+    # dashboard
+    dash_pkg = types.ModuleType("dashboard")
+    dash_pkg.__path__ = [str(_ROOT / "dashboard")]  # type: ignore[attr-defined]
+    sys.modules["dashboard"] = dash_pkg
+    auth_spec = importlib.util.spec_from_file_location(
+        "dashboard.auth", _ROOT / "dashboard" / "auth.py"
+    )
+    assert auth_spec and auth_spec.loader
+    auth_mod = importlib.util.module_from_spec(auth_spec)
+    sys.modules["dashboard.auth"] = auth_mod
+    auth_spec.loader.exec_module(auth_mod)
+    stats_spec = importlib.util.spec_from_file_location(
+        "dashboard.stats", _ROOT / "dashboard" / "stats.py"
+    )
+    assert stats_spec and stats_spec.loader
+    stats_mod = importlib.util.module_from_spec(stats_spec)
+    sys.modules["dashboard.stats"] = stats_mod
+    stats_spec.loader.exec_module(stats_mod)
+    handlers_spec = importlib.util.spec_from_file_location(
+        "dashboard.handlers", _ROOT / "dashboard" / "handlers.py"
+    )
+    assert handlers_spec and handlers_spec.loader
+    dh_mod = importlib.util.module_from_spec(handlers_spec)
+    sys.modules["dashboard.handlers"] = dh_mod
+    handlers_spec.loader.exec_module(dh_mod)
+    dash_pkg.DASHBOARD_TOKEN = auth_mod.DASHBOARD_TOKEN  # type: ignore[attr-defined]
+    dash_pkg.dashboard_handler = dh_mod.dashboard_handler  # type: ignore[attr-defined]
+    dash_pkg.stats_api_handler = dh_mod.stats_api_handler  # type: ignore[attr-defined]
+
+    # webhooks.handlers
+    wh_pkg = types.ModuleType("webhooks")
+    wh_pkg.__path__ = [str(_ROOT / "webhooks")]  # type: ignore[attr-defined]
+    sys.modules["webhooks"] = wh_pkg
+    wh_spec = importlib.util.spec_from_file_location(
+        "webhooks.handlers", _ROOT / "webhooks" / "handlers.py"
+    )
+    assert wh_spec and wh_spec.loader
+    wh = importlib.util.module_from_spec(wh_spec)
+    sys.modules["webhooks.handlers"] = wh
+    wh_spec.loader.exec_module(wh)
+
+    return {
+        "wh": wh, "usage": usage_mod, "notify": notify_mod,
+        "budget_engine": beng_mod, "agg": agg_mod,
+    }
+
+
+@pytest.fixture
+def env(tmp_path):
+    # Snapshot modules that already exist so we don't permanently displace them.
+    saved: dict = {name: sys.modules[name] for name in _OWN_MODULES if name in sys.modules}
+
+    bag = _load_webhooks_pkg(tmp_path)
+    bag["usage"].usage_today.clear()
+    bag["usage"].usage_today.update(
+        bag["usage"]._empty_today_bucket("2026-05-09"),
+    )
+    bag["usage"].usage_history.clear()
+
+    yield bag
+
+    # Restore any modules we shadowed; remove the new ones we injected.
+    # This keeps test_pdf_export (which uses its own chat_pdf_export-side
+    # `render.render` module) working when run after this file.
+    for name in _OWN_MODULES:
+        if name in saved:
+            sys.modules[name] = saved[name]
+        else:
+            sys.modules.pop(name, None)
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+def _run(coro):
+    import asyncio
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _read_response_body(resp) -> dict:
+    """aiohttp's `web.json_response` returns Response with body bytes."""
+    body = resp.body
+    if hasattr(body, "_value"):
+        body = body._value
+    return json.loads(body.decode("utf-8"))
+
+
+# ── /track ───────────────────────────────────────────────────────────
+
+
+def test_track_handler_accumulates_usage(env):
+    resp = _run(env["wh"].usage_track_handler(_FakeRequest({
+        "model": "claude-sonnet-4-5",
+        "input_tokens": 1000,
+        "output_tokens": 100,
+        "reasoning_tokens": 500,
+    })))
+    assert resp.status == 200
+    body = _read_response_body(resp)
+    assert body["ok"] is True
+    today = body["today"]
+    assert today["input_tokens"] == 1000
+    assert today["output_tokens"] == 100
+    assert today["reasoning_tokens"] == 500
+    assert today["requests"] == 1
+    # cost = 1000 * $3/M + (100+500) * $15/M = 0.012
+    assert today["cost_usd"] == pytest.approx(0.012, rel=1e-6)
+
+
+def test_track_handler_invalid_payload_500(env):
+    """Bad request body bubbles up as 500 with `ok: false` so AZ-side
+    knows to retry / log without taking the bridge down."""
+
+    class _BadReq:
+        async def json(self):
+            raise ValueError("not json")
+
+    resp = _run(env["wh"].usage_track_handler(_BadReq()))
+    assert resp.status == 500
+    body = _read_response_body(resp)
+    assert body["ok"] is False
+    assert "error" in body
+
+
+def test_track_handler_missing_fields_default_zero(env):
+    """Missing token fields default to 0 (defensive — old AZ versions
+    might not send all fields)."""
+    resp = _run(env["wh"].usage_track_handler(_FakeRequest({
+        "model": "claude-sonnet-4-5",
+        "input_tokens": 100,
+    })))
+    assert resp.status == 200
+    body = _read_response_body(resp)
+    assert body["today"]["output_tokens"] == 0
+    assert body["today"]["cache_read_tokens"] == 0
+    assert body["today"]["reasoning_tokens"] == 0
+
+
+def test_track_handler_budget_check_failure_doesnt_500(env, monkeypatch):
+    """Budget check is fire-and-forget — a failed alert path must NOT
+    cause /track to reject. Crucial: AZ retries failed /track which
+    would double-count usage."""
+
+    async def boom():
+        raise Exception("simulated alert failure")
+
+    monkeypatch.setattr(env["wh"], "budget_check_all", boom)
+    resp = _run(env["wh"].usage_track_handler(_FakeRequest({
+        "model": "x", "input_tokens": 1, "output_tokens": 1,
+    })))
+    assert resp.status == 200  # /track still 200 despite budget exception
+
+
+# ── /usage ───────────────────────────────────────────────────────────
+
+
+def test_usage_get_handler_returns_today_and_history(env):
+    """GET /usage shape is what the dashboard JS depends on."""
+    # Seed some history
+    env["usage"].usage_history.append({"date": "2026-05-08", "requests": 5})
+    env["usage"].usage_today["requests"] = 3
+
+    resp = _run(env["wh"].usage_get_handler(_FakeRequest({})))
+    body = _read_response_body(resp)
+    assert "today" in body
+    assert "history" in body
+    assert body["today"]["requests"] == 3
+    assert isinstance(body["history"], list)
+    assert body["history"][0]["date"] == "2026-05-08"
+
+
+def test_usage_get_handler_history_capped_at_7(env):
+    """GET /usage returns last 7 history entries even if the in-memory
+    list has more (defensive — daily reset is supposed to cap this but
+    if someone's been hand-mutating, the response stays bounded)."""
+    for i in range(15):
+        env["usage"].usage_history.append({"date": f"day-{i}", "requests": 1})
+
+    resp = _run(env["wh"].usage_get_handler(_FakeRequest({})))
+    body = _read_response_body(resp)
+    assert len(body["history"]) == 7
+    # Returns the LAST 7 (most recent), not first 7.
+    assert body["history"][0]["date"] == "day-8"
+    assert body["history"][-1]["date"] == "day-14"
+
+
+# ── /notify ──────────────────────────────────────────────────────────
+
+
+def test_notify_handler_calls_send_telegram(env):
+    """POST /notify forwards `text` to send_telegram and returns 200."""
+    sent = []
+
+    async def fake_send(text, parse_mode=None, fallback_text=None):
+        sent.append({"text": text, "parse_mode": parse_mode,
+                     "fallback_text": fallback_text})
+
+    env["wh"].send_telegram = fake_send  # patch at module level
+
+    resp = _run(env["wh"].webhook_handler(_FakeRequest({
+        "text": "hello from AZ",
+    })))
+    assert resp.status == 200
+    body = _read_response_body(resp)
+    assert body["ok"] is True
+    assert len(sent) == 1
+    assert sent[0]["text"] == "hello from AZ"
+
+
+def test_notify_handler_markdown_conversion(env):
+    """`markdown: true` runs md_to_telegram_html before send. Prefix
+    (kind=task_response → 🤖) is added AFTER conversion so headers
+    parse cleanly."""
+    sent = []
+
+    async def fake_send(text, parse_mode=None, fallback_text=None):
+        sent.append({"text": text, "parse_mode": parse_mode,
+                     "fallback_text": fallback_text})
+
+    env["wh"].send_telegram = fake_send
+
+    _run(env["wh"].webhook_handler(_FakeRequest({
+        "text": "## Title\n\n**bold**",
+        "markdown": True,
+        "kind": "task_response",
+    })))
+    assert len(sent) == 1
+    assert sent[0]["parse_mode"] == "HTML"
+    # md_to_telegram_html converted ## and ** before the 🤖 prefix
+    assert "<b>Title</b>" in sent[0]["text"]
+    assert "<b>bold</b>" in sent[0]["text"]
+    assert sent[0]["text"].startswith("🤖 ")
+    # fallback_text has the prefix + raw markdown (parse-error safety net)
+    assert sent[0]["fallback_text"].startswith("🤖 ")
+
+
+def test_notify_handler_unknown_kind_no_prefix(env):
+    """Unknown kind → no prefix injected. Defensive: extending KIND_PREFIX
+    later shouldn't break old senders."""
+    sent = []
+
+    async def fake_send(text, parse_mode=None, fallback_text=None):
+        sent.append(text)
+
+    env["wh"].send_telegram = fake_send
+
+    _run(env["wh"].webhook_handler(_FakeRequest({
+        "text": "plain", "kind": "unknown",
+    })))
+    assert sent == ["plain"]


### PR DESCRIPTION
**TL;DR**: bot.py 의 4개 aiohttp 핸들러 + `run_webhook_server` 를 [`webhooks/handlers.py`](telegram-bridge/webhooks/handlers.py) 로 이동. **순수 코드 이동** — 이전 Phase 들에서 모든 의존이 이미 carved out 되어 configure() 주입 슬롯 불필요. 9개 테스트로 JSON I/O contract 핀.

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) Phase M. bot.py 누적: **3,579 → 1,538** (−57%).

---

## 옮긴 것 (4)

| 핸들러 | 라우트 | 역할 |
|---|---|---|
| `webhook_handler` | `POST /notify` | AZ → Telegram 메시지 전달 |
| `usage_track_handler` | `POST /track` | 토큰 사용량 누적 |
| `usage_get_handler` | `GET /usage` | 현재 사용량 스냅샷 |
| `run_webhook_server` | (server bootstrap) | 5개 라우트 등록 + :8443 시작 |

bot.py 는 4개 모두 re-export. `post_init` 의 `asyncio.create_task(run_webhook_server())` 변경 없음.

## 왜 이번 carve 가 깨끗했는가

Phase A-L 누적으로 모든 의존이 이미 carved:

| 의존 | 모듈 | Phase |
|---|---|---|
| `md_to_telegram_html` | render | F |
| `send_telegram` | notify | L |
| `track_usage`, `usage_today`, `usage_history` | pricing.usage | B |
| `budget_check_all` | budget.engine | K |
| `DASHBOARD_TOKEN`, `dashboard_handler`, `stats_api_handler` | dashboard | E |

순수 import + dispatch — `configure()` 주입 슬롯 불필요. **이전 작업의 누적 효과**가 여기서 발현된 마일스톤.

## 테스트 9종 ([tests/test_bridge_webhooks.py](tests/test_bridge_webhooks.py))

**POST /track** (4):
- 사용량 누적 + 200 응답 + `usage_today` 스냅샷 반환
- 잘못된 JSON → 500 + `ok: false` (AZ 가 retry/log 결정)
- 누락 토큰 필드 → 0 default (구버전 AZ 호환)
- `budget_check_all` 예외가 /track 을 500 으로 만들지 않음 (회귀 위험 — 재시도 시 토큰 중복 집계)

**GET /usage** (2):
- 대시보드 JS 가 의존하는 `{today, history}` shape
- history 7개 cap (메모리 list 가 더 길어도 응답은 capped)

**POST /notify** (3):
- happy path: `send_telegram` 호출
- `markdown: true` → md_to_telegram_html 변환 + `🤖` prefix 변환 **후** 추가 (회귀 위험 — prefix-first 면 `^#` 헤더 regex 깨짐)
- 알 수 없는 `kind` → prefix 미주입 (forward compatibility)

stubs.py 에 `aiohttp.web` 추가 (Application, AppRunner, TCPSite, Response, json_response) — 실제 서버 없이 핸들러 unit 테스트 가능.

테스트 fixture 가 sys.modules 오염을 save/restore — chat_pdf_export 의 `render.render` 임포트 (다른 모듈) 와 충돌 안 함.

## 검증

```
$ ruff check .          # All checks passed!
$ pytest -q             # 176 passed in 0.77s  (167 + 9 신규)

$ docker compose up -d --build telegram-bridge
$ docker logs telegram-bridge | grep '\[Webhook\|started'
webhooks.handlers - INFO - Webhook server started on :8443
                            ^^^^^^^^^^^^^^^^^^^ 새 모듈에서 server bootstrap

$ curl -X POST localhost:8443/track -d '{"input_tokens":1000,"output_tokens":100,"reasoning_tokens":500,...}'
→ requests=1 cost=$0.012  (1000×\$3/M + (100+500)×\$15/M ✓)
```

## 마일스톤 진행

[Repo Hardening 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/1):

- ✅ #76 Backup / #77 CI / #81 preflight
- ✅ #79 Phase A-L (13 모듈)
- 🔄 **#79 Phase M — webhooks ← 본 PR**
- ⏳ #79 future — monitor state + monitor loop, 나머지 cmd 그룹들

## bot.py 누적

| Phase | 누적 줄수 | Δ |
|---|---|---|
| 시작 | 3,579 | — |
| A → L | 1,653 | -1,926 |
| **M (webhooks)** | **1,538** | **-115** |

[#79](https://github.com/devyoon91/az-cliproxy-docker/issues/79) acceptance ("bot.py 1,000 lines 이하") 까지 ~538 줄.

## Test plan

- [x] ruff clean / 176/176 pytest
- [x] container rebuild + 시작
- [x] /track POST live round-trip 정상 (cost = expected)
- [x] webhooks.handlers 로거가 server start 로그 발생 (carved module 동작 증거)