### PR TITLE
feat(bridge): Telegram 음성 메시지 → STT → Agent Zero

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,21 @@ TELEGRAM_CHAT_ID=123456789
 #  헤더 인증을 권장합니다 (액세스 로그에 토큰이 남지 않음).
 
 # DASHBOARD_TOKEN=
+
+
+# ══════════════════════════════════════════════════════════════
+#  5) Voice STT  (선택)
+# ══════════════════════════════════════════════════════════════
+#  Telegram voice / audio 메시지를 OpenAI Whisper API 로 텍스트
+#  변환한 뒤 일반 메시지처럼 Agent Zero 에 전달합니다.
+#
+#  ▸ 미설정 → voice/audio 보내면 "음성 인식이 비활성화" 안내 reply.
+#  ▸ Option B (OpenAI provider) 를 이미 쓰고 있다면 같은 키 재사용 가능.
+#  ▸ 비용: ~$0.006/분 (whisper-1).
+#
+#  STT_MODEL    : 기본 whisper-1
+#  STT_LANGUAGE : 기본 ko (ISO-639-1; en, ja 등 지정 가능)
+
+# OPENAI_API_KEY=sk-your-openai-key-here
+# STT_MODEL=whisper-1
+# STT_LANGUAGE=ko

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,11 @@ services:
       # M5-E: web dashboard token (issue #23). Empty/unset disables /dashboard
       # and /api/stats. Set to any non-empty string to enable.
       - DASHBOARD_TOKEN=${DASHBOARD_TOKEN:-}
+      # Voice → STT → AZ. Empty/unset disables voice handling (handler still
+      # registers but replies "음성 인식이 비활성화" instead of crashing).
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - STT_MODEL=${STT_MODEL:-whisper-1}
+      - STT_LANGUAGE=${STT_LANGUAGE:-ko}
     volumes:
       - ./docs:/app/docs:ro
       - ./GUIDE.md:/app/GUIDE.md:ro

--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 RUN pip install --no-cache-dir \
     python-telegram-bot==21.* \
     aiohttp==3.* \
-    httpx
+    httpx \
+    openai
 
 COPY bot.py .
 COPY pricing/ ./pricing/

--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -913,6 +913,10 @@ def main():
     app.add_handler(CommandHandler("help", cmd_help))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
 
+    # Voice / audio messages → STT → send_to_agent_zero (text path).
+    from telegram_handlers.voice import handle_voice  # noqa: E402
+    app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, handle_voice))
+
     logger.info("Telegram Bridge Bot started (with monitor + multi-chat)")
     app.run_polling(allowed_updates=Update.ALL_TYPES)
 

--- a/telegram-bridge/telegram_handlers/stt.py
+++ b/telegram-bridge/telegram_handlers/stt.py
@@ -1,0 +1,69 @@
+"""Speech-to-text adapter for Telegram voice/audio messages.
+
+Single-engine for now (OpenAI Whisper API). Isolated behind a small
+async surface so swapping engines (faster-whisper, Google, Azure) means
+editing only this file — voice.py keeps calling `transcribe()`.
+
+Engine selection rationale: see plan doc. Operator-only bot, low call
+volume, Korean accuracy needs — Whisper API beats local models on every
+axis except offline.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+STT_MODEL = os.environ.get("STT_MODEL") or "whisper-1"
+STT_LANGUAGE = os.environ.get("STT_LANGUAGE") or "ko"
+
+_client = None
+
+
+class STTUnavailable(RuntimeError):
+    """Raised when STT cannot run because OPENAI_API_KEY is missing.
+
+    Voice handler catches this separately to give a clear setup hint
+    instead of a generic API error.
+    """
+
+
+def _get_client():
+    global _client
+    if _client is not None:
+        return _client
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise STTUnavailable("OPENAI_API_KEY is not set")
+
+    try:
+        from openai import AsyncOpenAI
+    except ImportError as e:
+        raise STTUnavailable(f"openai package not installed: {e}") from e
+
+    _client = AsyncOpenAI(api_key=api_key)
+    return _client
+
+
+async def transcribe(audio_path: str, *, language: str | None = None) -> str:
+    """Transcribe an audio file to text via OpenAI Whisper.
+
+    Returns the stripped transcript. Raises STTUnavailable if the
+    engine isn't configured; lets other openai exceptions bubble so the
+    caller can surface a useful error to the user.
+    """
+    client = _get_client()
+    lang = language or STT_LANGUAGE
+
+    with open(audio_path, "rb") as f:
+        result = await client.audio.transcriptions.create(
+            model=STT_MODEL,
+            file=f,
+            language=lang,
+        )
+
+    text = (getattr(result, "text", None) or "").strip()
+    logger.info("STT transcribed %d chars (lang=%s, model=%s)", len(text), lang, STT_MODEL)
+    return text

--- a/telegram-bridge/telegram_handlers/system.py
+++ b/telegram-bridge/telegram_handlers/system.py
@@ -75,5 +75,8 @@ async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "  /budget [day|week] [USD] → 예산 한도 + 자동 알림\n"
         "  /pricing [list|diff|snapshot] → LiteLLM 가격 스냅샷 + drift\n"
         "  /backup → 설정 경량 백업 (ZIP 파일 전송)\n"
-        "  /help → 도움말"
+        "  /help → 도움말\n\n"
+        "음성:\n"
+        "  🎤 voice / audio 메시지 전송 → STT 변환 후 AZ에 전달\n"
+        "  (OPENAI_API_KEY 필요 · 모델 whisper-1 · 언어 ko 기본)"
     )

--- a/telegram-bridge/telegram_handlers/voice.py
+++ b/telegram-bridge/telegram_handlers/voice.py
@@ -1,0 +1,82 @@
+"""Voice / audio Telegram handler — STT then forward to Agent Zero.
+
+Telegram VOICE (mic OGG/Opus) and AUDIO (mp3/m4a attachment) messages
+get downloaded, transcribed via `stt.transcribe`, echoed back to the
+user (so misrecognitions are obvious), and finally piped through the
+existing `bot.send_to_agent_zero` text path.
+
+`send_to_agent_zero` is imported lazily inside the handler to avoid a
+circular import — bot.py imports this module to register the handler.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from telegram_handlers.stt import STTUnavailable, transcribe
+
+logger = logging.getLogger(__name__)
+
+_chat_id_raw = os.environ.get("TELEGRAM_CHAT_ID")
+CHAT_ID: int | None = int(_chat_id_raw) if _chat_id_raw else None
+
+# Telegram bot API hard limit for getFile downloads.
+MAX_AUDIO_BYTES = 20 * 1024 * 1024
+
+
+async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if update.effective_chat.id != CHAT_ID:
+        await update.message.reply_text("권한이 없습니다.")
+        return
+
+    media = update.message.voice or update.message.audio
+    if media is None:
+        return
+
+    if media.file_size and media.file_size > MAX_AUDIO_BYTES:
+        await update.message.reply_text(
+            f"음성 파일이 너무 큽니다 ({media.file_size / 1024 / 1024:.1f}MB > 20MB). "
+            "더 짧게 녹음해주세요."
+        )
+        return
+
+    suffix = ".ogg" if update.message.voice else ".bin"
+    tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    tmp.close()
+    try:
+        tg_file = await media.get_file()
+        await tg_file.download_to_drive(tmp.name)
+
+        try:
+            text = await transcribe(tmp.name)
+        except STTUnavailable:
+            await update.message.reply_text(
+                "음성 인식이 비활성화되어 있습니다 (OPENAI_API_KEY 미설정)."
+            )
+            return
+        except Exception as e:
+            logger.exception("STT failed")
+            await update.message.reply_text(f"음성 인식 실패: {e}")
+            return
+
+        if not text:
+            await update.message.reply_text("들리지 않습니다. 다시 시도해주세요.")
+            return
+
+        await update.message.reply_text(f"🎤 들은 내용: {text}")
+
+        from bot import send_to_agent_zero
+
+        logger.info("Voice → Agent Zero: %s", text[:100])
+        response = await send_to_agent_zero(text)
+        await update.message.reply_text(response)
+
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary

- Telegram voice note(`filters.VOICE`)나 audio 첨부(`filters.AUDIO`)를 받으면 OpenAI Whisper API로 텍스트 변환 후 기존 `send_to_agent_zero` 텍스트 경로로 흘려보냅니다.
- Agent Zero `/api/message_async` 는 텍스트 전용이라 변환은 bridge 측에서 처리 — AZ 본체 변경 0, 다른 인터페이스 영향 0.
- "🎤 들은 내용: …" 트랜스크립트를 먼저 reply한 뒤 AZ 응답을 reply (오인식 디버깅 용이).
- `OPENAI_API_KEY` 미설정시 컨테이너는 정상 기동, voice 보낼 때만 "음성 인식이 비활성화" 안내 — 기존 텍스트 경로는 무영향.

## 변경 파일

- 신규: `telegram-bridge/telegram_handlers/stt.py` (Whisper API 어댑터, 엔진 교체 가능 격리)
- 신규: `telegram-bridge/telegram_handlers/voice.py` (handler — 권한체크 + 20MB 가드 + tempfile cleanup)
- `telegram-bridge/bot.py` — `MessageHandler(filters.VOICE | filters.AUDIO, handle_voice)` 등록 한 줄
- `telegram-bridge/Dockerfile` — `openai` 패키지 추가 (+5MB, 시스템 패키지 변경 없음)
- `docker-compose.yml` — `OPENAI_API_KEY` / `STT_MODEL` / `STT_LANGUAGE` env 주입 (모두 default empty)
- `.env.example` — 5번 섹션 'Voice STT' 안내 + 비용 (~\$0.006/분)
- `telegram_handlers/system.py` `/help` — 음성 사용 안내 한 단락

## Test plan

- [ ] `.env` 에 `OPENAI_API_KEY` 추가
- [ ] `docker compose build telegram-bridge && docker compose up -d telegram-bridge` 성공, 로그 정상
- [ ] Telegram 에서 한국어 voice note (10초 내외) → \"🎤 들은 내용: …\" + AZ 응답 reply 도착
- [ ] mp3/m4a 파일 첨부 → 동일 흐름
- [ ] 권한 없는 chat → \"권한이 없습니다.\" (텍스트 경로와 동일)
- [ ] `OPENAI_API_KEY` 비우고 voice → \"음성 인식이 비활성화되어 있습니다\" reply, 컨테이너 죽지 않음
- [ ] 기존 텍스트 메시지 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)