### PR TITLE
[Bridge] /chats + 6 모니터 토글 carve to telegram_handlers/chat.py (#79 Phase Q)

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -472,27 +472,10 @@ async def cmd_status(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text(status)
 
 
-async def cmd_chats(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """채팅 목록 조회"""
-    if update.effective_chat.id != CHAT_ID:
-        return
-
-    contexts = await fetch_chat_list()
-    if not contexts:
-        await update.message.reply_text("활성 채팅이 없습니다.")
-        return
-
-    lines = ["📋 채팅 목록:\n"]
-    for i, ctx in enumerate(contexts):
-        ctx_id = ctx.get("id", "")
-        name = ctx.get("name", "이름 없음")
-        is_current = "→ " if ctx_id == state.monitor_context else "  "
-        lines.append(f"{is_current}{i+1}. {name}\n   ID: {_short_id(ctx_id)}")
-
-    lines.append(f"\n현재 추적 중: {_short_id(state.monitor_context)}")
-    lines.append("\n채팅 전환: /switch [번호]")
-
-    await update.message.reply_text("\n".join(lines))
+# `/chats` moved to telegram_handlers/chat.py (issue #79 Phase Q) along
+# with the six monitor/track/verbose toggle handlers — they share the
+# same dep set (monitor.state + az_client.session + render.monitor).
+from telegram_handlers.chat import cmd_chats  # noqa: E402, F401
 
 
 async def cmd_switch(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -927,73 +910,18 @@ from telegram_handlers.cost import (  # noqa: E402, F401
 )
 
 
-async def cmd_monitor_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    if update.effective_chat.id != CHAT_ID:
-        return
-    state.monitor_enabled = True
-    # 현재 시점부터 모니터링 (이전 히스토리 전송 방지)
-    state.monitor_log_version = await sync_log_version(state.monitor_context)
-    await update.message.reply_text("✅ 웹 채팅 모니터링이 켜졌습니다. (현재 시점부터)")
-
-
-async def cmd_monitor_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    if update.effective_chat.id != CHAT_ID:
-        return
-    state.monitor_enabled = False
-    await update.message.reply_text("🔇 웹 채팅 모니터링이 꺼졌습니다.")
-
-
-async def cmd_track_chat_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Auto-track which AZ chat the monitor watches.
-
-    Renamed from /follow_on for clarity — old name was ambiguous about
-    direction (does \"follow\" mean Telegram→AZ or AZ→Telegram?). Both
-    /monitor and /track_chat are AZ→Telegram concerns; /track_chat
-    specifically controls whether the monitor switches its target when
-    the AZ web UI activates a different chat.
-
-    /follow_on is kept registered as an alias for muscle memory.
-    """
-    if update.effective_chat.id != CHAT_ID:
-        return
-    state.monitor_auto_follow = True
-    await update.message.reply_text(
-        "✅ 채팅 자동 추적 켜짐: 웹에서 채팅 전환 시 모니터가 따라갑니다."
-    )
-
-
-async def cmd_track_chat_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Pin the monitor to its current chat regardless of AZ web's active chat.
-    See cmd_track_chat_on for the rename rationale."""
-    if update.effective_chat.id != CHAT_ID:
-        return
-    state.monitor_auto_follow = False
-    await update.message.reply_text(
-        "📌 채팅 자동 추적 꺼짐: 현재 채팅만 고정 추적합니다."
-    )
-
-
-async def cmd_verbose_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Show every AZ log (info/tool/code_exe/response/error/warning) during
-    a task — useful when debugging a stuck profile. Default-quiet behavior
-    (only user echoes + task-completion summary) is the normal mode."""
-    if update.effective_chat.id != CHAT_ID:
-        return
-    state.monitor_verbose = True
-    await update.message.reply_text(
-        "🔊 상세 모니터 켜짐: AZ 활동 로그(도구/코드/info 등) 모두 텔레그램으로 전송."
-    )
-
-
-async def cmd_verbose_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Return to quiet mode — only user echoes during task, completion-time
-    answer + metrics card from task_report."""
-    if update.effective_chat.id != CHAT_ID:
-        return
-    state.monitor_verbose = False
-    await update.message.reply_text(
-        "🔇 상세 모니터 꺼짐: 진행 중엔 조용, 완료 시 답변+메트릭만."
-    )
+# /monitor_on/off, /track_chat_on/off, /verbose_on/off moved to
+# telegram_handlers/chat.py (issue #79 Phase Q) — all six are pure
+# state.X = bool flips that became carve-able once monitor state moved
+# out of bot.py (Phase P). Re-exported for the dispatcher in main().
+from telegram_handlers.chat import (  # noqa: E402, F401
+    cmd_monitor_off,
+    cmd_monitor_on,
+    cmd_track_chat_off,
+    cmd_track_chat_on,
+    cmd_verbose_off,
+    cmd_verbose_on,
+)
 
 
 

--- a/telegram-bridge/telegram_handlers/__init__.py
+++ b/telegram-bridge/telegram_handlers/__init__.py
@@ -7,6 +7,15 @@ pricing, usage, system, monitor toggles, …) into their own files
 under this package as their own bot.py-internal deps come unstuck.
 """
 
+from .chat import (
+    cmd_chats,
+    cmd_monitor_off,
+    cmd_monitor_on,
+    cmd_track_chat_off,
+    cmd_track_chat_on,
+    cmd_verbose_off,
+    cmd_verbose_on,
+)
 from .cost import cmd_budget, cmd_pricing, cmd_usage
 from .files import cmd_docs
 from .system import cmd_help, cmd_start
@@ -17,4 +26,8 @@ __all__ = [
     "cmd_budget", "cmd_pricing", "cmd_usage",
     "cmd_help", "cmd_start",
     "cmd_docs",
+    "cmd_chats",
+    "cmd_monitor_on", "cmd_monitor_off",
+    "cmd_track_chat_on", "cmd_track_chat_off",
+    "cmd_verbose_on", "cmd_verbose_off",
 ]

--- a/telegram-bridge/telegram_handlers/chat.py
+++ b/telegram-bridge/telegram_handlers/chat.py
@@ -1,0 +1,141 @@
+"""Chat-listing + monitor-toggle Telegram commands — Phase Q carve from
+bot.py (issue #79).
+
+Houses:
+  - `/chats`       — list AZ contexts, mark the one the monitor is watching
+  - `/monitor_on`  — resume AZ→Telegram echo (skips past history)
+  - `/monitor_off` — pause AZ→Telegram echo
+  - `/track_chat_on`  — auto-follow the AZ web UI's active chat
+  - `/track_chat_off` — pin the monitor to its current chat
+  - `/verbose_on`  — pass through every AZ log type (debug)
+  - `/verbose_off` — quiet mode: only `user` echoes during a task
+
+All seven became carve-able once Phase P moved the seven monitor-state
+globals to `monitor/state.py` — the handlers used to take `global …`
+declarations + bare reads from bot.py module scope. Now they read +
+write `state.X` and depend only on already-carved modules.
+
+`/switch` and `/new` stay in bot.py for now because they call
+`_stream_reset` (the streaming-edit module is still bot.py-internal).
+That's the next phase.
+"""
+from __future__ import annotations
+
+import os
+
+from az_client.session import fetch_chat_list, sync_log_version
+from monitor import state
+from render.monitor import short_id as _short_id
+from telegram import Update
+from telegram.ext import ContextTypes
+
+# Same env source bot.py uses — keeps the carve identical to the rest of
+# telegram_handlers/. Re-reading rather than threading CHAT_ID through is
+# fine because the env is set once at container start and these handlers
+# only fire under the running event loop.
+CHAT_ID = int(os.environ["TELEGRAM_CHAT_ID"])
+
+
+async def cmd_chats(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """채팅 목록 조회 — marks the currently-tracked context with `→ `.
+
+    Reads the live `cached_contexts` indirectly via `fetch_chat_list()`
+    (which hits AZ when the cache is empty and updates the same list
+    object the monitor loop populates). The `→` marker is anchored on
+    `state.monitor_context` so it stays in sync regardless of which
+    module last mutated it.
+    """
+    if update.effective_chat.id != CHAT_ID:
+        return
+
+    contexts = await fetch_chat_list()
+    if not contexts:
+        await update.message.reply_text("활성 채팅이 없습니다.")
+        return
+
+    lines = ["📋 채팅 목록:\n"]
+    for i, ctx in enumerate(contexts):
+        ctx_id = ctx.get("id", "")
+        name = ctx.get("name", "이름 없음")
+        is_current = "→ " if ctx_id == state.monitor_context else "  "
+        lines.append(f"{is_current}{i+1}. {name}\n   ID: {_short_id(ctx_id)}")
+
+    lines.append(f"\n현재 추적 중: {_short_id(state.monitor_context)}")
+    lines.append("\n채팅 전환: /switch [번호]")
+
+    await update.message.reply_text("\n".join(lines))
+
+
+async def cmd_monitor_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Resume AZ→Telegram echo. Re-anchors `monitor_log_version` to the
+    current cursor so the user doesn't get blasted with history that
+    accumulated while the monitor was off."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    state.monitor_enabled = True
+    state.monitor_log_version = await sync_log_version(state.monitor_context)
+    await update.message.reply_text("✅ 웹 채팅 모니터링이 켜졌습니다. (현재 시점부터)")
+
+
+async def cmd_monitor_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Pause the AZ→Telegram echo without tearing down the poll loop —
+    the loop just sees `state.monitor_enabled is False` and idles."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    state.monitor_enabled = False
+    await update.message.reply_text("🔇 웹 채팅 모니터링이 꺼졌습니다.")
+
+
+async def cmd_track_chat_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Auto-track which AZ chat the monitor watches.
+
+    Renamed from /follow_on for clarity — old name was ambiguous about
+    direction (does "follow" mean Telegram→AZ or AZ→Telegram?). Both
+    /monitor and /track_chat are AZ→Telegram concerns; /track_chat
+    specifically controls whether the monitor switches its target when
+    the AZ web UI activates a different chat.
+
+    /follow_on is kept registered as an alias in bot.py main() for
+    muscle memory — that's a registration concern, not a handler one.
+    """
+    if update.effective_chat.id != CHAT_ID:
+        return
+    state.monitor_auto_follow = True
+    await update.message.reply_text(
+        "✅ 채팅 자동 추적 켜짐: 웹에서 채팅 전환 시 모니터가 따라갑니다."
+    )
+
+
+async def cmd_track_chat_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Pin the monitor to its current chat regardless of AZ web's active
+    chat. See cmd_track_chat_on for the rename rationale."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    state.monitor_auto_follow = False
+    await update.message.reply_text(
+        "📌 채팅 자동 추적 꺼짐: 현재 채팅만 고정 추적합니다."
+    )
+
+
+async def cmd_verbose_on(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Show every AZ log (info / tool / code_exe / response / error /
+    warning) during a task — useful when debugging a stuck profile.
+    Default-quiet behavior (only user echoes + task-completion summary
+    from task_report) is the normal mode."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    state.monitor_verbose = True
+    await update.message.reply_text(
+        "🔊 상세 모니터 켜짐: AZ 활동 로그(도구/코드/info 등) 모두 텔레그램으로 전송."
+    )
+
+
+async def cmd_verbose_off(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Return to quiet mode — only user echoes during task, completion-time
+    answer + metrics card from task_report."""
+    if update.effective_chat.id != CHAT_ID:
+        return
+    state.monitor_verbose = False
+    await update.message.reply_text(
+        "🔇 상세 모니터 꺼짐: 진행 중엔 조용, 완료 시 답변+메트릭만."
+    )

--- a/tests/test_bridge_chat_handlers.py
+++ b/tests/test_bridge_chat_handlers.py
@@ -1,0 +1,293 @@
+"""Pin `telegram_handlers/chat.py` — Phase Q carve from bot.py (#79).
+
+What's worth testing:
+
+1. The six toggle handlers (`/monitor_on/off`, `/track_chat_on/off`,
+   `/verbose_on/off`) flip exactly one `state.X` attribute and reply
+   with a known string — that's their entire contract. A regression
+   here would silently flip semantics (e.g. `/verbose_on` writing to
+   `monitor_auto_follow` after a typo refactor).
+
+2. The chat-id gate (`update.effective_chat.id != CHAT_ID`) early-returns
+   without touching state. Critical for the toggle handlers: without
+   the gate any Telegram user could turn off this user's monitor.
+
+3. `cmd_chats` formats the list with the `→` marker on the active
+   context. The marker logic is purely string-formatting but it's
+   the only handler in this module with non-trivial output.
+
+`cmd_monitor_on` calls `sync_log_version` (async); the test patches
+it so we don't hit the network. Other 5 toggles + cmd_chats are
+patch-free.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent / "telegram-bridge"
+
+
+# Modules our fixture injects into sys.modules. Captured at fixture
+# entry, restored on teardown — otherwise the `render` package shim
+# we install (with just `render.monitor.short_id`) shadows the real
+# render package and breaks test_pdf_export when it runs after this
+# file. Same pattern as test_bridge_webhooks.
+_OWN_MODULES = (
+    "telegram", "telegram.ext",
+    "az_client", "az_client.session",
+    "monitor", "monitor.state",
+    "render", "render.monitor",
+    "telegram_handlers", "telegram_handlers.chat",
+)
+
+
+def _wire_chat_module(monkeypatch):
+    """Spec-load `telegram_handlers.chat` after stubbing the modules
+    its top-of-file imports pull in. The real `telegram` and
+    `aiohttp` libraries aren't on the test host.
+
+    Returns (chat_module, state_module, fetch_chat_list_mock,
+    sync_log_version_mock) so individual tests can drive the bits
+    they care about.
+    """
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "999")
+
+    # Fake `telegram` + `telegram.ext` — same shape today.py tests use.
+    if "telegram" not in sys.modules:
+        telegram_pkg = types.ModuleType("telegram")
+        telegram_pkg.Update = object  # type: ignore[attr-defined]
+        sys.modules["telegram"] = telegram_pkg
+        ext = types.ModuleType("telegram.ext")
+
+        class _CTX:
+            DEFAULT_TYPE = object
+
+        ext.ContextTypes = _CTX  # type: ignore[attr-defined]
+        sys.modules["telegram.ext"] = ext
+
+    # Fake az_client.session — only the two names chat.py imports.
+    az_client_pkg = types.ModuleType("az_client")
+    az_client_pkg.__path__ = [str(_ROOT / "az_client")]  # type: ignore[attr-defined]
+    sys.modules["az_client"] = az_client_pkg
+    session_mod = types.ModuleType("az_client.session")
+    session_mod.fetch_chat_list = AsyncMock(return_value=[])
+    session_mod.sync_log_version = AsyncMock(return_value=42)
+    sys.modules["az_client.session"] = session_mod
+
+    # Real monitor.state — mutating this is precisely what the handlers
+    # do, so we want the genuine module here, not a stub.
+    monitor_pkg = types.ModuleType("monitor")
+    monitor_pkg.__path__ = [str(_ROOT / "monitor")]  # type: ignore[attr-defined]
+    sys.modules["monitor"] = monitor_pkg
+    state_spec = importlib.util.spec_from_file_location(
+        "monitor.state", _ROOT / "monitor" / "state.py"
+    )
+    assert state_spec and state_spec.loader
+    state_mod = importlib.util.module_from_spec(state_spec)
+    sys.modules["monitor.state"] = state_mod
+    state_spec.loader.exec_module(state_mod)
+    monitor_pkg.state = state_mod  # so `from monitor import state` works
+
+    # Fake render.monitor with just `short_id` — the formatter is tested
+    # in test_bridge_render_monitor.py; here we only need the symbol.
+    render_pkg = types.ModuleType("render")
+    render_pkg.__path__ = [str(_ROOT / "render")]  # type: ignore[attr-defined]
+    sys.modules["render"] = render_pkg
+    rmon = types.ModuleType("render.monitor")
+    rmon.short_id = lambda x: (x[:8] if x else "없음")
+    sys.modules["render.monitor"] = rmon
+
+    # telegram_handlers package shim.
+    handlers_pkg = types.ModuleType("telegram_handlers")
+    handlers_pkg.__path__ = [str(_ROOT / "telegram_handlers")]  # type: ignore[attr-defined]
+    sys.modules["telegram_handlers"] = handlers_pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "telegram_handlers.chat", _ROOT / "telegram_handlers" / "chat.py"
+    )
+    assert spec and spec.loader
+    chat_mod = importlib.util.module_from_spec(spec)
+    sys.modules["telegram_handlers.chat"] = chat_mod
+    spec.loader.exec_module(chat_mod)
+
+    # Reset state defaults so tests don't see leakage from prior runs.
+    state_mod.az_context = ""
+    state_mod.monitor_enabled = True
+    state_mod.monitor_log_version = 0
+    state_mod.monitor_context = ""
+    state_mod.monitor_log_guid = ""
+    state_mod.monitor_auto_follow = True
+    state_mod.monitor_verbose = False
+
+    return chat_mod, state_mod, session_mod
+
+
+@pytest.fixture
+def chat_env(monkeypatch):
+    saved = {n: sys.modules[n] for n in _OWN_MODULES if n in sys.modules}
+    bag = _wire_chat_module(monkeypatch)
+    yield bag
+    # Restore originals; drop anything we newly added so other test
+    # files (notably test_pdf_export, which expects the real `render`
+    # package) see a clean module table.
+    for n in _OWN_MODULES:
+        if n in saved:
+            sys.modules[n] = saved[n]
+        else:
+            sys.modules.pop(n, None)
+
+
+def _make_update(chat_id: int = 999, text: str = "") -> MagicMock:
+    """Minimal Update double — only the attributes our handlers touch."""
+    upd = MagicMock()
+    upd.effective_chat.id = chat_id
+    upd.message.reply_text = AsyncMock()
+    return upd
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ── Chat-id gate ────────────────────────────────────────────────────
+
+
+def test_monitor_on_gates_unauthorized_chats(chat_env):
+    chat_mod, state_mod, session_mod = chat_env
+    upd = _make_update(chat_id=12345)  # not 999
+
+    _run(chat_mod.cmd_monitor_on(upd, MagicMock()))
+
+    # State unchanged — no flip from default True
+    assert state_mod.monitor_enabled is True
+    # No reply, no AZ call
+    upd.message.reply_text.assert_not_called()
+    session_mod.sync_log_version.assert_not_called()
+
+
+def test_verbose_on_gates_unauthorized_chats(chat_env):
+    """Spot-check a different toggle to confirm the gate isn't a
+    cmd_monitor_on-only quirk."""
+    chat_mod, state_mod, _ = chat_env
+    upd = _make_update(chat_id=1)
+
+    _run(chat_mod.cmd_verbose_on(upd, MagicMock()))
+
+    assert state_mod.monitor_verbose is False
+    upd.message.reply_text.assert_not_called()
+
+
+# ── Toggle semantics — each handler flips its one slot ──────────────
+
+
+def test_monitor_on_enables_and_resyncs(chat_env):
+    chat_mod, state_mod, session_mod = chat_env
+    state_mod.monitor_enabled = False  # start OFF
+    state_mod.monitor_context = "ctx-abc"
+    upd = _make_update()
+
+    _run(chat_mod.cmd_monitor_on(upd, MagicMock()))
+
+    assert state_mod.monitor_enabled is True
+    # log_version re-anchored from sync_log_version(monitor_context)
+    session_mod.sync_log_version.assert_awaited_once_with("ctx-abc")
+    assert state_mod.monitor_log_version == 42
+    upd.message.reply_text.assert_awaited_once()
+
+
+def test_monitor_off_only_flips_enabled(chat_env):
+    """No `sync_log_version` call on disable — that's a re-anchor for
+    re-enable, not a teardown."""
+    chat_mod, state_mod, session_mod = chat_env
+    upd = _make_update()
+
+    _run(chat_mod.cmd_monitor_off(upd, MagicMock()))
+
+    assert state_mod.monitor_enabled is False
+    session_mod.sync_log_version.assert_not_called()
+    upd.message.reply_text.assert_awaited_once()
+
+
+def test_track_chat_on_flips_auto_follow(chat_env):
+    chat_mod, state_mod, _ = chat_env
+    state_mod.monitor_auto_follow = False
+    upd = _make_update()
+
+    _run(chat_mod.cmd_track_chat_on(upd, MagicMock()))
+
+    assert state_mod.monitor_auto_follow is True
+
+
+def test_track_chat_off_flips_auto_follow(chat_env):
+    chat_mod, state_mod, _ = chat_env
+    upd = _make_update()
+
+    _run(chat_mod.cmd_track_chat_off(upd, MagicMock()))
+
+    assert state_mod.monitor_auto_follow is False
+
+
+def test_verbose_on_flips_verbose(chat_env):
+    chat_mod, state_mod, _ = chat_env
+    upd = _make_update()
+
+    _run(chat_mod.cmd_verbose_on(upd, MagicMock()))
+
+    assert state_mod.monitor_verbose is True
+
+
+def test_verbose_off_flips_verbose(chat_env):
+    chat_mod, state_mod, _ = chat_env
+    state_mod.monitor_verbose = True
+    upd = _make_update()
+
+    _run(chat_mod.cmd_verbose_off(upd, MagicMock()))
+
+    assert state_mod.monitor_verbose is False
+
+
+# ── /chats formatting ───────────────────────────────────────────────
+
+
+def test_chats_empty_says_no_chats(chat_env, monkeypatch):
+    chat_mod, _, _ = chat_env
+    # `chat.py` did `from az_client.session import fetch_chat_list` at
+    # module load — the binding lives on the chat module, not on
+    # az_client.session. Patch the bound name to control return value.
+    monkeypatch.setattr(chat_mod, "fetch_chat_list", AsyncMock(return_value=[]))
+    upd = _make_update()
+
+    _run(chat_mod.cmd_chats(upd, MagicMock()))
+
+    upd.message.reply_text.assert_awaited_once_with("활성 채팅이 없습니다.")
+
+
+def test_chats_marks_active_context(chat_env, monkeypatch):
+    """The `→` arrow goes on the context whose id matches
+    `state.monitor_context`, not on the first-listed chat. Trivial-
+    looking but easy to flip if someone refactors the marker logic."""
+    chat_mod, state_mod, _ = chat_env
+    state_mod.monitor_context = "ctx-2"
+    monkeypatch.setattr(chat_mod, "fetch_chat_list", AsyncMock(return_value=[
+        {"id": "ctx-1", "name": "first"},
+        {"id": "ctx-2", "name": "second"},
+        {"id": "ctx-3", "name": "third"},
+    ]))
+    upd = _make_update()
+
+    _run(chat_mod.cmd_chats(upd, MagicMock()))
+
+    sent = upd.message.reply_text.await_args.args[0]
+    # Active marker on second only
+    assert "→ 2. second" in sent
+    assert "  1. first" in sent
+    assert "  3. third" in sent
+    # Footer points at active context
+    assert "현재 추적 중: ctx-2" in sent


### PR DESCRIPTION
## TL;DR

Phase P 가 모니터 상태를 `monitor/state.py` 로 분리한 덕에, 7개 핸들러 (`/chats`, `/monitor_on·off`, `/track_chat_on·off`, `/verbose_on·off`) 가 한꺼번에 `telegram_handlers/chat.py` 로 이동 가능해짐. 전부 `state.X` 읽고 쓰는 한두 줄짜리라 묶어서 carve.

**bot.py: 1,067 lines (이전 1,139 → −72)** · 목표 ≤ 1,000 까지 약 67 라인 남음.

## 왜 분리했나

Phase P 머지 직후 이 7개는 더 이상 bot.py 글로벌에 의존하지 않음 → 의존성이 깔끔해진 시점에 묶어서 이동. `_stream_reset` 을 호출하지 않는 핸들러만 골랐기 때문에 추가 carve 없이 바로 빠질 수 있음.

`/switch`, `/new` 는 `_stream_reset` 을 호출해서 다음 phase 까지 bot.py 에 잔류. (스트리밍 모듈 carve 가 다음 차례)

## 변경 요약

| 파일 | 변경 |
|------|------|
| `telegram-bridge/telegram_handlers/chat.py` | 신규 — 7개 핸들러 + 그룹 docstring |
| `telegram-bridge/telegram_handlers/__init__.py` | 7개 심볼 재노출 추가 |
| `telegram-bridge/bot.py` | 7개 함수 본체를 import 한 줄씩으로 치환 |
| `tests/test_bridge_chat_handlers.py` | 신규 — 10개 테스트 |

## 의존성 요약

```
chat.py ─┬─ monitor.state (Phase P)
         ├─ az_client.session (Phase H — fetch_chat_list, sync_log_version)
         └─ render.monitor (Phase J — short_id)
```

bot.py-내부 식별자에 대한 의존 0개.

## 검증

- ✅ `ruff check` 깨끗 (3 paths)
- ✅ `pytest`: **196/196** (이전 186 + 신규 10)
  - 채팅 ID 게이트: 2개 (대표 핸들러로 게이트 회귀 방지)
  - 토글 시맨틱: 6개 (각 핸들러가 정확히 하나의 슬롯만 뒤집음)
  - `/chats` 마커 위치: 2개 (빈 목록 / 가운데 활성)
- ✅ 컨테이너 리빌드 + 부팅:
  ```
  __main__ - INFO - Monitor synced to log_version: 0
  __main__ - INFO - Agent Zero monitor started
  ```
- ✅ `sys.modules` save/restore 추가 — `test_pdf_export` 와 충돌 X (`test_bridge_webhooks` 와 같은 패턴)

## 다음 단계

`_stream_reset` + `streaming_msg_id` + `streaming_text` + `_stream_extend` 를 `streaming/` 모듈로 carve → `/switch`, `/new` 도 옮길 수 있게 됨. 그 phase 에서 bot.py 가 1,000 라인 아래로 내려갈 가능성 큼.

Closes part of #79.