### PR TITLE
[Eval] LLM-as-judge 채점기 — util 모델로 expected vs actual (#112)

### DIFF
--- a/eval/judge.py
+++ b/eval/judge.py
@@ -1,0 +1,462 @@
+"""LLM-as-judge — case + trace → score/passed/reasoning.
+
+util 모델 (기본 Haiku 4.5) 에 expected_behaviors + judge_criteria + 응답을
+주고 JSON 으로 점수를 받는다.  점수 / 통과 여부 / 실패한 행동 목록 / 한 줄
+근거를 `eval/runs/<timestamp>/<case_id>.judge.json` 에 기록하고, 트레이스
+파일에는 judge 호출 비용을 추가한다.
+
+설계 분리:
+- `JudgeClient` Protocol — runner 의 AZClient 와 같은 패턴.
+  - `HTTPJudgeClient` 가 실제 Anthropic Messages API 호출.
+  - `FakeJudgeClient` 가 캔드 응답으로 테스트.
+- `parse_judge_response` 가 LLM 의 흔한 quirks (코드 펜스, preamble) 를 흡수.
+- 비용 계산은 Haiku 4.5 고정 rate.  agent-zero/lib/pricing.py 의
+  canonical 값과 일치하도록 두 곳에서 같이 관리.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from .schema import EvalCase, load_case
+
+logger = logging.getLogger(__name__)
+
+
+# 기본 통과 임계값 — score >= 이 값이면 passed=True.
+DEFAULT_PASS_THRESHOLD = 0.7
+
+# 기본 judge 모델.  settings.example.json 의 util_model_name 과 일치.
+DEFAULT_JUDGE_MODEL = "claude-haiku-4-5"
+
+# Haiku 4.5 per-token rates (USD).  Anthropic 가격이 바뀌면 여기와
+# agent-zero/lib/pricing.py 의 _ALIASES/테이블을 함께 업데이트.
+# 캐싱은 judge 가 단일-호출이라 무시 (cache hit 자체가 안 일어남).
+_HAIKU_INPUT_RATE = 0.0000008    # $0.80 / 1M
+_HAIKU_OUTPUT_RATE = 0.000004    # $4.00 / 1M
+
+
+# ── 데이터 클래스 ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class JudgeResponse:
+    """JudgeClient 가 반환하는 원시 응답 — runner 가 파싱 + 점수 산출."""
+
+    content: str
+    input_tokens: int
+    output_tokens: int
+
+
+@dataclass
+class JudgeResult:
+    """단일 케이스 채점 결과.  `.judge.json` 으로 직렬화."""
+
+    case_id: str
+    score: float
+    passed: bool
+    reasoning: str
+    failed_behaviors: list[str]
+    judge_model: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    error: str | None = None
+
+
+# ── 클라이언트 ──────────────────────────────────────────────────────────
+
+
+class JudgeClient(Protocol):
+    """eval/judge 가 의존하는 최소 인터페이스."""
+
+    async def score(
+        self, *, system: str, user: str, model: str
+    ) -> JudgeResponse:
+        ...
+
+
+class HTTPJudgeClient:
+    """Anthropic Messages API 호출용 실 클라이언트.
+
+    anthropic SDK 는 옵션 의존 — `score()` 안에서 lazy import 한다.
+    """
+
+    def __init__(self, *, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+
+    async def score(
+        self, *, system: str, user: str, model: str
+    ) -> JudgeResponse:
+        import anthropic  # 지연 import
+
+        if not self.api_key:
+            raise RuntimeError("ANTHROPIC_API_KEY not set")
+
+        client = anthropic.AsyncAnthropic(api_key=self.api_key)
+        resp = await client.messages.create(
+            model=model,
+            max_tokens=512,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+            temperature=0,
+        )
+        text = ""
+        for block in resp.content:
+            if getattr(block, "type", "") == "text":
+                text += getattr(block, "text", "")
+        return JudgeResponse(
+            content=text,
+            input_tokens=int(getattr(resp.usage, "input_tokens", 0) or 0),
+            output_tokens=int(getattr(resp.usage, "output_tokens", 0) or 0),
+        )
+
+
+class FakeJudgeClient:
+    """캔드 응답을 순서대로 반환하는 테스트 더블.
+
+    `error_on_call` 가 True 면 호출 시 RuntimeError 를 raise — 클라이언트
+    오류 경로 (네트워크/인증 실패 등) 검증용.
+    """
+
+    def __init__(
+        self,
+        responses: list[JudgeResponse],
+        *,
+        error_on_call: bool = False,
+    ) -> None:
+        if not responses and not error_on_call:
+            raise ValueError(
+                "FakeJudgeClient requires at least one response "
+                "or error_on_call=True"
+            )
+        self._responses = list(responses)
+        self._idx = 0
+        self._error_on_call = error_on_call
+        self.received_prompts: list[tuple[str, str, str]] = []
+
+    async def score(
+        self, *, system: str, user: str, model: str
+    ) -> JudgeResponse:
+        self.received_prompts.append((system, user, model))
+        if self._error_on_call:
+            raise RuntimeError("simulated judge failure")
+        if self._idx < len(self._responses):
+            r = self._responses[self._idx]
+            self._idx += 1
+            return r
+        return self._responses[-1]
+
+
+# ── 프롬프트 ────────────────────────────────────────────────────────────
+
+
+_SYSTEM_PROMPT = """You are an evaluator. Score how well an AI response satisfies a set of
+expected behaviors for a given task.
+
+Output ONLY valid JSON matching this schema. No preamble, no markdown fences.
+
+{
+  "score": <float between 0.0 and 1.0>,
+  "reasoning": "<one sentence explaining the score>",
+  "failed_behaviors": [<exact strings from the expected_behaviors list that were NOT met>]
+}
+
+Scoring:
+- 1.0 = all expected behaviors met
+- 0.0 = none met
+- partial = (met / total), nudged by judge_criteria"""
+
+
+def build_user_prompt(case: EvalCase, response_text: str) -> str:
+    """case 와 관찰된 응답으로부터 judge user message 작성."""
+    behaviors = "\n".join(f"- {b}" for b in case.expected_behaviors)
+    criteria = case.judge_criteria.strip() or "(none)"
+    response = (response_text or "").strip() or "(empty)"
+    return (
+        f"Task:\n{case.task}\n\n"
+        f"Expected behaviors:\n{behaviors}\n\n"
+        f"Judge criteria:\n{criteria}\n\n"
+        f"AI response:\n{response}"
+    )
+
+
+def parse_judge_response(content: str) -> dict[str, Any]:
+    """LLM 응답에서 JSON 객체 추출.
+
+    흔한 quirks:
+    - ` ```json … ``` ` 코드 펜스로 감싸기
+    - "Here is the JSON: { … }" 같이 preamble
+    - 마지막에 trailing 텍스트
+
+    전략: 첫 `{` 부터 마지막 `}` 까지를 잘라 json.loads.  실패 시 ValueError.
+    """
+    text = content.strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start < 0 or end < 0 or end < start:
+        raise ValueError(f"no JSON object found in: {content[:200]}")
+    snippet = text[start : end + 1]
+    return json.loads(snippet)
+
+
+def _compute_judge_cost(input_tokens: int, output_tokens: int) -> float:
+    """Haiku 4.5 rate 기반 비용 (USD).  6자리 반올림."""
+    return round(
+        max(0, int(input_tokens)) * _HAIKU_INPUT_RATE
+        + max(0, int(output_tokens)) * _HAIKU_OUTPUT_RATE,
+        6,
+    )
+
+
+# ── 핵심 채점 ───────────────────────────────────────────────────────────
+
+
+async def judge_trace(
+    case: EvalCase,
+    trace_data: dict[str, Any],
+    client: JudgeClient,
+    *,
+    model: str = DEFAULT_JUDGE_MODEL,
+    pass_threshold: float = DEFAULT_PASS_THRESHOLD,
+) -> JudgeResult:
+    """단일 트레이스 채점.  실패 경로(클라이언트 오류/파싱 실패) 모두
+    JudgeResult 의 `error` 필드로 흡수해 호출자가 균일하게 처리하도록 한다."""
+    final_response = trace_data.get("final_response", "") or ""
+    user_prompt = build_user_prompt(case, final_response)
+
+    try:
+        resp = await client.score(
+            system=_SYSTEM_PROMPT, user=user_prompt, model=model
+        )
+    except Exception as e:
+        return JudgeResult(
+            case_id=case.id,
+            score=0.0,
+            passed=False,
+            reasoning="",
+            failed_behaviors=[],
+            judge_model=model,
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            error=f"judge call failed: {e}",
+        )
+
+    cost = _compute_judge_cost(resp.input_tokens, resp.output_tokens)
+
+    try:
+        parsed = parse_judge_response(resp.content)
+    except (ValueError, json.JSONDecodeError) as e:
+        return JudgeResult(
+            case_id=case.id,
+            score=0.0,
+            passed=False,
+            reasoning="",
+            failed_behaviors=[],
+            judge_model=model,
+            input_tokens=resp.input_tokens,
+            output_tokens=resp.output_tokens,
+            cost_usd=cost,
+            error=f"judge response not parseable: {e}",
+        )
+
+    # 점수 범위 클램프 — 모델이 1.2 같이 내놓아도 1.0 으로 캡.
+    raw_score = parsed.get("score", 0.0)
+    try:
+        score = float(raw_score)
+    except (TypeError, ValueError):
+        score = 0.0
+    score = max(0.0, min(1.0, score))
+
+    failed = parsed.get("failed_behaviors", []) or []
+    if not isinstance(failed, list):
+        failed = []
+    failed = [str(x) for x in failed]
+
+    return JudgeResult(
+        case_id=case.id,
+        score=score,
+        passed=score >= pass_threshold,
+        reasoning=str(parsed.get("reasoning", "")),
+        failed_behaviors=failed,
+        judge_model=model,
+        input_tokens=resp.input_tokens,
+        output_tokens=resp.output_tokens,
+        cost_usd=cost,
+    )
+
+
+# ── 회차 디렉토리 단위 처리 ─────────────────────────────────────────────
+
+
+async def judge_run_dir(
+    run_dir: Path | str,
+    cases_dir: Path | str,
+    client: JudgeClient,
+    *,
+    model: str = DEFAULT_JUDGE_MODEL,
+    pass_threshold: float = DEFAULT_PASS_THRESHOLD,
+) -> list[JudgeResult]:
+    """run_dir 안의 모든 트레이스를 채점.
+
+    출력:
+    - `<run_dir>/<case_id>.judge.json` (JudgeResult 직렬화)
+    - `<run_dir>/<case_id>.json` 의 `judge_cost_usd` 필드 갱신 (error 가 없을 때만)
+    """
+    run_dir = Path(run_dir)
+    cases_dir = Path(cases_dir)
+
+    results: list[JudgeResult] = []
+    for trace_path in sorted(run_dir.glob("*.json")):
+        # _summary.json / .judge.json 은 건너뜀
+        if trace_path.name.startswith("_"):
+            continue
+        if trace_path.name.endswith(".judge.json"):
+            continue
+
+        try:
+            trace_data = json.loads(trace_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning(f"skip unreadable trace {trace_path.name}: {e}")
+            continue
+
+        case_id = trace_data.get("case_id")
+        if not case_id:
+            logger.warning(
+                f"trace {trace_path.name} has no case_id — skip"
+            )
+            continue
+
+        case_path = cases_dir / f"{case_id}.yaml"
+        if not case_path.is_file():
+            logger.warning(
+                f"case yaml missing for {case_id} (expected {case_path})"
+            )
+            continue
+        case = load_case(case_path)
+
+        result = await judge_trace(
+            case,
+            trace_data,
+            client,
+            model=model,
+            pass_threshold=pass_threshold,
+        )
+        results.append(result)
+
+        # 1) JudgeResult 직렬화
+        judge_path = run_dir / f"{case_id}.judge.json"
+        judge_path.write_text(
+            json.dumps(asdict(result), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        # 2) trace JSON 의 judge_cost_usd 갱신 — error 면 0 으로 두고
+        # 그 외에는 실제 cost.  cost 가 있는 경우만 디스크에 다시 쓴다.
+        if result.error is None and result.cost_usd > 0:
+            trace_data["judge_cost_usd"] = result.cost_usd
+            trace_path.write_text(
+                json.dumps(trace_data, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+    return results
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="python -m eval.judge",
+        description="Score eval traces with an LLM-as-judge.",
+    )
+    p.add_argument(
+        "--run-dir",
+        required=True,
+        help="채점할 트레이스 JSON 들이 있는 디렉토리",
+    )
+    p.add_argument(
+        "--cases-dir",
+        default="eval/cases",
+        help="case YAML 디렉토리 (기본 eval/cases)",
+    )
+    p.add_argument(
+        "--model",
+        default=DEFAULT_JUDGE_MODEL,
+        help=f"judge 모델 (기본 {DEFAULT_JUDGE_MODEL})",
+    )
+    p.add_argument(
+        "--pass-threshold",
+        type=float,
+        default=DEFAULT_PASS_THRESHOLD,
+        help=f"passed=True 임계값 (기본 {DEFAULT_PASS_THRESHOLD})",
+    )
+    return p.parse_args(argv)
+
+
+def _print_summary(results: list[JudgeResult]) -> None:
+    passed = sum(1 for r in results if r.passed)
+    failed = sum(1 for r in results if not r.passed and not r.error)
+    errored = sum(1 for r in results if r.error)
+    total_cost = sum(r.cost_usd for r in results)
+    print(
+        f"\n[judge] {passed}/{len(results)} passed, "
+        f"{failed} failed, {errored} errored | "
+        f"total cost ${total_cost:.4f}"
+    )
+    for r in results:
+        if r.error:
+            mark, detail = "ERR", r.error
+        elif r.passed:
+            mark, detail = "OK ", r.reasoning[:80]
+        else:
+            mark, detail = "FAIL", r.reasoning[:80]
+        print(
+            f"  [{mark}] {r.case_id:30s} score={r.score:.2f}  "
+            f"cost=${r.cost_usd:.4f}  {detail}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("EVAL_LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    run_dir = Path(args.run_dir)
+    cases_dir = Path(args.cases_dir)
+
+    if not run_dir.is_dir():
+        print(f"[judge] run_dir not found: {run_dir}", file=sys.stderr)
+        return 2
+
+    client = HTTPJudgeClient()
+    results = asyncio.run(
+        judge_run_dir(
+            run_dir,
+            cases_dir,
+            client,
+            model=args.model,
+            pass_threshold=args.pass_threshold,
+        )
+    )
+    _print_summary(results)
+
+    if not results:
+        return 1
+    errored = sum(1 for r in results if r.error)
+    failed = sum(1 for r in results if not r.passed and not r.error)
+    return 0 if errored == 0 and failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/trace.py
+++ b/eval/trace.py
@@ -54,6 +54,10 @@ class Trace:
     guard_violations: list[str] = field(default_factory=list)
     error: str | None = None
 
+    # judge (#112) 가 채우는 별도 비용 — runner 자체에서는 항상 0.
+    # 트레이스 단위 총비용은 `cost_usd + judge_cost_usd`.
+    judge_cost_usd: float = 0.0
+
     def to_dict(self) -> dict[str, Any]:
         """asdict 결과를 그대로 JSON 직렬화에 쓰기 위한 보조."""
         return asdict(self)

--- a/tests/test_eval_judge.py
+++ b/tests/test_eval_judge.py
@@ -1,0 +1,493 @@
+"""eval/judge.py 검증.
+
+LLM 호출은 FakeJudgeClient 로 모킹.  실제 Anthropic 호출 없이:
+- 프롬프트 조립
+- JSON 응답 파싱 (코드 펜스/preamble/malformed 케이스)
+- 점수 클램프 / passed 임계값
+- 클라이언트 오류 / 파싱 실패 분기
+- judge_run_dir 의 디스크 IO (judge.json 작성 + trace.json judge_cost_usd 갱신)
+- CLI 파싱
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from eval.judge import (
+    DEFAULT_JUDGE_MODEL,
+    DEFAULT_PASS_THRESHOLD,
+    FakeJudgeClient,
+    JudgeResponse,
+    _compute_judge_cost,
+    _parse_args,
+    build_user_prompt,
+    judge_run_dir,
+    judge_trace,
+    parse_judge_response,
+)
+from eval.schema import EvalCase
+
+
+def _make_case(**overrides) -> EvalCase:
+    defaults = dict(
+        id="t1",
+        task="요약해줘",
+        expected_behaviors=["한국어로 답한다", "3줄 이내로 답한다"],
+        judge_criteria="간결하고 정확해야 함",
+        tags=["test"],
+        max_turns=5,
+        max_cost_usd=0.10,
+        timeout_sec=60,
+    )
+    defaults.update(overrides)
+    return EvalCase(**defaults)
+
+
+def _make_trace_data(response: str = "응답입니다") -> dict:
+    return {
+        "case_id": "t1",
+        "task": "요약해줘",
+        "started_at": "2026-05-12T01:00:00+00:00",
+        "ended_at": "2026-05-12T01:00:05+00:00",
+        "duration_ms": 5000,
+        "az_task_id": "task-1",
+        "turns": 1,
+        "tool_calls": [],
+        "final_response": response,
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "reasoning_tokens": 0,
+        "cost_usd": 0.001,
+        "guard_violations": [],
+        "error": None,
+        "judge_cost_usd": 0.0,
+    }
+
+
+def _good_judge_response(
+    *, score: float = 0.9, failed: list | None = None
+) -> JudgeResponse:
+    payload = {
+        "score": score,
+        "reasoning": "거의 모든 기준 충족",
+        "failed_behaviors": failed or [],
+    }
+    return JudgeResponse(
+        content=json.dumps(payload, ensure_ascii=False),
+        input_tokens=300,
+        output_tokens=40,
+    )
+
+
+# ── 프롬프트 ────────────────────────────────────────────────────────────
+
+
+def test_build_user_prompt_contains_all_sections():
+    case = _make_case()
+    prompt = build_user_prompt(case, "테스트 응답")
+    assert "Task:\n요약해줘" in prompt
+    assert "- 한국어로 답한다" in prompt
+    assert "- 3줄 이내로 답한다" in prompt
+    assert "Judge criteria:\n간결하고 정확해야 함" in prompt
+    assert "AI response:\n테스트 응답" in prompt
+
+
+def test_build_user_prompt_empty_response_uses_placeholder():
+    case = _make_case()
+    prompt = build_user_prompt(case, "")
+    assert "AI response:\n(empty)" in prompt
+
+
+def test_build_user_prompt_whitespace_only_response_uses_placeholder():
+    case = _make_case()
+    prompt = build_user_prompt(case, "   \n  ")
+    assert "AI response:\n(empty)" in prompt
+
+
+def test_build_user_prompt_empty_criteria_uses_placeholder():
+    case = _make_case(judge_criteria="")
+    prompt = build_user_prompt(case, "응답")
+    assert "Judge criteria:\n(none)" in prompt
+
+
+# ── JSON 파싱 ───────────────────────────────────────────────────────────
+
+
+def test_parse_judge_response_plain_json():
+    text = '{"score": 0.8, "reasoning": "ok", "failed_behaviors": []}'
+    out = parse_judge_response(text)
+    assert out["score"] == 0.8
+
+
+def test_parse_judge_response_with_code_fence():
+    text = """```json
+{"score": 0.5, "reasoning": "절반", "failed_behaviors": ["x"]}
+```"""
+    out = parse_judge_response(text)
+    assert out["score"] == 0.5
+    assert out["failed_behaviors"] == ["x"]
+
+
+def test_parse_judge_response_with_preamble_and_trailing():
+    text = (
+        "Here is my evaluation:\n"
+        '{"score": 0.7, "reasoning": "good", "failed_behaviors": []}\n'
+        "End of response."
+    )
+    out = parse_judge_response(text)
+    assert out["score"] == 0.7
+
+
+def test_parse_judge_response_malformed_raises():
+    with pytest.raises(ValueError, match="no JSON object"):
+        parse_judge_response("not even close to JSON")
+
+
+def test_parse_judge_response_invalid_json_raises():
+    """첫 `{` 와 마지막 `}` 사이가 valid JSON 이 아니면 json.JSONDecodeError."""
+    with pytest.raises(json.JSONDecodeError):
+        parse_judge_response("{score: bad}")
+
+
+# ── 비용 계산 ───────────────────────────────────────────────────────────
+
+
+def test_compute_judge_cost_basic():
+    # 1000 input @ $0.80/1M + 100 output @ $4.00/1M
+    cost = _compute_judge_cost(1000, 100)
+    assert cost == round(1000 * 0.0000008 + 100 * 0.000004, 6)
+
+
+def test_compute_judge_cost_zero():
+    assert _compute_judge_cost(0, 0) == 0.0
+
+
+def test_compute_judge_cost_negative_clamped():
+    """음수 입력은 0 으로 클램프 — provider quirk 방어."""
+    assert _compute_judge_cost(-100, -50) == 0.0
+
+
+# ── judge_trace ──────────────────────────────────────────────────────────
+
+
+def test_judge_trace_happy_path():
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient([_good_judge_response(score=0.9)])
+    result = asyncio.run(judge_trace(case, trace, client))
+
+    assert result.case_id == "t1"
+    assert result.score == 0.9
+    assert result.passed is True  # 0.9 >= 0.7
+    assert result.reasoning == "거의 모든 기준 충족"
+    assert result.failed_behaviors == []
+    assert result.judge_model == DEFAULT_JUDGE_MODEL
+    assert result.input_tokens == 300
+    assert result.output_tokens == 40
+    assert result.cost_usd > 0
+    assert result.error is None
+
+
+def test_judge_trace_below_threshold_marks_failed():
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient(
+        [_good_judge_response(score=0.5, failed=["한국어로 답한다"])]
+    )
+    result = asyncio.run(judge_trace(case, trace, client))
+    assert result.score == 0.5
+    assert result.passed is False
+    assert result.failed_behaviors == ["한국어로 답한다"]
+
+
+def test_judge_trace_custom_threshold():
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient([_good_judge_response(score=0.5)])
+    result = asyncio.run(
+        judge_trace(case, trace, client, pass_threshold=0.4)
+    )
+    assert result.passed is True  # 0.5 >= 0.4
+
+
+def test_judge_trace_score_clamped_high():
+    """모델이 1.2 같이 반환해도 1.0 으로 캡."""
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient([_good_judge_response(score=1.5)])
+    result = asyncio.run(judge_trace(case, trace, client))
+    assert result.score == 1.0
+
+
+def test_judge_trace_score_clamped_low():
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient([_good_judge_response(score=-0.3)])
+    result = asyncio.run(judge_trace(case, trace, client))
+    assert result.score == 0.0
+
+
+def test_judge_trace_non_numeric_score_falls_back_to_zero():
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient(
+        [
+            JudgeResponse(
+                content='{"score": "high", "reasoning": "x", "failed_behaviors": []}',
+                input_tokens=100,
+                output_tokens=10,
+            )
+        ]
+    )
+    result = asyncio.run(judge_trace(case, trace, client))
+    assert result.score == 0.0
+    assert result.passed is False
+    assert result.error is None  # 파싱은 성공, 값만 fallback
+
+
+def test_judge_trace_client_failure_recorded_as_error():
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient([], error_on_call=True)
+    result = asyncio.run(judge_trace(case, trace, client))
+    assert result.error and "judge call failed" in result.error
+    assert result.score == 0.0
+    assert result.passed is False
+    assert result.cost_usd == 0.0
+
+
+def test_judge_trace_unparseable_response_recorded_as_error():
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient(
+        [
+            JudgeResponse(
+                content="이 응답은 JSON 이 아닙니다",
+                input_tokens=200,
+                output_tokens=20,
+            )
+        ]
+    )
+    result = asyncio.run(judge_trace(case, trace, client))
+    assert result.error and "not parseable" in result.error
+    # 호출 자체는 성공했으므로 토큰/비용은 기록.
+    assert result.input_tokens == 200
+    assert result.cost_usd > 0
+
+
+def test_judge_trace_failed_behaviors_must_be_list():
+    """모델이 failed_behaviors 를 str 로 반환하면 빈 리스트로 정규화."""
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient(
+        [
+            JudgeResponse(
+                content='{"score": 0.6, "reasoning": "x", "failed_behaviors": "한국어로 답한다"}',
+                input_tokens=100,
+                output_tokens=10,
+            )
+        ]
+    )
+    result = asyncio.run(judge_trace(case, trace, client))
+    assert result.failed_behaviors == []
+
+
+def test_judge_trace_uses_custom_model():
+    case = _make_case()
+    trace = _make_trace_data()
+    client = FakeJudgeClient([_good_judge_response()])
+    result = asyncio.run(
+        judge_trace(case, trace, client, model="claude-opus-4-5")
+    )
+    assert result.judge_model == "claude-opus-4-5"
+    # 클라이언트에도 같은 model 이 전달됐는지 확인.
+    assert client.received_prompts[-1][2] == "claude-opus-4-5"
+
+
+def test_judge_trace_passes_final_response_into_prompt():
+    case = _make_case()
+    trace = _make_trace_data(response="구체적인 응답 본문")
+    client = FakeJudgeClient([_good_judge_response()])
+    asyncio.run(judge_trace(case, trace, client))
+    _, user_prompt, _ = client.received_prompts[-1]
+    assert "구체적인 응답 본문" in user_prompt
+
+
+# ── judge_run_dir ───────────────────────────────────────────────────────
+
+
+def _setup_run_dir(tmp_path: Path) -> tuple[Path, Path]:
+    """run_dir + cases_dir 준비.  trace 2개 + case YAML 2개."""
+    cases_dir = tmp_path / "cases"
+    cases_dir.mkdir()
+    (cases_dir / "alpha.yaml").write_text(
+        "task: t1\nexpected_behaviors: [b1]\n", encoding="utf-8"
+    )
+    (cases_dir / "beta.yaml").write_text(
+        "task: t2\nexpected_behaviors: [b2]\n", encoding="utf-8"
+    )
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "alpha.json").write_text(
+        json.dumps(
+            {**_make_trace_data(), "case_id": "alpha"}, ensure_ascii=False
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "beta.json").write_text(
+        json.dumps(
+            {**_make_trace_data(), "case_id": "beta"}, ensure_ascii=False
+        ),
+        encoding="utf-8",
+    )
+    # 잡파일 — 무시되어야 한다.
+    (run_dir / "_summary.json").write_text(
+        '{"x": 1}', encoding="utf-8"
+    )
+    return run_dir, cases_dir
+
+
+def test_judge_run_dir_writes_judge_json_and_updates_trace(
+    tmp_path: Path,
+):
+    run_dir, cases_dir = _setup_run_dir(tmp_path)
+    client = FakeJudgeClient(
+        [_good_judge_response(score=0.85), _good_judge_response(score=0.4)]
+    )
+
+    results = asyncio.run(
+        judge_run_dir(run_dir, cases_dir, client)
+    )
+    assert len(results) == 2
+    assert {r.case_id for r in results} == {"alpha", "beta"}
+
+    # .judge.json 파일이 생성됐는가.
+    a_judge = json.loads(
+        (run_dir / "alpha.judge.json").read_text(encoding="utf-8")
+    )
+    assert a_judge["score"] == 0.85
+    assert a_judge["passed"] is True
+
+    b_judge = json.loads(
+        (run_dir / "beta.judge.json").read_text(encoding="utf-8")
+    )
+    assert b_judge["score"] == 0.4
+    assert b_judge["passed"] is False
+
+    # trace JSON 에 judge_cost_usd 가 채워졌는가.
+    a_trace = json.loads(
+        (run_dir / "alpha.json").read_text(encoding="utf-8")
+    )
+    assert a_trace["judge_cost_usd"] > 0
+
+
+def test_judge_run_dir_skips_traces_with_missing_case_yaml(
+    tmp_path: Path,
+):
+    run_dir, cases_dir = _setup_run_dir(tmp_path)
+    # case yaml 하나 삭제.
+    (cases_dir / "alpha.yaml").unlink()
+    client = FakeJudgeClient([_good_judge_response()])
+
+    results = asyncio.run(
+        judge_run_dir(run_dir, cases_dir, client)
+    )
+    # alpha 는 건너뛰고 beta 만 채점.
+    assert len(results) == 1
+    assert results[0].case_id == "beta"
+
+
+def test_judge_run_dir_skips_summary_and_judge_files(tmp_path: Path):
+    """_summary.json 과 이미 존재하는 .judge.json 은 트레이스로 오해하지 않는다."""
+    run_dir, cases_dir = _setup_run_dir(tmp_path)
+    # 미리 alpha.judge.json 을 심어두고, 한 번 더 돌려도 무한 루프 안 된다.
+    (run_dir / "alpha.judge.json").write_text(
+        '{"case_id": "alpha", "score": 0.0, "passed": false}',
+        encoding="utf-8",
+    )
+    client = FakeJudgeClient([_good_judge_response()])
+    results = asyncio.run(
+        judge_run_dir(run_dir, cases_dir, client)
+    )
+    case_ids = [r.case_id for r in results]
+    # _summary 와 alpha.judge 는 트레이스로 인식되지 않아야 한다.
+    assert "_summary" not in case_ids
+    # alpha 의 .judge.json 파일이 두 번째 트레이스로 picked-up 안 되어야 한다.
+    # (즉 결과는 alpha, beta 둘 다 — alpha.json 은 여전히 정상 트레이스)
+    assert sorted(case_ids) == ["alpha", "beta"]
+
+
+def test_judge_run_dir_handles_judge_error_without_updating_trace_cost(
+    tmp_path: Path,
+):
+    """판정 오류가 난 케이스는 trace.json 에 judge_cost_usd 를 쓰지 않는다."""
+    run_dir, cases_dir = _setup_run_dir(tmp_path)
+    client = FakeJudgeClient([], error_on_call=True)
+    results = asyncio.run(
+        judge_run_dir(run_dir, cases_dir, client)
+    )
+    for r in results:
+        assert r.error
+    a_trace = json.loads(
+        (run_dir / "alpha.json").read_text(encoding="utf-8")
+    )
+    # 변경되지 않았어야 함.
+    assert a_trace["judge_cost_usd"] == 0.0
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+
+
+def test_parse_args_minimal():
+    ns = _parse_args(["--run-dir", "some/path"])
+    assert ns.run_dir == "some/path"
+    assert ns.cases_dir == "eval/cases"
+    assert ns.model == DEFAULT_JUDGE_MODEL
+    assert ns.pass_threshold == DEFAULT_PASS_THRESHOLD
+
+
+def test_parse_args_overrides():
+    ns = _parse_args(
+        [
+            "--run-dir",
+            "x",
+            "--cases-dir",
+            "y",
+            "--model",
+            "claude-opus-4-5",
+            "--pass-threshold",
+            "0.5",
+        ]
+    )
+    assert ns.cases_dir == "y"
+    assert ns.model == "claude-opus-4-5"
+    assert ns.pass_threshold == 0.5
+
+
+def test_parse_args_run_dir_required():
+    with pytest.raises(SystemExit):
+        _parse_args([])
+
+
+# ── FakeJudgeClient 자체 ────────────────────────────────────────────────
+
+
+def test_fake_judge_client_replays_last_when_queue_empty():
+    only = _good_judge_response()
+    client = FakeJudgeClient([only])
+    r1 = asyncio.run(client.score(system="s", user="u1", model="m"))
+    r2 = asyncio.run(client.score(system="s", user="u2", model="m"))
+    assert r1 is only and r2 is only
+
+
+def test_fake_judge_client_requires_responses_or_error_flag():
+    with pytest.raises(ValueError):
+        FakeJudgeClient([])
+    # error_on_call=True 이면 빈 큐도 OK.
+    FakeJudgeClient([], error_on_call=True)


### PR DESCRIPTION
Closes #112 — 마일스톤 [Quality Evals 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/2) 3단계.

**TL;DR**: [#111](https://github.com/devyoon91/az-cliproxy-docker/issues/111) runner 가 떨군 트레이스 위에 LLM-as-judge 를 얹어 `score`, `passed`, `reasoning`, `failed_behaviors` 를 산출. Haiku 4.5 단일 호출 / JSON 응답 강제 / 비용은 trace 에 합산.

## Why

- runner 가 트레이스만 모아도 \"통과인가\"를 자동 판정할 수단이 없으면 회귀 비교가 불가능.
- 외부 도구(LangSmith eval, OpenAI evals 등) 없이 우리 코드 안에서 같은 효과를 내는 게 마일스톤 목표.
- JSON 응답 + 임계값 기반 pass/fail 은 업계 표준 LLM-as-judge 패턴.

## 변경

| 파일 | 내용 |
|---|---|
| [eval/judge.py](eval/judge.py) | `JudgeClient` Protocol + `HTTPJudgeClient` + `FakeJudgeClient`, `judge_trace` / `judge_run_dir`, CLI |
| [eval/trace.py](eval/trace.py) | `Trace.judge_cost_usd: float = 0.0` 신규 필드 — 기존 trace JSON 와 forward-compatible |
| [tests/test_eval_judge.py](tests/test_eval_judge.py) | 32 케이스 (prompt/parse/cost/judge/run_dir/CLI/FakeClient) |

## 핵심 설계

**클라이언트 분리** ([#111](https://github.com/devyoon91/az-cliproxy-docker/issues/111) 의 AZClient 와 동일 패턴):

| 구현 | 역할 |
|---|---|
| `HTTPJudgeClient` | anthropic SDK 호출, `ANTHROPIC_API_KEY` env 사용, lazy import |
| `FakeJudgeClient` | 캔드 응답 큐 + `error_on_call` 플래그로 실패 경로 검증 |

**오류 일원화** — LLM 호출 실패도, JSON 파싱 실패도 모두 `JudgeResult.error` 로 흡수. 호출자는 한 타입만 보면 됨.

**LLM 응답 파싱** — `parse_judge_response()` 가 흔한 quirks 흡수:
- 코드 펜스 (\`\`\`json … \`\`\`)
- preamble \"Here is my evaluation: …\"
- 후행 텍스트

전략: 첫 `{` ~ 마지막 `}` 잘라 `json.loads`. 실패 시 `ValueError` → `JudgeResult.error`.

**비용 계산** — Haiku 4.5 rate ($0.80/M input, $4.00/M output) 인라인. [agent-zero/lib/pricing.py](agent-zero/lib/pricing.py) 가 canonical 소스로 주석 표기 — 가격 바뀌면 두 곳 같이 업데이트.

## 출력

```
eval/runs/<timestamp>/
├── alpha.json           ← runner 가 생성 (#111). judge_cost_usd 가 갱신됨.
├── alpha.judge.json     ← judge 가 신규 생성 (이 PR).
├── beta.json
├── beta.judge.json
└── _summary.json        ← runner summary (#111)
```

`.judge.json` 스키마:

```json
{
  "case_id": "alpha",
  "score": 0.85,
  "passed": true,
  "reasoning": "거의 모든 기준 충족",
  "failed_behaviors": [],
  "judge_model": "claude-haiku-4-5",
  "input_tokens": 300,
  "output_tokens": 40,
  "cost_usd": 0.00040,
  "error": null
}
```

## CLI

```bash
python -m eval.judge --run-dir eval/runs/20260512-093015
python -m eval.judge --run-dir <dir> --pass-threshold 0.8 --model claude-opus-4-5
```

종료 코드: 모두 passed + error 0 → 0, 그 외 → 1 ([#111](https://github.com/devyoon91/az-cliproxy-docker/issues/111) runner 와 동일 컨벤션, [#116](https://github.com/devyoon91/az-cliproxy-docker/issues/116) CI 가 체이닝).

## Verification

```
$ python -m pytest tests/test_eval_judge.py -v
============================= 32 passed in 0.15s ==============================

$ python -m pytest
============================= 292 passed in 1.21s =============================

$ python -m ruff check eval/ tests/test_eval_judge.py
All checks passed!
```

## Test plan

**프롬프트 조립** (4):
- [x] task / expected_behaviors / criteria / response 모두 포함
- [x] 빈 응답 / whitespace 만 → `(empty)` 플레이스홀더
- [x] 빈 criteria → `(none)` 플레이스홀더

**JSON 파싱** (5):
- [x] plain JSON / 코드 펜스 / preamble+trailing / malformed → `ValueError` / 유효 시작-끝이지만 invalid JSON → `JSONDecodeError`

**점수 처리** (5):
- [x] 정상 통과 (>= threshold)
- [x] 임계값 미만 → `passed=False`
- [x] custom threshold 적용
- [x] 1.5 → 1.0 / -0.3 → 0.0 클램프
- [x] non-numeric score → 0.0 fallback (error 아님)

**오류 경로** (2):
- [x] 클라이언트 raise → `error` 채움, cost 0
- [x] 파싱 실패 → `error` 채움, cost 는 기록 (호출은 성공했으므로)

**비용 / failed_behaviors / 모델 전달** (4):
- [x] Haiku rate 기반 cost 일치
- [x] 음수 토큰 클램프
- [x] failed_behaviors 가 str 면 빈 리스트로 정규화
- [x] custom model 이 클라이언트에 전달

**judge_run_dir 디스크 IO** (4):
- [x] 정상 — `.judge.json` 생성 + `trace.json.judge_cost_usd` 갱신
- [x] case yaml 누락 시 해당 케이스만 skip
- [x] `_summary.json` / `*.judge.json` 자체는 트레이스로 오인 안 함 (재실행 안전)
- [x] judge 오류 케이스는 trace 의 judge_cost_usd 갱신 안 함

**CLI / FakeJudgeClient** (5):
- [x] minimal / overrides / `--run-dir` 필수
- [x] 큐 비면 마지막 응답 반복
- [x] 빈 큐 + `error_on_call=False` 거부

## 다음

- [#113](https://github.com/devyoon91/az-cliproxy-docker/issues/113) — 기본 골든셋 10개. runner+judge 인프라가 다 갖춰졌으니 실제 케이스 작성 단계.