### PR TITLE
[Eval] eval/runner.py + AZ 클라이언트 + 트레이스 캡처 (#111)

### DIFF
--- a/eval/az_client.py
+++ b/eval/az_client.py
@@ -1,0 +1,226 @@
+"""Agent Zero 클라이언트 — 케이스 실행을 위한 최소 인터페이스.
+
+설계 의도:
+
+- runner 는 `AZClient` Protocol 만 알고, 구체 구현은 둘:
+  - `HTTPAZClient` — 실제 AZ 컨테이너에 메시지를 보내고 task_report
+    JSON 이 디스크에 떨어지는 것을 기다린다.
+  - `FakeAZClient` — 테스트용. 미리 준비한 task_report 를 즉시 떨어뜨려
+    runner 의 트레이스 변환·가드 검사 로직만 단위 테스트한다.
+
+task_report JSON 의 생성 자체는 AZ 내부 확장 (`monologue_end/_50_task_report_finish.py`)
+이 책임지므로, 클라이언트는 "메시지 전달 → 완료된 JSON 등장 대기" 만 한다.
+별도 토큰 트래킹 코드를 만들지 않는 게 핵심: 기존 task_report 시스템이
+이미 입출력/캐시/비용을 정확히 기록하므로 그걸 재사용.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """클라이언트가 한 케이스 실행 후 반환하는 원시 결과.
+
+    - `task_report`: AZ task_report JSON 의 파싱된 dict. 완료된 경우 항상 채워짐.
+    - `started_at_iso` / `ended_at_iso`: 메시지 송신 ~ 완료 감지 사이의 UTC 시각.
+    - `error`: 클라이언트 측 오류 (timeout, 네트워크, 파싱 등). task_report
+      가 채워졌으면 None.
+    """
+
+    task_report: dict[str, Any] | None
+    started_at_iso: str
+    ended_at_iso: str
+    error: str | None = None
+
+
+class AZClient(Protocol):
+    """Eval runner 가 의존하는 최소 인터페이스."""
+
+    async def send_and_wait(self, task: str, *, timeout_sec: int) -> RunResult:
+        ...
+
+
+# ── HTTP 구현 ───────────────────────────────────────────────────────────
+
+
+class HTTPAZClient:
+    """실제 AZ 컨테이너에 붙어 케이스를 실행.
+
+    동작:
+    1. `/api/message_async` 로 task 송신.
+    2. `tasks_dir` (= host 의 `agent-zero/logs/tasks/`) 에서 `started_at`
+       이 송신 시각 이후이고 `ended_reason == "completed"` 인 JSON 을
+       polling.
+    3. 그 JSON 을 task_report 로 반환.
+
+    aiohttp 는 옵션 의존성으로 두고 실제 import 는 메서드 안에서만 한다 —
+    테스트는 FakeAZClient 로 돌리므로 aiohttp 미설치 환경에서도 import 가능.
+    """
+
+    def __init__(
+        self,
+        *,
+        az_url: str,
+        az_prefix: str = "/api",
+        tasks_dir: Path | str,
+        poll_interval_sec: float = 0.5,
+    ) -> None:
+        self.az_url = az_url.rstrip("/")
+        self.az_prefix = az_prefix
+        self.tasks_dir = Path(tasks_dir)
+        self.poll_interval_sec = poll_interval_sec
+
+    async def send_and_wait(
+        self, task: str, *, timeout_sec: int
+    ) -> RunResult:
+        import aiohttp  # 지연 import — 테스트 환경 의존성 회피
+
+        from .trace import now_iso
+
+        started_iso = now_iso()
+        started_mono = time.monotonic()
+
+        # 1. 메시지 송신.
+        try:
+            async with aiohttp.ClientSession() as session:
+                # CSRF 토큰 획득 (v1.8+ 보호).
+                csrf = ""
+                try:
+                    async with session.get(
+                        f"{self.az_url}{self.az_prefix}/csrf_token",
+                        headers={"Origin": "http://localhost:50001"},
+                        timeout=aiohttp.ClientTimeout(total=10),
+                    ) as resp:
+                        if resp.status == 200:
+                            csrf = (await resp.json()).get("token", "")
+                except Exception as e:
+                    logger.warning(f"csrf_token fetch failed: {e}")
+
+                headers = {"Origin": "http://localhost:50001"}
+                if csrf:
+                    headers["X-CSRF-Token"] = csrf
+
+                async with session.post(
+                    f"{self.az_url}{self.az_prefix}/message_async",
+                    json={"text": task, "context": ""},
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        return RunResult(
+                            task_report=None,
+                            started_at_iso=started_iso,
+                            ended_at_iso=now_iso(),
+                            error=(
+                                f"message_async failed: {resp.status} {body[:200]}"
+                            ),
+                        )
+        except Exception as e:
+            return RunResult(
+                task_report=None,
+                started_at_iso=started_iso,
+                ended_at_iso=now_iso(),
+                error=f"send failed: {e}",
+            )
+
+        # 2. 완료된 task_report JSON 을 디스크에서 polling.
+        report = await self._wait_for_report(
+            send_mono=started_mono, timeout_sec=timeout_sec
+        )
+        ended_iso = now_iso()
+
+        if report is None:
+            return RunResult(
+                task_report=None,
+                started_at_iso=started_iso,
+                ended_at_iso=ended_iso,
+                error=f"timed out waiting for task_report ({timeout_sec}s)",
+            )
+
+        return RunResult(
+            task_report=report,
+            started_at_iso=started_iso,
+            ended_at_iso=ended_iso,
+        )
+
+    async def _wait_for_report(
+        self, *, send_mono: float, timeout_sec: int
+    ) -> dict[str, Any] | None:
+        """`tasks_dir` 에서 송신 이후 생성된 completed task_report 를 찾을 때까지 대기.
+
+        조건:
+        - JSON 파일의 mtime 이 송신 시각 이후 (간단·신뢰가능한 1차 필터)
+        - `ended_reason == "completed"` (orphaned 는 실패로 간주)
+
+        여러 후보가 있으면 mtime 이 가장 빠른 것을 고른다 — 같은 디렉토리를
+        쓰는 평행 작업이 없다는 단일 테넌트 가정 (eval 운영 시 유지).
+        """
+        send_wall = time.time() - (time.monotonic() - send_mono)
+        deadline = send_mono + timeout_sec
+
+        while time.monotonic() < deadline:
+            if self.tasks_dir.exists():
+                candidates: list[tuple[float, Path]] = []
+                for p in self.tasks_dir.glob("*.json"):
+                    if p.name.endswith(".tmp"):
+                        continue
+                    try:
+                        st = p.stat()
+                    except OSError:
+                        continue
+                    if st.st_mtime < send_wall:
+                        continue
+                    candidates.append((st.st_mtime, p))
+
+                candidates.sort(key=lambda x: x[0])
+                for _, path in candidates:
+                    try:
+                        data = json.loads(path.read_text(encoding="utf-8"))
+                    except Exception:
+                        continue
+                    if data.get("ended_reason") == "completed":
+                        return data
+
+            await asyncio.sleep(self.poll_interval_sec)
+
+        return None
+
+
+# ── 테스트용 가짜 클라이언트 ────────────────────────────────────────────
+
+
+class FakeAZClient:
+    """캔드 응답을 즉시 반환하는 테스트 더블.
+
+    `responses` 큐에 RunResult 를 넣어두면 호출 순서대로 반환한다.
+    큐가 비면 마지막 응답을 반복한다 — 한 가지 결과만 흉내내고 싶을 때 편의.
+    """
+
+    def __init__(self, responses: list[RunResult]) -> None:
+        if not responses:
+            raise ValueError("FakeAZClient requires at least one response")
+        self._responses = list(responses)
+        self._idx = 0
+        self.received_tasks: list[str] = []
+        self.received_timeouts: list[int] = []
+
+    async def send_and_wait(
+        self, task: str, *, timeout_sec: int
+    ) -> RunResult:
+        self.received_tasks.append(task)
+        self.received_timeouts.append(timeout_sec)
+        if self._idx < len(self._responses):
+            resp = self._responses[self._idx]
+            self._idx += 1
+            return resp
+        return self._responses[-1]

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -1,0 +1,312 @@
+"""Eval runner — 케이스 한 건 또는 전체를 실행하고 트레이스 JSON 저장.
+
+CLI:
+    python -m eval.runner --case <id>     # 단건
+    python -m eval.runner --all           # 전체
+
+`--cases-dir` 와 `--runs-dir` 로 디렉토리 override 가능. AZ 엔드포인트는
+`--az-url` 또는 env `AZ_API_URL` (기본 http://localhost:50001).
+task_report 디렉토리는 `--tasks-dir` 또는 env `EVAL_TASKS_DIR`
+(기본 `agent-zero/logs/tasks`).
+
+테스트는 `run_case()` / `run_all()` 를 `FakeAZClient` 와 함께 호출해
+HTTP·디스크 의존 없이 동작 검증.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .az_client import AZClient, HTTPAZClient, RunResult
+from .schema import EvalCase, EvalSchemaError, load_case, load_cases
+from .trace import Trace, make_run_dir, now_iso, save_trace
+
+logger = logging.getLogger(__name__)
+
+
+# 디렉토리 기본값. CLI / env 가 override.
+_DEFAULT_CASES_DIR = Path("eval/cases")
+_DEFAULT_RUNS_DIR = Path("eval/runs")
+_DEFAULT_TASKS_DIR = Path("agent-zero/logs/tasks")
+
+
+@dataclass
+class RunSummary:
+    """한 회차 실행 결과 요약. /eval 명령·CI 가 이 dict 를 그대로 리포트."""
+
+    run_dir: Path
+    started_at: str
+    ended_at: str
+    total: int
+    passed_guards: int  # guard_violations / error 모두 비어있는 케이스 수
+    failed_guards: int
+    total_cost_usd: float
+    total_duration_ms: int
+    traces: list[Trace]
+
+    def to_summary_dict(self) -> dict:
+        return {
+            "run_dir": str(self.run_dir),
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "total": self.total,
+            "passed_guards": self.passed_guards,
+            "failed_guards": self.failed_guards,
+            "total_cost_usd": round(self.total_cost_usd, 6),
+            "total_duration_ms": self.total_duration_ms,
+            "cases": [
+                {
+                    "case_id": t.case_id,
+                    "turns": t.turns,
+                    "cost_usd": round(t.cost_usd, 6),
+                    "duration_ms": t.duration_ms,
+                    "guard_violations": list(t.guard_violations),
+                    "error": t.error,
+                }
+                for t in self.traces
+            ],
+        }
+
+
+# ── 단일 케이스 실행 ────────────────────────────────────────────────────
+
+
+async def run_case(
+    case: EvalCase, client: AZClient, *, run_dir: Path
+) -> Trace:
+    """케이스 한 건을 실행, Trace 생성 + JSON 저장.
+
+    가드 위반(턴/비용/타임아웃)은 `trace.guard_violations` 에, 클라이언트
+    오류는 `trace.error` 에 기록된다. 둘 다 비어있으면 가드 통과.
+    """
+    result: RunResult = await client.send_and_wait(
+        case.task, timeout_sec=case.timeout_sec
+    )
+
+    if result.task_report is None:
+        # 송신 실패·타임아웃: 빈 trace + error.
+        trace = Trace(
+            case_id=case.id,
+            task=case.task,
+            started_at=result.started_at_iso,
+            ended_at=result.ended_at_iso,
+            duration_ms=_iso_diff_ms(
+                result.started_at_iso, result.ended_at_iso
+            ),
+            az_task_id=None,
+            turns=0,
+            tool_calls=[],
+            final_response="",
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            reasoning_tokens=0,
+            cost_usd=0.0,
+            guard_violations=[],
+            error=result.error or "no task_report returned",
+        )
+    else:
+        trace = Trace.from_task_report(
+            case_id=case.id,
+            task=case.task,
+            started_at=result.started_at_iso,
+            ended_at=result.ended_at_iso,
+            report=result.task_report,
+        )
+        violations = _check_guards(case, trace)
+        if violations:
+            trace.guard_violations = violations
+
+    save_trace(trace, run_dir)
+    return trace
+
+
+def _check_guards(case: EvalCase, trace: Trace) -> list[str]:
+    """case 의 가드(max_turns / max_cost_usd / timeout) 위반 항목 목록."""
+    out: list[str] = []
+    if trace.turns > case.max_turns:
+        out.append(f"max_turns_exceeded ({trace.turns}>{case.max_turns})")
+    if trace.cost_usd > case.max_cost_usd:
+        out.append(
+            f"max_cost_exceeded (${trace.cost_usd:.4f}>${case.max_cost_usd:.4f})"
+        )
+    # 타임아웃 가드 — duration_ms 기반. 단, 클라이언트가 자체적으로
+    # timeout_sec 으로 끊었으면 task_report 가 없어서 여긴 안 옴.
+    if trace.duration_ms > case.timeout_sec * 1000:
+        out.append(
+            f"timeout_exceeded ({trace.duration_ms}ms>{case.timeout_sec}s)"
+        )
+    return out
+
+
+def _iso_diff_ms(start_iso: str, end_iso: str) -> int:
+    try:
+        s = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
+        e = datetime.fromisoformat(end_iso.replace("Z", "+00:00"))
+        return max(0, int((e - s).total_seconds() * 1000))
+    except (ValueError, AttributeError):
+        return 0
+
+
+# ── 전체 실행 ───────────────────────────────────────────────────────────
+
+
+async def run_all(
+    cases: list[EvalCase],
+    client: AZClient,
+    *,
+    runs_dir: Path,
+) -> RunSummary:
+    """주어진 케이스 목록을 직렬 실행 (eval 은 보통 동시성 가치가 작음 —
+    AZ 가 한 번에 한 monologue 만 깔끔히 처리하는 게 안전)."""
+    started_at = now_iso()
+    started_dt = datetime.now(timezone.utc)  # noqa: UP017
+    run_dir = make_run_dir(runs_dir, started_at=started_dt)
+
+    traces: list[Trace] = []
+    for case in cases:
+        logger.info(f"[eval] running case: {case.id}")
+        trace = await run_case(case, client, run_dir=run_dir)
+        traces.append(trace)
+
+    ended_at = now_iso()
+
+    passed = sum(1 for t in traces if not t.guard_violations and not t.error)
+    failed = len(traces) - passed
+    total_cost = sum(t.cost_usd for t in traces)
+    total_duration = sum(t.duration_ms for t in traces)
+
+    summary = RunSummary(
+        run_dir=run_dir,
+        started_at=started_at,
+        ended_at=ended_at,
+        total=len(traces),
+        passed_guards=passed,
+        failed_guards=failed,
+        total_cost_usd=total_cost,
+        total_duration_ms=total_duration,
+        traces=traces,
+    )
+    _write_summary(summary)
+    return summary
+
+
+def _write_summary(summary: RunSummary) -> None:
+    """`<run_dir>/_summary.json` 으로 회차 요약 저장."""
+    path = summary.run_dir / "_summary.json"
+    path.write_text(
+        json.dumps(summary.to_summary_dict(), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="python -m eval.runner",
+        description="Run eval golden-set cases against Agent Zero.",
+    )
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--case", help="단건 실행 — 케이스 id 또는 YAML 경로")
+    g.add_argument("--all", action="store_true", help="cases-dir 의 전체 실행")
+    p.add_argument(
+        "--cases-dir",
+        default=str(_DEFAULT_CASES_DIR),
+        help=f"YAML 케이스 디렉토리 (기본 {_DEFAULT_CASES_DIR})",
+    )
+    p.add_argument(
+        "--runs-dir",
+        default=str(_DEFAULT_RUNS_DIR),
+        help=f"결과 저장 디렉토리 (기본 {_DEFAULT_RUNS_DIR})",
+    )
+    p.add_argument(
+        "--az-url",
+        default=os.environ.get("AZ_API_URL", "http://localhost:50001"),
+        help="AZ HTTP 엔드포인트 (env AZ_API_URL)",
+    )
+    p.add_argument(
+        "--tasks-dir",
+        default=os.environ.get("EVAL_TASKS_DIR", str(_DEFAULT_TASKS_DIR)),
+        help=(
+            f"AZ task_report JSON 디렉토리 (기본 {_DEFAULT_TASKS_DIR}, "
+            "env EVAL_TASKS_DIR)"
+        ),
+    )
+    return p.parse_args(argv)
+
+
+def _resolve_cases(args: argparse.Namespace) -> list[EvalCase]:
+    cases_dir = Path(args.cases_dir)
+    if args.all:
+        return load_cases(cases_dir)
+    # --case: 파일 경로 또는 id
+    target = args.case
+    p = Path(target)
+    if p.is_file():
+        return [load_case(p)]
+    # id 로 가정 — cases_dir 에서 찾는다
+    candidate = cases_dir / f"{target}.yaml"
+    if not candidate.is_file():
+        raise EvalSchemaError(
+            f"case not found: {target} (looked in {candidate})"
+        )
+    return [load_case(candidate)]
+
+
+def _print_summary(summary: RunSummary) -> None:
+    print(f"\n[eval] run_dir: {summary.run_dir}")
+    print(
+        f"[eval] {summary.passed_guards}/{summary.total} passed "
+        f"(guards) | total cost ${summary.total_cost_usd:.4f} | "
+        f"duration {summary.total_duration_ms / 1000:.1f}s"
+    )
+    for t in summary.traces:
+        status = "OK"
+        if t.error:
+            status = f"ERROR: {t.error}"
+        elif t.guard_violations:
+            status = "GUARD: " + "; ".join(t.guard_violations)
+        print(
+            f"  - {t.case_id:30s} turns={t.turns:>2} "
+            f"cost=${t.cost_usd:.4f} {t.duration_ms / 1000:>5.1f}s  {status}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("EVAL_LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        cases = _resolve_cases(args)
+    except EvalSchemaError as e:
+        print(f"[eval] failed to load cases: {e}", file=sys.stderr)
+        return 2
+
+    if not cases:
+        print("[eval] no cases to run", file=sys.stderr)
+        return 1
+
+    client = HTTPAZClient(az_url=args.az_url, tasks_dir=args.tasks_dir)
+    summary = asyncio.run(
+        run_all(cases, client, runs_dir=Path(args.runs_dir))
+    )
+    _print_summary(summary)
+    # CI 관점에서: 가드 실패가 하나라도 있으면 비제로 종료.  세부 baseline
+    # 비교(통과율 -10%p 기준 등)는 #116 워크플로우의 책임.
+    return 0 if summary.failed_guards == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/trace.py
+++ b/eval/trace.py
@@ -1,0 +1,160 @@
+"""Eval trace — 한 케이스 실행 결과의 표준 직렬화.
+
+AZ 의 task_report JSON 을 1차 소스로 삼아 우리 트레이스 포맷으로 정규화.
+필드는 가능한 한 task_report 의 키와 맞춰 다운스트림(judge, dashboard)이
+양쪽 모두를 같은 키로 다룰 수 있게 한다.
+
+task_report 가 사용할 수 없는 경우(스텁/오류) 호출자가 빈 trace 또는
+`error` 가 채워진 trace 를 만들 수 있도록 모든 토큰 필드는 0 기본값.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """task_report 의 `tool_calls[]` 한 항목을 정규화한 형태."""
+
+    name: str
+    args_preview: str
+    duration_ms: int
+
+
+@dataclass
+class Trace:
+    """단일 eval 케이스 실행 결과.
+
+    `from_task_report` 가 표준 컨버터.  guard_violations / error 는
+    runner 가 정책 위반(턴 초과, 비용 초과, 타임아웃)을 기록할 자리.
+    """
+
+    case_id: str
+    task: str
+    started_at: str
+    ended_at: str
+    duration_ms: int
+
+    az_task_id: str | None
+    turns: int
+    tool_calls: list[ToolCall]
+    final_response: str
+
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    reasoning_tokens: int
+    cost_usd: float
+
+    guard_violations: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """asdict 결과를 그대로 JSON 직렬화에 쓰기 위한 보조."""
+        return asdict(self)
+
+    @classmethod
+    def from_task_report(
+        cls,
+        *,
+        case_id: str,
+        task: str,
+        started_at: str,
+        ended_at: str,
+        report: dict[str, Any],
+    ) -> Trace:
+        """AZ task_report JSON 을 받아 Trace 로 변환.
+
+        `totals` 의 토큰/비용을 우선 사용한다.  `final_response` 는
+        task_report 가 채우는 최상위 필드를 먼저 보고, 없으면 마지막
+        `response` 툴의 `args_preview` 를 폴백으로.
+        """
+        totals = report.get("totals", {}) or {}
+
+        tool_calls: list[ToolCall] = []
+        for tc in report.get("tool_calls", []) or []:
+            duration_ms = tc.get("duration_ms")
+            if duration_ms is None:
+                duration_ms = int((tc.get("duration_sec", 0) or 0) * 1000)
+            tool_calls.append(
+                ToolCall(
+                    name=str(tc.get("name", "")),
+                    args_preview=str(tc.get("args_preview", "")),
+                    duration_ms=int(duration_ms or 0),
+                )
+            )
+
+        final_response = report.get("final_response") or ""
+        if not final_response:
+            # task_report.py 가 final_response 를 못 잡은 경우 — response
+            # 툴의 args_preview 가 가장 가까운 폴백 (truncated 일 수 있음).
+            for tc in reversed(report.get("tool_calls", []) or []):
+                if tc.get("name") == "response":
+                    final_response = tc.get("args_preview", "")
+                    break
+
+        duration_ms = int((report.get("elapsed_sec", 0) or 0) * 1000)
+        if duration_ms == 0:
+            duration_ms = _diff_ms(started_at, ended_at)
+
+        return cls(
+            case_id=case_id,
+            task=task,
+            started_at=started_at,
+            ended_at=ended_at,
+            duration_ms=duration_ms,
+            az_task_id=report.get("task_id"),
+            turns=int(report.get("iterations", 0) or 0),
+            tool_calls=tool_calls,
+            final_response=str(final_response or ""),
+            input_tokens=int(totals.get("input_tokens", 0) or 0),
+            output_tokens=int(totals.get("output_tokens", 0) or 0),
+            cache_read_tokens=int(totals.get("cache_read_tokens", 0) or 0),
+            cache_creation_tokens=int(
+                totals.get("cache_creation_tokens", 0) or 0
+            ),
+            reasoning_tokens=int(totals.get("reasoning_tokens", 0) or 0),
+            cost_usd=float(totals.get("cost_usd", 0.0) or 0.0),
+        )
+
+
+def _diff_ms(start_iso: str, end_iso: str) -> int:
+    """ISO 두 시각의 차이(ms).  파싱 실패 시 0."""
+    try:
+        s = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
+        e = datetime.fromisoformat(end_iso.replace("Z", "+00:00"))
+        return max(0, int((e - s).total_seconds() * 1000))
+    except (ValueError, AttributeError):
+        return 0
+
+
+def now_iso() -> str:
+    """현재 UTC 시각을 ISO8601 로.  trace 의 started_at/ended_at 표준."""
+    return datetime.now(timezone.utc).isoformat()  # noqa: UP017
+
+
+def make_run_dir(base: Path | str, *, started_at: datetime | None = None) -> Path:
+    """`<base>/<YYYYmmdd-HHMMSS>/` 신규 디렉토리 생성.  runner 가 한 회차의
+    모든 케이스를 같은 디렉토리에 모으는 데 사용."""
+    started_at = started_at or datetime.now(timezone.utc)  # noqa: UP017
+    stamp = started_at.strftime("%Y%m%d-%H%M%S")
+    d = Path(base) / stamp
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def save_trace(trace: Trace, run_dir: Path | str) -> Path:
+    """Trace 를 `<run_dir>/<case_id>.json` 으로 직렬화."""
+    d = Path(run_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{trace.case_id}.json"
+    path.write_text(
+        json.dumps(trace.to_dict(), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return path

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -1,0 +1,349 @@
+"""eval/runner.py 검증 — FakeAZClient 로 HTTP/디스크 의존 없이 동작 검증.
+
+테스트 시나리오:
+- 단일 케이스 정상 실행 → trace JSON + summary JSON 생성
+- 가드 위반 분기 (max_turns, max_cost, timeout)
+- 클라이언트 오류 분기 (error 필드 채움)
+- 전체 실행 + summary 집계
+- CLI 인자 파싱 (--case, --all, --cases-dir, --az-url, --tasks-dir)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from eval.az_client import FakeAZClient, RunResult
+from eval.runner import (
+    RunSummary,
+    _parse_args,
+    _resolve_cases,
+    run_all,
+    run_case,
+)
+from eval.schema import EvalCase, EvalSchemaError
+
+
+def _make_case(**overrides) -> EvalCase:
+    """테스트용 기본 케이스. overrides 로 가드 필드를 좁힐 수 있다."""
+    defaults = dict(
+        id="t1",
+        task="hello",
+        expected_behaviors=["responds with hello"],
+        judge_criteria="",
+        tags=[],
+        max_turns=10,
+        max_cost_usd=0.50,
+        timeout_sec=120,
+    )
+    defaults.update(overrides)
+    return EvalCase(**defaults)
+
+
+def _make_report(
+    *,
+    iterations: int = 1,
+    cost: float = 0.001,
+    input_tokens: int = 100,
+    elapsed_sec: float = 1.0,
+    response: str = "hi",
+) -> dict:
+    return {
+        "task_id": "task-test-001",
+        "started_at": "2026-05-12T01:00:00+00:00",
+        "ended_at": "2026-05-12T01:00:01+00:00",
+        "elapsed_sec": elapsed_sec,
+        "iterations": iterations,
+        "ended_reason": "completed",
+        "final_response": response,
+        "tool_calls": [
+            {"name": "response", "args_preview": response, "duration_ms": 1}
+        ],
+        "totals": {
+            "tool_calls": 1,
+            "llm_calls": 1,
+            "input_tokens": input_tokens,
+            "output_tokens": 10,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+            "reasoning_tokens": 0,
+            "cost_usd": cost,
+        },
+    }
+
+
+# ── run_case 단위 ───────────────────────────────────────────────────────
+
+
+def test_run_case_success(tmp_path: Path):
+    case = _make_case()
+    client = FakeAZClient(
+        [
+            RunResult(
+                task_report=_make_report(),
+                started_at_iso="2026-05-12T01:00:00+00:00",
+                ended_at_iso="2026-05-12T01:00:01+00:00",
+            )
+        ]
+    )
+    trace = asyncio.run(run_case(case, client, run_dir=tmp_path))
+
+    assert client.received_tasks == ["hello"]
+    assert client.received_timeouts == [120]
+    assert trace.case_id == "t1"
+    assert trace.turns == 1
+    assert trace.cost_usd == 0.001
+    assert trace.error is None
+    assert trace.guard_violations == []
+    # 디스크에도 저장.
+    saved = json.loads((tmp_path / "t1.json").read_text(encoding="utf-8"))
+    assert saved["case_id"] == "t1"
+
+
+def test_run_case_records_client_error(tmp_path: Path):
+    case = _make_case()
+    client = FakeAZClient(
+        [
+            RunResult(
+                task_report=None,
+                started_at_iso="2026-05-12T01:00:00+00:00",
+                ended_at_iso="2026-05-12T01:02:00+00:00",
+                error="timed out waiting for task_report (120s)",
+            )
+        ]
+    )
+    trace = asyncio.run(run_case(case, client, run_dir=tmp_path))
+    assert trace.error and "timed out" in trace.error
+    assert trace.turns == 0
+    assert trace.cost_usd == 0.0
+    assert trace.duration_ms == 120_000
+
+
+# ── 가드 검사 ───────────────────────────────────────────────────────────
+
+
+def test_guard_max_turns_violation(tmp_path: Path):
+    case = _make_case(max_turns=2)
+    client = FakeAZClient(
+        [
+            RunResult(
+                task_report=_make_report(iterations=5),
+                started_at_iso="s",
+                ended_at_iso="e",
+            )
+        ]
+    )
+    trace = asyncio.run(run_case(case, client, run_dir=tmp_path))
+    assert any("max_turns_exceeded" in v for v in trace.guard_violations)
+
+
+def test_guard_max_cost_violation(tmp_path: Path):
+    case = _make_case(max_cost_usd=0.01)
+    client = FakeAZClient(
+        [
+            RunResult(
+                task_report=_make_report(cost=0.50),
+                started_at_iso="s",
+                ended_at_iso="e",
+            )
+        ]
+    )
+    trace = asyncio.run(run_case(case, client, run_dir=tmp_path))
+    assert any("max_cost_exceeded" in v for v in trace.guard_violations)
+
+
+def test_guard_timeout_violation(tmp_path: Path):
+    """duration_ms 가 timeout_sec*1000 을 넘으면 timeout_exceeded 가드.
+
+    클라이언트가 자체적으로 timeout 으로 끊었으면 task_report 가 None 이라
+    error 분기로 들어가지만, AZ 가 응답하긴 했는데 너무 오래 걸린 경우는
+    여기에 잡힌다."""
+    case = _make_case(timeout_sec=1)
+    client = FakeAZClient(
+        [
+            RunResult(
+                task_report=_make_report(elapsed_sec=5.0),
+                started_at_iso="s",
+                ended_at_iso="e",
+            )
+        ]
+    )
+    trace = asyncio.run(run_case(case, client, run_dir=tmp_path))
+    assert any("timeout_exceeded" in v for v in trace.guard_violations)
+
+
+def test_multiple_guard_violations_all_reported(tmp_path: Path):
+    case = _make_case(max_turns=1, max_cost_usd=0.001, timeout_sec=1)
+    client = FakeAZClient(
+        [
+            RunResult(
+                task_report=_make_report(
+                    iterations=5, cost=0.5, elapsed_sec=5.0
+                ),
+                started_at_iso="s",
+                ended_at_iso="e",
+            )
+        ]
+    )
+    trace = asyncio.run(run_case(case, client, run_dir=tmp_path))
+    assert len(trace.guard_violations) == 3
+
+
+# ── run_all ──────────────────────────────────────────────────────────────
+
+
+def test_run_all_aggregates_summary(tmp_path: Path):
+    cases = [
+        _make_case(id="a"),
+        _make_case(id="b", max_cost_usd=0.0001),  # 일부러 위반시킴
+        _make_case(id="c"),
+    ]
+    client = FakeAZClient(
+        [
+            RunResult(
+                task_report=_make_report(cost=0.001),
+                started_at_iso="s",
+                ended_at_iso="e",
+            ),
+            RunResult(
+                task_report=_make_report(cost=0.01),  # max_cost 0.0001 위반
+                started_at_iso="s",
+                ended_at_iso="e",
+            ),
+            RunResult(
+                task_report=_make_report(cost=0.002),
+                started_at_iso="s",
+                ended_at_iso="e",
+            ),
+        ]
+    )
+    summary: RunSummary = asyncio.run(
+        run_all(cases, client, runs_dir=tmp_path)
+    )
+    assert summary.total == 3
+    assert summary.passed_guards == 2
+    assert summary.failed_guards == 1
+    assert summary.total_cost_usd == pytest.approx(0.013, rel=1e-3)
+    # run_dir 안에 3개 trace + summary.
+    assert (summary.run_dir / "a.json").is_file()
+    assert (summary.run_dir / "b.json").is_file()
+    assert (summary.run_dir / "c.json").is_file()
+    assert (summary.run_dir / "_summary.json").is_file()
+    summary_json = json.loads(
+        (summary.run_dir / "_summary.json").read_text(encoding="utf-8")
+    )
+    assert summary_json["passed_guards"] == 2
+    assert summary_json["cases"][1]["case_id"] == "b"
+
+
+def test_run_all_empty_cases_list(tmp_path: Path):
+    client = FakeAZClient(
+        [RunResult(task_report=_make_report(), started_at_iso="s", ended_at_iso="e")]
+    )
+    summary = asyncio.run(run_all([], client, runs_dir=tmp_path))
+    assert summary.total == 0
+    assert summary.passed_guards == 0
+    assert client.received_tasks == []
+
+
+# ── CLI 파싱 ─────────────────────────────────────────────────────────────
+
+
+def test_parse_args_case_and_all_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        _parse_args(["--case", "x", "--all"])
+
+
+def test_parse_args_requires_one():
+    with pytest.raises(SystemExit):
+        _parse_args([])
+
+
+def test_parse_args_case_with_overrides():
+    ns = _parse_args(
+        [
+            "--case",
+            "my_case",
+            "--cases-dir",
+            "custom/cases",
+            "--runs-dir",
+            "custom/runs",
+            "--az-url",
+            "http://example:9999",
+            "--tasks-dir",
+            "/tmp/tasks",
+        ]
+    )
+    assert ns.case == "my_case"
+    assert ns.cases_dir == "custom/cases"
+    assert ns.runs_dir == "custom/runs"
+    assert ns.az_url == "http://example:9999"
+    assert ns.tasks_dir == "/tmp/tasks"
+
+
+def test_parse_args_all():
+    ns = _parse_args(["--all"])
+    assert ns.all is True
+    assert ns.case is None
+
+
+# ── _resolve_cases ───────────────────────────────────────────────────────
+
+
+def test_resolve_cases_all(tmp_path: Path):
+    (tmp_path / "x.yaml").write_text(
+        "task: t\nexpected_behaviors: [b]\n", encoding="utf-8"
+    )
+    (tmp_path / "y.yaml").write_text(
+        "task: t\nexpected_behaviors: [b]\n", encoding="utf-8"
+    )
+    ns = _parse_args(["--all", "--cases-dir", str(tmp_path)])
+    cases = _resolve_cases(ns)
+    assert sorted(c.id for c in cases) == ["x", "y"]
+
+
+def test_resolve_cases_single_by_id(tmp_path: Path):
+    (tmp_path / "alpha.yaml").write_text(
+        "task: t\nexpected_behaviors: [b]\n", encoding="utf-8"
+    )
+    ns = _parse_args(["--case", "alpha", "--cases-dir", str(tmp_path)])
+    cases = _resolve_cases(ns)
+    assert [c.id for c in cases] == ["alpha"]
+
+
+def test_resolve_cases_single_by_path(tmp_path: Path):
+    p = tmp_path / "beta.yaml"
+    p.write_text("task: t\nexpected_behaviors: [b]\n", encoding="utf-8")
+    ns = _parse_args(["--case", str(p)])
+    cases = _resolve_cases(ns)
+    assert [c.id for c in cases] == ["beta"]
+
+
+def test_resolve_cases_missing_id(tmp_path: Path):
+    ns = _parse_args(["--case", "ghost", "--cases-dir", str(tmp_path)])
+    with pytest.raises(EvalSchemaError, match="case not found"):
+        _resolve_cases(ns)
+
+
+# ── FakeAZClient 동작 ───────────────────────────────────────────────────
+
+
+def test_fake_client_replays_last_response_when_queue_empty():
+    """캔드 응답 큐가 비면 마지막 응답을 반복 — 동일 결과 시뮬레이션 편의."""
+    only = RunResult(
+        task_report=_make_report(),
+        started_at_iso="s",
+        ended_at_iso="e",
+    )
+    client = FakeAZClient([only])
+    r1 = asyncio.run(client.send_and_wait("a", timeout_sec=10))
+    r2 = asyncio.run(client.send_and_wait("b", timeout_sec=20))
+    assert r1 is only and r2 is only
+    assert client.received_tasks == ["a", "b"]
+
+
+def test_fake_client_requires_responses():
+    with pytest.raises(ValueError):
+        FakeAZClient([])

--- a/tests/test_eval_trace.py
+++ b/tests/test_eval_trace.py
@@ -1,0 +1,209 @@
+"""eval/trace.py 검증.
+
+task_report JSON → Trace 변환의 모든 분기를 다룬다 — totals/iterations,
+final_response 폴백, duration 계산, save/load 라운드트립.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from eval.trace import (
+    ToolCall,
+    Trace,
+    make_run_dir,
+    now_iso,
+    save_trace,
+)
+
+
+def _sample_report() -> dict:
+    """대표 task_report JSON 1건. 실제 AZ 출력 포맷을 미러링."""
+    return {
+        "task_id": "task-20260512-100000-abcdef",
+        "started_at": "2026-05-12T01:00:00+00:00",
+        "ended_at": "2026-05-12T01:00:12.5+00:00",
+        "elapsed_sec": 12.5,
+        "iterations": 3,
+        "ended_reason": "completed",
+        "final_response": "정상 응답 본문입니다.",
+        "tool_calls": [
+            {
+                "name": "code_execution_tool",
+                "args_preview": '{"runtime":"python","code":"print(1)"}',
+                "duration_ms": 142.7,
+            },
+            {
+                "name": "response",
+                "args_preview": "정상 응답 본문입니다.",
+                "duration_ms": 5.0,
+            },
+        ],
+        "totals": {
+            "tool_calls": 2,
+            "llm_calls": 4,
+            "input_tokens": 1500,
+            "output_tokens": 320,
+            "cache_read_tokens": 12000,
+            "cache_creation_tokens": 800,
+            "reasoning_tokens": 50,
+            "cost_usd": 0.0421,
+        },
+    }
+
+
+# ── 정상 변환 ───────────────────────────────────────────────────────────
+
+
+def test_from_task_report_happy_path():
+    trace = Trace.from_task_report(
+        case_id="my_case",
+        task="요약해줘",
+        started_at="2026-05-12T01:00:00+00:00",
+        ended_at="2026-05-12T01:00:12.5+00:00",
+        report=_sample_report(),
+    )
+    assert trace.case_id == "my_case"
+    assert trace.az_task_id == "task-20260512-100000-abcdef"
+    assert trace.turns == 3
+    assert trace.input_tokens == 1500
+    assert trace.cache_read_tokens == 12000
+    assert trace.cost_usd == 0.0421
+    assert trace.duration_ms == 12500
+    assert trace.final_response == "정상 응답 본문입니다."
+    assert len(trace.tool_calls) == 2
+    assert trace.tool_calls[0].name == "code_execution_tool"
+    assert trace.tool_calls[0].duration_ms == 142  # float → int
+    assert trace.guard_violations == []
+    assert trace.error is None
+
+
+def test_final_response_falls_back_to_response_tool_args():
+    """task_report 가 final_response 를 안 채운 경우 — response 툴의
+    args_preview 가 폴백."""
+    report = _sample_report()
+    del report["final_response"]
+    trace = Trace.from_task_report(
+        case_id="x",
+        task="t",
+        started_at=now_iso(),
+        ended_at=now_iso(),
+        report=report,
+    )
+    assert trace.final_response == "정상 응답 본문입니다."
+
+
+def test_final_response_empty_when_no_response_tool():
+    report = _sample_report()
+    del report["final_response"]
+    report["tool_calls"] = [
+        tc for tc in report["tool_calls"] if tc["name"] != "response"
+    ]
+    trace = Trace.from_task_report(
+        case_id="x",
+        task="t",
+        started_at=now_iso(),
+        ended_at=now_iso(),
+        report=report,
+    )
+    assert trace.final_response == ""
+
+
+def test_duration_falls_back_to_iso_diff_when_elapsed_missing():
+    report = _sample_report()
+    del report["elapsed_sec"]
+    trace = Trace.from_task_report(
+        case_id="x",
+        task="t",
+        started_at="2026-05-12T01:00:00+00:00",
+        ended_at="2026-05-12T01:00:10+00:00",
+        report=report,
+    )
+    assert trace.duration_ms == 10000
+
+
+def test_missing_totals_defaults_to_zero():
+    """`totals` 키가 통째로 빠져도 트레이스 변환은 정상 동작 (0 으로 채움)."""
+    trace = Trace.from_task_report(
+        case_id="x",
+        task="t",
+        started_at=now_iso(),
+        ended_at=now_iso(),
+        report={"iterations": 1, "ended_reason": "completed"},
+    )
+    assert trace.input_tokens == 0
+    assert trace.cost_usd == 0.0
+    assert trace.turns == 1
+
+
+def test_tool_call_duration_sec_compat():
+    """legacy 포맷 (duration_sec 만 있고 duration_ms 가 없는) 도 변환되어야 한다."""
+    report = _sample_report()
+    report["tool_calls"] = [
+        {"name": "x", "args_preview": "y", "duration_sec": 0.5}
+    ]
+    trace = Trace.from_task_report(
+        case_id="x",
+        task="t",
+        started_at=now_iso(),
+        ended_at=now_iso(),
+        report=report,
+    )
+    assert trace.tool_calls[0].duration_ms == 500
+
+
+# ── 저장 / 라운드트립 ───────────────────────────────────────────────────
+
+
+def test_save_trace_writes_json(tmp_path: Path):
+    trace = Trace.from_task_report(
+        case_id="case_a",
+        task="t",
+        started_at=now_iso(),
+        ended_at=now_iso(),
+        report=_sample_report(),
+    )
+    path = save_trace(trace, tmp_path)
+    assert path == tmp_path / "case_a.json"
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["case_id"] == "case_a"
+    assert on_disk["az_task_id"] == "task-20260512-100000-abcdef"
+    assert on_disk["tool_calls"][0]["name"] == "code_execution_tool"
+
+
+def test_make_run_dir_creates_timestamped_subdir(tmp_path: Path):
+    fixed = datetime(2026, 5, 12, 9, 30, 15, tzinfo=timezone.utc)  # noqa: UP017
+    d = make_run_dir(tmp_path, started_at=fixed)
+    assert d.name == "20260512-093015"
+    assert d.is_dir()
+    assert d.parent == tmp_path
+
+
+def test_trace_to_dict_preserves_tool_calls():
+    """asdict 변환 시 ToolCall 도 dict 로 풀려야 JSON 직렬화 가능."""
+    trace = Trace(
+        case_id="x",
+        task="t",
+        started_at="s",
+        ended_at="e",
+        duration_ms=0,
+        az_task_id=None,
+        turns=0,
+        tool_calls=[ToolCall(name="t", args_preview="a", duration_ms=1)],
+        final_response="",
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
+        reasoning_tokens=0,
+        cost_usd=0.0,
+    )
+    d = trace.to_dict()
+    assert d["tool_calls"][0] == {
+        "name": "t",
+        "args_preview": "a",
+        "duration_ms": 1,
+    }
+    # JSON 직렬화 라운드트립.
+    assert json.loads(json.dumps(d))["case_id"] == "x"


### PR DESCRIPTION
Closes #111 — 마일스톤 [Quality Evals 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/2) 2단계.

**TL;DR**: 케이스 → AZ `/message_async` → host-mount 된 `agent-zero/logs/tasks/` 에서 완료된 `task_report` JSON 을 polling → 정규화한 Trace 로 저장. 토큰/비용은 기존 task_report 가 이미 다 기록하므로 우리는 변환만 한다.

## Why

- [#110](https://github.com/devyoon91/az-cliproxy-docker/issues/110) 의 case YAML 스키마 위에 실제 실행 엔진 필요. judge ([#112](https://github.com/devyoon91/az-cliproxy-docker/issues/112)) / 골든셋 ([#113](https://github.com/devyoon91/az-cliproxy-docker/issues/113)) / `/eval` ([#114](https://github.com/devyoon91/az-cliproxy-docker/issues/114)) 모두 여기에 의존.
- **재발명 금지**: AZ 의 `task_report` 시스템이 이미 turns / tokens / cache / cost / tool_calls 를 정확히 기록. eval runner 는 이걸 1차 소스로 쓰고 토큰 카운트 재구현 안 함. 이슈 #111 의 "토큰/비용은 기존 `telegram-bridge/pricing` 로직 재사용" 요건을 같은 task JSON 을 통해 충족.

## 아키텍처

```
EvalCase (YAML)
    │
    ▼
run_case ─── AZClient.send_and_wait ──► AZ /message_async
    │                                         │
    │                              writes task_report JSON
    │                                         ▼
    │                          agent-zero/logs/tasks/<task_id>.json
    │                                         │
    │           polls dir for new completed JSON
    │                                         │
    ▼                                         ▼
Trace.from_task_report ◄────────────────  RunResult.task_report
    │
    ▼
save_trace → eval/runs/<timestamp>/<case_id>.json
```

**`AZClient` Protocol** — 구체 구현 둘:

| 구현 | 용도 |
|---|---|
| `HTTPAZClient` | 실제 AZ 컨테이너 — aiohttp 로 메시지 송신 + 디스크 polling |
| `FakeAZClient` | 테스트 — 캔드 `RunResult` 큐, HTTP/디스크 의존 0 |

## 변경 파일

| 파일 | 내용 |
|---|---|
| [eval/trace.py](eval/trace.py) | `Trace` / `ToolCall` dataclass, `from_task_report` 변환, `save_trace`, `make_run_dir` |
| [eval/az_client.py](eval/az_client.py) | `AZClient` Protocol, `HTTPAZClient`, `FakeAZClient`, `RunResult` |
| [eval/runner.py](eval/runner.py) | `run_case`, `run_all`, 가드 검사, argparse CLI |
| [tests/test_eval_trace.py](tests/test_eval_trace.py) | 9 케이스 — 정상 변환, 폴백, duration, totals 누락, legacy `duration_sec` |
| [tests/test_eval_runner.py](tests/test_eval_runner.py) | 18 케이스 — 가드 위반 3종, 다중 위반, run_all 집계, CLI 파싱, `_resolve_cases` |

## CLI

```bash
python -m eval.runner --case example_pr_title_check
python -m eval.runner --all
python -m eval.runner --all --az-url http://localhost:50001
```

| 인자 | 기본 | env override |
|---|---|---|
| `--cases-dir` | `eval/cases` | — |
| `--runs-dir` | `eval/runs` | — |
| `--az-url` | `http://localhost:50001` | `AZ_API_URL` |
| `--tasks-dir` | `agent-zero/logs/tasks` | `EVAL_TASKS_DIR` |

종료 코드: 가드 통과 시 0, 위반/오류 1건 이상 시 1. baseline 비교는 [#116](https://github.com/devyoon91/az-cliproxy-docker/issues/116) 책임.

## 가드 (case YAML 의 `max_*` 와 매칭)

| 가드 | 트리거 | trace 필드 |
|---|---|---|
| `max_turns_exceeded` | task_report.iterations > case.max_turns | `guard_violations[]` |
| `max_cost_exceeded` | totals.cost_usd > case.max_cost_usd | `guard_violations[]` |
| `timeout_exceeded` | duration_ms > case.timeout_sec*1000 | `guard_violations[]` |
| 클라이언트 오류 | task_report 못 받음 (송신 실패/타임아웃) | `error` |

## Verification

```
$ python -m pytest
============================= 260 passed in 1.09s =============================

$ python -m ruff check eval/ tests/test_eval_trace.py tests/test_eval_runner.py
All checks passed!
```

## Test plan

- [x] 정상 케이스 → trace JSON + `_summary.json` 저장
- [x] task_report 누락 시 `error` 필드 채움
- [x] `max_turns` / `max_cost` / `timeout` 가드 각각 위반 시 `guard_violations[]` 기록
- [x] 다중 위반 모두 보고
- [x] `run_all` 집계 — passed/failed 카운트, total_cost_usd, total_duration_ms
- [x] CLI: `--case` vs `--all` 상호배타, 필수 인자, override 전달
- [x] `_resolve_cases` — id / 파일경로 / 미존재 분기
- [x] `FakeAZClient` 큐 비면 마지막 응답 반복
- [x] `final_response` 폴백 (top-level 없을 때 response 툴 args_preview)
- [x] legacy `duration_sec` 필드 호환

## 다음

- [#112](https://github.com/devyoon91/az-cliproxy-docker/issues/112) — judge 모듈. 이 PR 의 Trace JSON 을 받아 `expected_behaviors` 별 점수화.