### PR TITLE
[Bridge] 모니터 상태 carve to monitor/state.py (#79 Phase P)

### DIFF
--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -17,5 +17,6 @@ COPY az_client/ ./az_client/
 COPY telegram_handlers/ ./telegram_handlers/
 COPY notify/ ./notify/
 COPY webhooks/ ./webhooks/
+COPY monitor/ ./monitor/
 
 CMD ["python", "bot.py"]

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -48,22 +48,15 @@ CHAT_ID = int(os.environ["TELEGRAM_CHAT_ID"])
 # (issue #79 Phase H). Re-exported below so existing call sites and
 # direct constant references keep working.
 
-# Agent Zero context ID (세션 유지)
-az_context = ""
-
-# 모니터링 상태
-monitor_enabled = True
-monitor_log_version = 0
-monitor_context = ""
-monitor_log_guid = ""
-monitor_auto_follow = True  # 웹에서 활성 채팅 변경 시 자동 추적
-# When False (the default), only `user` log types echo through to Telegram
-# during a task — AZ's intermediate activity (info/tool/code_exe/response/
-# error/warning) is suppressed. The user instead gets two clean messages
-# at task completion: AZ's answer + the metrics card (driven from
-# task_report.py). When True, every log type passes through unchanged for
-# debugging. Toggled via /verbose_on, /verbose_off.
-monitor_verbose = False
+# AZ session + monitor-loop globals (`az_context`, `monitor_enabled`,
+# `monitor_log_version`, `monitor_context`, `monitor_log_guid`,
+# `monitor_auto_follow`, `monitor_verbose`) moved to `monitor/state.py`
+# (issue #79 Phase P). Access them as attributes on the imported
+# module so reads + writes stay shared with every other module that
+# imports `monitor.state` (the cmd handlers we'll carve in subsequent
+# phases). `monitor.state.monitor_enabled = True` from any module
+# reaches the same slot as a read here.
+from monitor import state  # noqa: E402
 
 # Telegram Bot 인스턴스 (모니터에서 사용)
 tg_bot: Bot | None = None
@@ -217,18 +210,15 @@ from notify.telegram import send_telegram  # noqa: E402, F401
 # ── Agent Zero 웹 채팅 모니터 ──
 async def monitor_agent_zero():
     """Agent Zero의 모든 대화를 백그라운드로 모니터링하여 Telegram에 전달"""
-    global monitor_log_version, monitor_context, monitor_log_guid
-    global monitor_enabled, monitor_auto_follow
-
     logger.info("Agent Zero monitor started")
     await asyncio.sleep(10)
 
     # 최초 시작 시 현재 시점으로 스킵 (기존 히스토리 전송 방지)
-    monitor_log_version = await sync_log_version(monitor_context)
-    logger.info(f"Monitor synced to log_version: {monitor_log_version}")
+    state.monitor_log_version = await sync_log_version(state.monitor_context)
+    logger.info(f"Monitor synced to log_version: {state.monitor_log_version}")
 
     while True:
-        if not monitor_enabled:
+        if not state.monitor_enabled:
             await asyncio.sleep(5)
             continue
 
@@ -237,8 +227,8 @@ async def monitor_agent_zero():
             headers = get_headers()
 
             poll_payload = {
-                "log_from": monitor_log_version,
-                "context": monitor_context or None,
+                "log_from": state.monitor_log_version,
+                "context": state.monitor_context or None,
                 "timezone": "Asia/Seoul",
             }
 
@@ -270,25 +260,25 @@ async def monitor_agent_zero():
             new_log_version = poll_data.get("log_version", 0)
 
             # 자동 추적: 웹에서 다른 채팅으로 전환된 경우
-            if monitor_auto_follow and new_context and new_context != monitor_context:
-                old_ctx = _short_id(monitor_context)
+            if state.monitor_auto_follow and new_context and new_context != state.monitor_context:
+                old_ctx = _short_id(state.monitor_context)
                 new_ctx = _short_id(new_context)
                 # Drop the in-progress stream tied to the old chat — the
                 # 채팅 전환 알림 is itself a fresh standalone message and
                 # the new chat's logs should start their own stream.
-                _stream_reset(monitor_context or "_default")
+                _stream_reset(state.monitor_context or "_default")
                 await send_telegram(f"🔄 채팅 전환 감지: {old_ctx} → {new_ctx}")
-                monitor_context = new_context
-                monitor_log_guid = new_log_guid
+                state.monitor_context = new_context
+                state.monitor_log_guid = new_log_guid
                 # 현재 시점으로 스킵 (이전 히스토리 전송 방지)
-                monitor_log_version = await sync_log_version(new_context)
+                state.monitor_log_version = await sync_log_version(new_context)
                 await asyncio.sleep(2)
                 continue
 
             # 대화가 리셋된 경우
-            if new_log_guid and new_log_guid != monitor_log_guid:
-                monitor_log_guid = new_log_guid
-                monitor_log_version = new_log_version  # 현재 시점 유지
+            if new_log_guid and new_log_guid != state.monitor_log_guid:
+                state.monitor_log_guid = new_log_guid
+                state.monitor_log_version = new_log_version  # 현재 시점 유지
                 await asyncio.sleep(2)
                 continue
 
@@ -299,7 +289,7 @@ async def monitor_agent_zero():
                 # streaming_msg_id docstring above. We batch this poll's logs
                 # and either edit the active message or open a new one.
                 # A `user`-type log mid-batch marks a new turn boundary.
-                stream_key = monitor_context or "_default"
+                stream_key = state.monitor_context or "_default"
                 pending: list[str] = []
 
                 async def flush_pending():
@@ -323,13 +313,13 @@ async def monitor_agent_zero():
                         _stream_reset(stream_key)
 
                     formatted = format_monitor_message(
-                        log_type, heading, content, verbose=monitor_verbose,
+                        log_type, heading, content, verbose=state.monitor_verbose,
                     )
                     if formatted:
                         pending.append(formatted)
 
                 await flush_pending()
-                monitor_log_version = new_log_version
+                state.monitor_log_version = new_log_version
 
         except asyncio.CancelledError:
             break
@@ -344,11 +334,9 @@ async def monitor_agent_zero():
 # ── Agent Zero API: Telegram에서 직접 메시지 전송 ──
 async def send_to_agent_zero(message: str) -> str:
     """Agent Zero /message_async API로 메시지 전송"""
-    global az_context, monitor_context, monitor_log_version
-
     payload = {
         "text": message,
-        "context": az_context,
+        "context": state.az_context,
     }
     headers = get_headers()
 
@@ -381,11 +369,11 @@ async def send_to_agent_zero(message: str) -> str:
             else:
                 data = await resp.json()
 
-            az_context = data.get("context", az_context)
+            state.az_context = data.get("context", state.az_context)
             # 모니터도 같은 컨텍스트 추적하도록 동기화
-            if monitor_context != az_context:
-                monitor_context = az_context
-                monitor_log_version = await sync_log_version(az_context)
+            if state.monitor_context != state.az_context:
+                state.monitor_context = state.az_context
+                state.monitor_log_version = await sync_log_version(state.az_context)
 
         return "✅ Agent Zero에 전달 완료. 응답은 자동으로 전송됩니다."
 
@@ -450,14 +438,14 @@ async def check_agent_zero_status() -> str:
         except Exception as e:
             logger.debug(f"model_config_get failed: {e}")
 
-        ctx_short = _short_id(monitor_context)
+        ctx_short = _short_id(state.monitor_context)
         return (
             f"Agent Zero: 정상 동작 중\n\n"
             f"📋 프로필: {profile}\n"
             f"🤖 메인 모델: {chat_model}\n"
             f"⚡ 유틸 모델: {util_model}\n\n"
-            f"모니터링: {'켜짐' if monitor_enabled else '꺼짐'}\n"
-            f"자동 추적: {'켜짐' if monitor_auto_follow else '꺼짐'}\n"
+            f"모니터링: {'켜짐' if state.monitor_enabled else '꺼짐'}\n"
+            f"자동 추적: {'켜짐' if state.monitor_auto_follow else '꺼짐'}\n"
             f"현재 채팅: {ctx_short}"
         )
     except Exception as e:
@@ -498,10 +486,10 @@ async def cmd_chats(update: Update, context: ContextTypes.DEFAULT_TYPE):
     for i, ctx in enumerate(contexts):
         ctx_id = ctx.get("id", "")
         name = ctx.get("name", "이름 없음")
-        is_current = "→ " if ctx_id == monitor_context else "  "
+        is_current = "→ " if ctx_id == state.monitor_context else "  "
         lines.append(f"{is_current}{i+1}. {name}\n   ID: {_short_id(ctx_id)}")
 
-    lines.append(f"\n현재 추적 중: {_short_id(monitor_context)}")
+    lines.append(f"\n현재 추적 중: {_short_id(state.monitor_context)}")
     lines.append("\n채팅 전환: /switch [번호]")
 
     await update.message.reply_text("\n".join(lines))
@@ -509,8 +497,6 @@ async def cmd_chats(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def cmd_switch(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """채팅 전환"""
-    global az_context, monitor_context, monitor_log_version, monitor_log_guid
-
     if update.effective_chat.id != CHAT_ID:
         return
 
@@ -537,13 +523,13 @@ async def cmd_switch(update: Update, context: ContextTypes.DEFAULT_TYPE):
     target_name = target.get("name", "이름 없음")
 
     # Close any in-progress stream tied to the previous chat before swapping.
-    _stream_reset(monitor_context or "_default")
+    _stream_reset(state.monitor_context or "_default")
 
-    az_context = target_id
-    monitor_context = target_id
-    monitor_log_guid = ""
+    state.az_context = target_id
+    state.monitor_context = target_id
+    state.monitor_log_guid = ""
     # 현재 시점으로 스킵 (이전 히스토리 전송 방지)
-    monitor_log_version = await sync_log_version(target_id)
+    state.monitor_log_version = await sync_log_version(target_id)
 
     await update.message.reply_text(f"✅ 채팅 전환: {target_name}\nID: {_short_id(target_id)}")
 
@@ -562,7 +548,6 @@ async def cmd_new(update: Update, context: ContextTypes.DEFAULT_TYPE):
     UI's "New Chat" button uses), gets the real ctxid back, then pins both
     az_context and monitor_context to it before replying.
     """
-    global az_context, monitor_context, monitor_log_version, monitor_log_guid
     if update.effective_chat.id != CHAT_ID:
         return
     msg = update.effective_message
@@ -577,7 +562,7 @@ async def cmd_new(update: Update, context: ContextTypes.DEFAULT_TYPE):
         # data per its chat_inherit_project setting (matches web UI behavior).
         async with session.post(
             f"{AZ_API_URL}{AZ_API_PREFIX}/chat_create",
-            json={"current_context": az_context or ""},
+            json={"current_context": state.az_context or ""},
             headers=headers,
             timeout=aiohttp.ClientTimeout(total=15),
         ) as resp:
@@ -587,7 +572,7 @@ async def cmd_new(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 headers = get_headers()
                 async with session.post(
                     f"{AZ_API_URL}{AZ_API_PREFIX}/chat_create",
-                    json={"current_context": az_context or ""},
+                    json={"current_context": state.az_context or ""},
                     headers=headers,
                     timeout=aiohttp.ClientTimeout(total=15),
                 ) as retry:
@@ -604,14 +589,14 @@ async def cmd_new(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # Close any in-progress stream from the previous chat — new chat's logs
     # should open their own message, not extend the old one.
-    _stream_reset(monitor_context or "_default")
+    _stream_reset(state.monitor_context or "_default")
 
-    az_context = new_ctxid
-    monitor_context = new_ctxid
-    monitor_log_guid = ""
+    state.az_context = new_ctxid
+    state.monitor_context = new_ctxid
+    state.monitor_log_guid = ""
     # Skip past whatever log_version the new context starts at so we don't
     # re-stream the (empty) initial state. This mirrors /switch behavior.
-    monitor_log_version = await sync_log_version(new_ctxid)
+    state.monitor_log_version = await sync_log_version(new_ctxid)
 
     await msg.reply_text(
         f"✅ 새 대화 시작됨\nID: {_short_id(new_ctxid)}"
@@ -623,7 +608,7 @@ async def cmd_logs(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.effective_chat.id != CHAT_ID:
         return
 
-    if not monitor_context:
+    if not state.monitor_context:
         await update.message.reply_text("추적 중인 채팅이 없습니다. /chats 로 확인하세요.")
         return
 
@@ -636,7 +621,7 @@ async def cmd_logs(update: Update, context: ContextTypes.DEFAULT_TYPE):
         # chat export API로 전체 대화 JSON 가져오기
         async with session.post(
             f"{AZ_API_URL}{AZ_API_PREFIX}/chat_export",
-            json={"ctxid": monitor_context},
+            json={"ctxid": state.monitor_context},
             headers=headers,
             timeout=aiohttp.ClientTimeout(total=30),
         ) as resp:
@@ -652,12 +637,12 @@ async def cmd_logs(update: Update, context: ContextTypes.DEFAULT_TYPE):
         # JSON 파일로 전송
         json_str = json.dumps(content, ensure_ascii=False, indent=2)
         json_file = io.BytesIO(json_str.encode("utf-8"))
-        json_file.name = f"chat_log_{monitor_context[:8]}.json"
+        json_file.name = f"chat_log_{state.monitor_context[:8]}.json"
 
         await tg_bot.send_document(
             chat_id=CHAT_ID,
             document=json_file,
-            caption=f"📋 채팅 로그 (Context: {_short_id(monitor_context)})",
+            caption=f"📋 채팅 로그 (Context: {_short_id(state.monitor_context)})",
         )
 
         # 텍스트 요약도 함께 생성
@@ -683,7 +668,7 @@ async def cmd_logs(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if txt_lines:
             txt_str = "\n\n".join(txt_lines)
             txt_file = io.BytesIO(txt_str.encode("utf-8"))
-            txt_file.name = f"chat_log_{monitor_context[:8]}.txt"
+            txt_file.name = f"chat_log_{state.monitor_context[:8]}.txt"
             await tg_bot.send_document(
                 chat_id=CHAT_ID,
                 document=txt_file,
@@ -767,7 +752,7 @@ async def cmd_backup(update: Update, context: ContextTypes.DEFAULT_TYPE):
             meta = {
                 "timestamp": datetime.now().isoformat(),
                 "type": "telegram-light-backup",
-                "monitor_context": monitor_context,
+                "monitor_context": state.monitor_context,
             }
             zf.writestr(
                 "backup_meta.json",
@@ -943,20 +928,18 @@ from telegram_handlers.cost import (  # noqa: E402, F401
 
 
 async def cmd_monitor_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    global monitor_enabled, monitor_log_version
     if update.effective_chat.id != CHAT_ID:
         return
-    monitor_enabled = True
+    state.monitor_enabled = True
     # 현재 시점부터 모니터링 (이전 히스토리 전송 방지)
-    monitor_log_version = await sync_log_version(monitor_context)
+    state.monitor_log_version = await sync_log_version(state.monitor_context)
     await update.message.reply_text("✅ 웹 채팅 모니터링이 켜졌습니다. (현재 시점부터)")
 
 
 async def cmd_monitor_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    global monitor_enabled
     if update.effective_chat.id != CHAT_ID:
         return
-    monitor_enabled = False
+    state.monitor_enabled = False
     await update.message.reply_text("🔇 웹 채팅 모니터링이 꺼졌습니다.")
 
 
@@ -971,10 +954,9 @@ async def cmd_track_chat_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     /follow_on is kept registered as an alias for muscle memory.
     """
-    global monitor_auto_follow
     if update.effective_chat.id != CHAT_ID:
         return
-    monitor_auto_follow = True
+    state.monitor_auto_follow = True
     await update.message.reply_text(
         "✅ 채팅 자동 추적 켜짐: 웹에서 채팅 전환 시 모니터가 따라갑니다."
     )
@@ -983,10 +965,9 @@ async def cmd_track_chat_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def cmd_track_chat_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Pin the monitor to its current chat regardless of AZ web's active chat.
     See cmd_track_chat_on for the rename rationale."""
-    global monitor_auto_follow
     if update.effective_chat.id != CHAT_ID:
         return
-    monitor_auto_follow = False
+    state.monitor_auto_follow = False
     await update.message.reply_text(
         "📌 채팅 자동 추적 꺼짐: 현재 채팅만 고정 추적합니다."
     )
@@ -996,10 +977,9 @@ async def cmd_verbose_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Show every AZ log (info/tool/code_exe/response/error/warning) during
     a task — useful when debugging a stuck profile. Default-quiet behavior
     (only user echoes + task-completion summary) is the normal mode."""
-    global monitor_verbose
     if update.effective_chat.id != CHAT_ID:
         return
-    monitor_verbose = True
+    state.monitor_verbose = True
     await update.message.reply_text(
         "🔊 상세 모니터 켜짐: AZ 활동 로그(도구/코드/info 등) 모두 텔레그램으로 전송."
     )
@@ -1008,10 +988,9 @@ async def cmd_verbose_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def cmd_verbose_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Return to quiet mode — only user echoes during task, completion-time
     answer + metrics card from task_report."""
-    global monitor_verbose
     if update.effective_chat.id != CHAT_ID:
         return
-    monitor_verbose = False
+    state.monitor_verbose = False
     await update.message.reply_text(
         "🔇 상세 모니터 꺼짐: 진행 중엔 조용, 완료 시 답변+메트릭만."
     )

--- a/telegram-bridge/monitor/__init__.py
+++ b/telegram-bridge/monitor/__init__.py
@@ -1,0 +1,32 @@
+"""Monitor state package — Phase P carve from bot.py (issue #79).
+
+Houses the seven monitor-loop globals that bot.py used to own at module
+level (`az_context`, `monitor_enabled`, `monitor_log_version`,
+`monitor_context`, `monitor_log_guid`, `monitor_auto_follow`,
+`monitor_verbose`).
+
+Why a dedicated `state` submodule rather than just module-level names
+on `monitor` itself: callers do `from monitor import state` and then
+write `state.monitor_enabled = True`. Attribute access on a module
+object is shared by every importer — read+write stays consistent
+across bot.py, the monitor loop, the cmd handlers, and any future
+carves into `telegram_handlers/`. A bare `from monitor import
+monitor_enabled` would give each importer its own rebound local and
+silently fork the state, which is exactly the trap that bit
+`pricing.usage.usage_today` (the clear+update pattern there).
+
+This phase is purely a name-rebinding refactor — no behavior change.
+The point is to unstick the cmd handlers (cmd_chats / cmd_switch /
+cmd_new / cmd_logs / cmd_backup / cmd_monitor_on/off /
+cmd_track_chat_on/off / cmd_verbose_on/off) so subsequent phases can
+move them under `telegram_handlers/` without dragging bot.py-internal
+imports into those modules.
+
+The `monitor` package is intentionally separate from `render/monitor.py`
+(the pure formatter `format_monitor_message`). Different concerns:
+state lives here, formatting lives there.
+"""
+
+from . import state
+
+__all__ = ["state"]

--- a/telegram-bridge/monitor/state.py
+++ b/telegram-bridge/monitor/state.py
@@ -1,0 +1,68 @@
+"""Monitor state singleton — Phase P carve from bot.py (issue #79).
+
+Holds the seven module-level globals the AZ web-chat monitor loop and
+its companion command handlers used to keep on bot.py.
+
+Access pattern (read+write):
+    from monitor import state
+    if state.monitor_enabled:
+        ...
+    state.monitor_log_version = await sync_log_version(state.monitor_context)
+
+Why module attributes — not a `@dataclass` or a singleton class: the
+old call sites used bare `monitor_enabled = True` assignments, and
+`module.attr = value` keeps that one-liner shape while remaining
+visible to every importer. A class instance would force callers to
+wire a singleton through configure() (like notify.telegram does for
+its Bot reference) — overkill for what is genuinely process-wide
+mutable state.
+
+Keep this file free of imports beyond `from __future__` — the whole
+point is that callers can `from monitor import state` without dragging
+telegram, aiohttp, or budget machinery in along the way.
+"""
+from __future__ import annotations
+
+# ── Agent Zero session ──
+# Active context the bridge sends user messages to via /message_async.
+# Empty string at boot — AZ creates a fresh context on first message.
+az_context: str = ""
+
+# ── Monitor loop state ──
+# Master kill-switch for the AZ→Telegram log echo. /monitor_off pauses
+# the poll loop without tearing it down. Default ON so a fresh boot
+# starts streaming immediately.
+monitor_enabled: bool = True
+
+# AZ's `log_version` cursor we last consumed from /api/poll. Strictly
+# monotonic per `monitor_log_guid` window. Reset to "current" via
+# `sync_log_version` whenever we switch context, so the user never
+# gets blasted with stale history on a chat switch / monitor toggle.
+monitor_log_version: int = 0
+
+# Which AZ context the monitor is currently watching. Empty == let AZ
+# pick (default web-UI active chat). Tracked separately from
+# `az_context` because the user can pin the monitor to one chat while
+# sending to another (rare, but supported via /track_chat_off).
+monitor_context: str = ""
+
+# AZ's per-context log GUID. When this changes mid-session it means
+# the chat got reset / cleared from the web UI; we re-anchor
+# `monitor_log_version` to the current cursor so we don't replay the
+# new history.
+monitor_log_guid: str = ""
+
+# When True, the monitor loop hops to whatever context AZ's web UI
+# activates next. /track_chat_off pins the monitor to its current
+# chat. Default ON so casual users get the obvious "Telegram mirrors
+# the web UI" behavior.
+monitor_auto_follow: bool = True
+
+# When False (the default), only `user`-type logs echo through to
+# Telegram during a task — AZ's intermediate activity (info / tool /
+# code_exe / response / error / warning) is suppressed and the user
+# instead gets two clean messages at task completion (AZ's answer +
+# the metrics card from task_report.py). When True, every log type
+# passes through unchanged for debugging. Toggled via /verbose_on,
+# /verbose_off.
+monitor_verbose: bool = False

--- a/tests/test_bridge_monitor_state.py
+++ b/tests/test_bridge_monitor_state.py
@@ -1,0 +1,136 @@
+"""Pin `monitor/state.py` — Phase P carve from bot.py (issue #79).
+
+The whole reason this module exists is that bot.py used to keep these
+seven globals at module scope and let cmd handlers + the monitor loop
+mutate them via `global` declarations. The carve replaces those with
+attribute access (`state.monitor_enabled = True`) so the cmd handlers
+can move under `telegram_handlers/` in subsequent phases without
+dragging bot.py-internal imports along.
+
+What's worth pinning:
+
+1. **Defaults match the prior bot.py defaults exactly** — a regression
+   here would silently flip /verbose-quiet, kill the monitor at boot,
+   or break auto-follow.
+2. **Cross-module attribute mutation is visible to every importer** —
+   this is the core invariant the carve relies on. If a future change
+   ever rebinds the names (`from monitor.state import monitor_enabled`
+   instead of `from monitor import state`) it forks state silently;
+   this test catches that by asserting the module object identity is
+   the same regardless of how callers grab it.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_BRIDGE = Path(__file__).resolve().parent.parent / "telegram-bridge"
+
+
+@pytest.fixture
+def state():
+    """Fresh import of `monitor.state` per test so default-value asserts
+    don't see leaked mutations from prior tests.
+
+    Uses the package machinery (not exec_module on the file alone) so
+    `from monitor import state` continues to work the way bot.py does it.
+    """
+    import sys
+
+    saved = {k: sys.modules[k] for k in list(sys.modules) if k.startswith("monitor")}
+    saved_path = list(sys.path)
+    sys.path.insert(0, str(_BRIDGE))
+    for k in list(saved):
+        del sys.modules[k]
+    try:
+        from monitor import state as fresh
+        importlib.reload(fresh)
+        yield fresh
+    finally:
+        for k in list(sys.modules):
+            if k.startswith("monitor"):
+                del sys.modules[k]
+        sys.modules.update(saved)
+        sys.path[:] = saved_path
+
+
+# ── Defaults ────────────────────────────────────────────────────────
+
+
+def test_az_context_default_empty(state):
+    assert state.az_context == ""
+
+
+def test_monitor_enabled_default_on(state):
+    """Bot starts with monitoring ON — flipping this default would
+    silently break the AZ→Telegram echo for every fresh boot."""
+    assert state.monitor_enabled is True
+
+
+def test_monitor_log_version_default_zero(state):
+    assert state.monitor_log_version == 0
+
+
+def test_monitor_context_default_empty(state):
+    assert state.monitor_context == ""
+
+
+def test_monitor_log_guid_default_empty(state):
+    assert state.monitor_log_guid == ""
+
+
+def test_monitor_auto_follow_default_on(state):
+    """Auto-follow ON is the obvious 'mirrors the web UI' UX. /track_chat_off
+    pins to current. Flipping this default reverses every casual user's
+    expected behavior."""
+    assert state.monitor_auto_follow is True
+
+
+def test_monitor_verbose_default_off(state):
+    """Quiet mode is the default — only user echoes during a task, plus the
+    completion summary. Verbose floods the chat with tool/code logs and
+    is debug-only."""
+    assert state.monitor_verbose is False
+
+
+# ── Cross-module attribute mutation ─────────────────────────────────
+
+
+def test_state_is_singleton_across_imports(state):
+    """Two different import statements should hand back the same module
+    object — that's the contract every callsite relies on. If a future
+    refactor ever puts `monitor.state` behind a __getattr__ wrapper or
+    similar indirection, this catches it before behavior diverges.
+    """
+    a = importlib.import_module("monitor.state")
+    from monitor import state as b
+    assert a is b is state
+
+
+def test_write_via_attribute_is_visible_to_other_importers(state):
+    """The whole point of the carve. Writing through one reference
+    must be observable through the other — otherwise the cmd
+    handlers (in their own modules in later phases) will silently
+    fork state from the monitor loop in bot.py.
+    """
+    other = importlib.import_module("monitor.state")
+    state.monitor_enabled = False
+    state.monitor_log_version = 999
+    state.az_context = "test-ctx"
+    assert other.monitor_enabled is False
+    assert other.monitor_log_version == 999
+    assert other.az_context == "test-ctx"
+
+
+def test_package_init_reexports_state(state):
+    """`from monitor import state` works because monitor/__init__.py
+    exposes it. If __init__.py is rewritten to drop the re-export
+    (and the package only ships `state.py`), `from monitor import state`
+    would still work via attribute access on the package — but pinning
+    that the explicit re-export is present documents the intent.
+    """
+    import monitor
+    assert monitor.state is state


### PR DESCRIPTION
## TL;DR

bot.py 가 가지고 있던 모니터 루프 글로벌 7개 (`az_context`, `monitor_enabled`, `monitor_log_version`, `monitor_context`, `monitor_log_guid`, `monitor_auto_follow`, `monitor_verbose`) 를 `monitor/state.py` 로 분리. 호출부 ~30 곳을 `state.X` 속성 접근으로 일괄 치환. 동작은 그대로, 다음 단계 cmd 핸들러 carve 의 길을 열어주는 메커니컬 리팩터링.

**bot.py: 1,160 → 1,139 lines (−21)** · 목표 ≤ 1,000 까지 약 139 라인 남음.

## 왜 분리했나

`cmd_chats` / `cmd_switch` / `cmd_new` / `cmd_logs` / `cmd_backup` / `cmd_monitor_on·off` / `cmd_track_chat_on·off` / `cmd_verbose_on·off` 가 전부 이 7개 글로벌을 읽고 씁니다. 글로벌이 bot.py 안에 있는 한, 이 핸들러들을 `telegram_handlers/` 로 옮기면 bot.py 를 거꾸로 import 해야 하고 → 순환 임포트.

`monitor/state.py` 를 모듈 단위 싱글턴으로 만들어 두면, 모든 importer 가 같은 슬롯을 보기 때문에 `state.monitor_enabled = True` 한 줄로 기존 `global` 선언과 같은 의미를 유지할 수 있습니다.

## 왜 dataclass / 싱글턴 클래스가 아닌 모듈 속성인가

기존 호출부가 `monitor_enabled = True` 식의 한 줄 대입이었고, **모듈 속성 쓰기는 모든 importer 가 같은 슬롯을 본다**는 점이 핵심. 클래스 인스턴스로 하면 `notify.telegram` 처럼 `configure()` 로 싱글턴을 주입해야 하는데, 진짜 프로세스 단위 가변 상태에는 과한 추상화.

## 변경 요약

| 파일 | 변경 |
|------|------|
| `telegram-bridge/monitor/__init__.py` | 신규 — `state` 재노출 |
| `telegram-bridge/monitor/state.py` | 신규 — 7개 글로벌 + 자세한 docstring |
| `telegram-bridge/bot.py` | 글로벌 선언 제거, ~30 곳을 `state.X` 로 치환, 11개 함수에서 `global` 선언 제거 |
| `telegram-bridge/Dockerfile` | `COPY monitor/ ./monitor/` 추가 |
| `tests/test_bridge_monitor_state.py` | 신규 — 10개 테스트 (기본값 7개 + 크로스모듈 가시성 3개) |

## 검증

- ✅ `ruff check` 깨끗 (bot.py + monitor/ + 신규 테스트)
- ✅ `pytest`: **186/186** (이전 176 + 신규 10)
  - 7개: 기본값 회귀 방지 (`monitor_enabled` 기본 ON, `monitor_verbose` 기본 OFF 등 — 한 번이라도 뒤집히면 부팅 시 모니터 죽거나 verbose 가 기본이 됨)
  - 3개: 크로스모듈 mutation 가시성 (carve 의 핵심 invariant)
- ✅ 컨테이너 리빌드 + 부팅: 정상
  ```
  __main__ - INFO - Monitor synced to log_version: 0
  __main__ - INFO - Agent Zero monitor started
  ```

## 후속 단계

이 phase 가 머지되면 cmd 핸들러들을 `telegram_handlers/` 로 옮길 수 있습니다 — `cmd_chats`/`cmd_switch`/`cmd_new` (채팅 관리), `cmd_monitor_on·off`/`cmd_track_chat_on·off`/`cmd_verbose_on·off` (모니터 토글) 가 1순위. 더 이상 bot.py 글로벌에 의존하지 않으니 깔끔하게 빠질 수 있음.

Closes part of #79.