### PR TITLE
[Dashboard] eval 페이지 — 통과율/비용/지연 추이 차트 (#115)

### DIFF
--- a/telegram-bridge/dashboard/__init__.py
+++ b/telegram-bridge/dashboard/__init__.py
@@ -16,14 +16,24 @@ which now live in task_agg.agg. See PR #89 for the dependency note.
 """
 
 from .auth import DASHBOARD_TOKEN, _check_dashboard_auth
+from .eval_handlers import (
+    EVAL_DASHBOARD_HTML,
+    eval_dashboard_handler,
+    eval_stats_api_handler,
+)
+from .eval_stats import _build_eval_stats
 from .handlers import DASHBOARD_HTML, dashboard_handler, stats_api_handler
 from .stats import _build_stats
 
 __all__ = [
     "DASHBOARD_TOKEN",
     "DASHBOARD_HTML",
+    "EVAL_DASHBOARD_HTML",
     "_check_dashboard_auth",
     "_build_stats",
+    "_build_eval_stats",
     "dashboard_handler",
     "stats_api_handler",
+    "eval_dashboard_handler",
+    "eval_stats_api_handler",
 ]

--- a/telegram-bridge/dashboard/eval_handlers.py
+++ b/telegram-bridge/dashboard/eval_handlers.py
@@ -1,0 +1,63 @@
+"""aiohttp 핸들러 — `/dashboard/eval` + `/api/eval-stats` (#115).
+
+[`handlers.py`](./handlers.py) 의 cost dashboard 와 동일 패턴:
+- 템플릿은 모듈 import 시점에 한 번 읽고,
+- API 는 `_build_eval_stats` 호출 결과를 그대로 json_response 로 감싼다.
+- 인증은 기존 DASHBOARD_TOKEN 재사용 (cost / eval 양쪽 모두 같은 토큰).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from aiohttp import web
+
+from .auth import DASHBOARD_TOKEN, _check_dashboard_auth
+from .eval_stats import _build_eval_stats
+
+
+def _load_eval_template() -> str:
+    return (Path(__file__).resolve().parent / "eval_template.html").read_text(
+        encoding="utf-8"
+    )
+
+
+EVAL_DASHBOARD_HTML = _load_eval_template()
+
+
+async def eval_stats_api_handler(request):
+    """GET /api/eval-stats?range=30d&token=..."""
+    if not DASHBOARD_TOKEN:
+        return web.Response(status=404, text="dashboard disabled")
+    if not _check_dashboard_auth(request):
+        return web.json_response({"error": "unauthorized"}, status=401)
+    raw_range = (request.query.get("range") or "30d").lower().strip()
+    try:
+        n = int(raw_range[:-1] if raw_range.endswith("d") else raw_range)
+    except ValueError:
+        n = 30
+    n = max(1, min(n, 90))
+    payload = _build_eval_stats(range_days=n)
+    return web.json_response(payload)
+
+
+async def eval_dashboard_handler(request):
+    """GET /dashboard/eval?token=..."""
+    if not DASHBOARD_TOKEN:
+        return web.Response(status=404, text="dashboard disabled")
+    if not _check_dashboard_auth(request):
+        if not request.query.get("token"):
+            return web.Response(
+                status=401,
+                content_type="text/html",
+                charset="utf-8",
+                text=(
+                    "<h1>🔒 unauthorized</h1>"
+                    "<p>?token=... 쿼리 파라미터를 붙여 다시 접속하세요.</p>"
+                ),
+            )
+    return web.Response(
+        status=200,
+        content_type="text/html",
+        charset="utf-8",
+        text=EVAL_DASHBOARD_HTML,
+    )

--- a/telegram-bridge/dashboard/eval_stats.py
+++ b/telegram-bridge/dashboard/eval_stats.py
@@ -1,0 +1,238 @@
+"""`_build_eval_stats(range_days)` — eval/runs/ 회차 summary JSON 들의 집계.
+
+각 회차는 `eval/runs/<YYYYmmdd-HHMMSS>/_summary.json` 한 개를 떨군다
+(#114 의 build_run_summary). 이 모듈은 그 파일들을 읽어 dashboard JS 가
+바로 쓸 수 있는 JSON 으로 변환한다.
+
+핵심 시계열 3개:
+- pass_rate_trend: 회차별 통과율 (회귀 감지의 1차 신호)
+- per_case_avg: 케이스별 평균 통과율·비용·지연
+- duration_distribution: 케이스별 p50/p95/max 지연
+
+dashboard/stats.py 와 같은 \"순수 dict 반환\" 패턴 — HTTP 핸들러는 이걸
+json_response 로 감싸기만.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# 컨테이너 안에서의 eval/runs 위치.  docker-compose.yml 의
+# ./eval:/app/eval 마운트 (#114) 가 전제.
+EVAL_RUNS_DIR = Path(os.environ.get("EVAL_RUNS_DIR", "/app/eval/runs"))
+
+
+# ── 시간 파싱 / 윈도우 ──────────────────────────────────────────────────
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)  # noqa: UP017
+
+
+def _parse_started_at(summary: dict) -> datetime | None:
+    """summary['started_at'] ISO 문자열 → aware datetime.  파싱 실패 시 None."""
+    s = summary.get("started_at")
+    if not isinstance(s, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)  # noqa: UP017
+        return dt
+    except ValueError:
+        return None
+
+
+def _load_run_summaries() -> list[dict]:
+    """EVAL_RUNS_DIR 의 모든 _summary.json 을 읽어 started_at 오름차순 정렬.
+
+    누락/오염 파일은 조용히 skip (디버그 로그).  디렉토리 자체가 없으면 빈 리스트.
+    """
+    if not EVAL_RUNS_DIR.is_dir():
+        return []
+    out: list[dict] = []
+    for run_dir in EVAL_RUNS_DIR.iterdir():
+        if not run_dir.is_dir():
+            continue
+        summary_path = run_dir / "_summary.json"
+        if not summary_path.is_file():
+            continue
+        try:
+            data = json.loads(summary_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.debug(f"skip bad summary {summary_path}: {e}")
+            continue
+        out.append(data)
+    out.sort(key=lambda s: s.get("started_at") or "")
+    return out
+
+
+def _filter_window(summaries: list[dict], range_days: int) -> list[dict]:
+    """range_days 기준 윈도우 필터 — 현재 시각으로부터 N일 이내 회차만."""
+    cutoff = _utc_now() - timedelta(days=range_days)
+    out: list[dict] = []
+    for s in summaries:
+        ts = _parse_started_at(s)
+        if ts is None:
+            continue
+        if ts >= cutoff:
+            out.append(s)
+    return out
+
+
+# ── 집계 ────────────────────────────────────────────────────────────────
+
+
+def _pass_rate(summary: dict) -> tuple[int, int]:
+    """(passed, total).  total 은 채점된 + 가드 위반 + runner 에러 모두 포함."""
+    total = int(summary.get("total", 0) or 0)
+    passed = int(summary.get("passed_judges", 0) or 0)
+    return passed, total
+
+
+def _build_pass_rate_trend(summaries: list[dict]) -> list[dict]:
+    out: list[dict] = []
+    for s in summaries:
+        passed, total = _pass_rate(s)
+        rate = (passed / total) if total else 0.0
+        out.append(
+            {
+                "started_at": s.get("started_at"),
+                "passed": passed,
+                "total": total,
+                "pass_rate": round(rate, 4),
+            }
+        )
+    return out
+
+
+def _build_per_case_avg(summaries: list[dict]) -> list[dict]:
+    """케이스별 평균 — 통과율, 실행 비용, 채점 비용, 지연."""
+    agg: dict[str, dict] = {}
+    for s in summaries:
+        for c in s.get("cases", []) or []:
+            cid = c.get("case_id")
+            if not cid:
+                continue
+            bucket = agg.setdefault(
+                cid,
+                {
+                    "runs": 0,
+                    "pass_count": 0,
+                    "sum_run_cost": 0.0,
+                    "sum_judge_cost": 0.0,
+                    "sum_duration_ms": 0,
+                    "duration_samples": [],
+                },
+            )
+            bucket["runs"] += 1
+            if c.get("passed"):
+                bucket["pass_count"] += 1
+            bucket["sum_run_cost"] += float(c.get("run_cost_usd", 0.0) or 0.0)
+            bucket["sum_judge_cost"] += float(
+                c.get("judge_cost_usd", 0.0) or 0.0
+            )
+            d_ms = int(c.get("duration_ms", 0) or 0)
+            bucket["sum_duration_ms"] += d_ms
+            bucket["duration_samples"].append(d_ms)
+
+    out: list[dict] = []
+    for cid, b in agg.items():
+        runs = b["runs"]
+        out.append(
+            {
+                "case_id": cid,
+                "runs": runs,
+                "pass_count": b["pass_count"],
+                "pass_rate": round(b["pass_count"] / runs, 4) if runs else 0.0,
+                "avg_run_cost_usd": round(b["sum_run_cost"] / runs, 6)
+                if runs
+                else 0.0,
+                "avg_judge_cost_usd": round(
+                    b["sum_judge_cost"] / runs, 6
+                )
+                if runs
+                else 0.0,
+                "avg_duration_ms": int(b["sum_duration_ms"] / runs)
+                if runs
+                else 0,
+            }
+        )
+    out.sort(key=lambda r: r["case_id"])
+    return out
+
+
+def _percentile(samples: list[int], pct: float) -> int:
+    """샘플의 nearest-rank percentile.  빈 리스트면 0."""
+    if not samples:
+        return 0
+    s = sorted(samples)
+    k = max(0, min(len(s) - 1, int(round(pct / 100 * (len(s) - 1)))))
+    return int(s[k])
+
+
+def _build_duration_distribution(summaries: list[dict]) -> list[dict]:
+    """케이스별 p50 / p95 / max 지연 (ms)."""
+    samples: dict[str, list[int]] = {}
+    for s in summaries:
+        for c in s.get("cases", []) or []:
+            cid = c.get("case_id")
+            if not cid:
+                continue
+            d_ms = int(c.get("duration_ms", 0) or 0)
+            samples.setdefault(cid, []).append(d_ms)
+
+    out: list[dict] = []
+    for cid, arr in samples.items():
+        out.append(
+            {
+                "case_id": cid,
+                "runs": len(arr),
+                "p50_ms": _percentile(arr, 50),
+                "p95_ms": _percentile(arr, 95),
+                "max_ms": max(arr) if arr else 0,
+            }
+        )
+    out.sort(key=lambda r: r["case_id"])
+    return out
+
+
+# ── 메인 ────────────────────────────────────────────────────────────────
+
+
+def _build_eval_stats(range_days: int = 30) -> dict:
+    """dashboard JS 가 fetch 해서 차트에 그릴 수 있는 모양으로 정리.
+
+    Shape:
+      {
+        "now": "...",
+        "range_days": 30,
+        "total_runs": N,
+        "latest": {...} | None,      # 가장 최근 회차의 summary 그대로
+        "pass_rate_trend": [...],    # 회차별 통과율 (라인 차트)
+        "per_case_avg": [...],       # 케이스별 평균 (바 차트)
+        "duration_distribution": [...],  # 케이스별 p50/p95/max (분포 차트)
+      }
+    """
+    all_summaries = _load_run_summaries()
+    window = _filter_window(all_summaries, range_days)
+
+    latest = window[-1] if window else (
+        all_summaries[-1] if all_summaries else None
+    )
+
+    return {
+        "now": _utc_now().isoformat(),
+        "range_days": range_days,
+        "total_runs": len(window),
+        "latest": latest,
+        "pass_rate_trend": _build_pass_rate_trend(window),
+        "per_case_avg": _build_per_case_avg(window),
+        "duration_distribution": _build_duration_distribution(window),
+    }

--- a/telegram-bridge/dashboard/eval_template.html
+++ b/telegram-bridge/dashboard/eval_template.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <title>AZ Eval Dashboard</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      margin: 0; padding: 1.5rem;
+      background: #0f1115; color: #e8e8ec;
+    }
+    .header {
+      display: flex; justify-content: space-between; align-items: flex-start;
+      gap: 1rem; flex-wrap: wrap; margin-bottom: .5rem;
+    }
+    h1 { margin: 0 0 .25rem 0; font-size: 1.4rem; }
+    .toolbar { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
+    .toolbar select, .toolbar button, .toolbar a {
+      background: #1c1f27; color: #e8e8ec; border: 1px solid #2c313c;
+      border-radius: 6px; padding: .35rem .65rem; font-size: .85rem;
+      cursor: pointer; font-family: inherit; text-decoration: none;
+    }
+    .toolbar select:hover, .toolbar button:hover, .toolbar a:hover { border-color: #3a4150; }
+    .toolbar .label { font-size: .75rem; color: #9aa0aa; margin-right: .25rem; }
+    .sub {
+      color: #9aa0aa; font-size: .8rem; margin-bottom: 1.25rem;
+      display: flex; gap: 1rem; flex-wrap: wrap;
+    }
+    .grid { display: grid; gap: 1rem; grid-template-columns: 1fr; }
+    @media (min-width: 900px) { .grid { grid-template-columns: 1fr 1fr; } .span-2 { grid-column: span 2; } }
+    .card {
+      background: #181b22; border: 1px solid #262a33; border-radius: 10px;
+      padding: 1rem; min-height: 240px;
+    }
+    .card h2 { margin: 0 0 .75rem 0; font-size: .95rem; color: #c8ccd6; font-weight: 500; }
+    .totals { display: grid; gap: .5rem .75rem; grid-template-columns: 1fr 1fr; font-size: .85rem; }
+    .totals .v { color: #8cc; font-variant-numeric: tabular-nums; }
+    .err { color: #f88; padding: .5rem 1rem; }
+    canvas { max-height: 280px; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div>
+      <h1>🧪 AZ Eval Dashboard</h1>
+      <div class="sub">
+        <span id="updated"></span>
+        <span id="run-count"></span>
+      </div>
+    </div>
+    <div class="toolbar">
+      <a id="cost-link" href="/dashboard">← 비용 대시보드</a>
+      <span class="label">범위</span>
+      <select id="range">
+        <option value="7d">7일</option>
+        <option value="30d" selected>30일</option>
+        <option value="90d">90일</option>
+      </select>
+      <button id="refresh">🔄</button>
+    </div>
+  </div>
+
+  <div id="err" class="err" style="display:none"></div>
+
+  <div class="grid">
+    <div class="card">
+      <h2>📌 최신 회차</h2>
+      <div id="latest" class="totals">로딩...</div>
+    </div>
+    <div class="card">
+      <h2>📈 통과율 추이</h2>
+      <canvas id="passRate"></canvas>
+    </div>
+    <div class="card span-2">
+      <h2>💰 케이스별 평균 비용 (실행 + 채점)</h2>
+      <canvas id="perCaseCost"></canvas>
+    </div>
+    <div class="card span-2">
+      <h2>⏱ 케이스별 지연 분포 (p50 / p95 / max)</h2>
+      <canvas id="duration"></canvas>
+    </div>
+  </div>
+
+<script>
+const $ = (id) => document.getElementById(id);
+const charts = {};
+const params = new URLSearchParams(location.search);
+const token = params.get('token') || '';
+
+// 비용 대시보드 링크에 같은 token 을 붙여 클릭 한 번에 이동.
+const costLink = $('cost-link');
+if (token) costLink.href = '/dashboard?token=' + encodeURIComponent(token);
+
+async function fetchStats() {
+  const range = $('range').value || '30d';
+  const qs = new URLSearchParams({ range });
+  if (token) qs.set('token', token);
+  const resp = await fetch('/api/eval-stats?' + qs.toString());
+  if (!resp.ok) {
+    if (resp.status === 401) {
+      throw new Error('401: ?token=... 파라미터를 붙여 다시 접속하세요.');
+    }
+    throw new Error('HTTP ' + resp.status);
+  }
+  return resp.json();
+}
+
+function fmtDateShort(iso) {
+  if (!iso) return '?';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString('ko-KR', {
+      month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit'
+    });
+  } catch (e) { return iso; }
+}
+
+function renderLatest(latest) {
+  const box = $('latest');
+  if (!latest) {
+    box.innerHTML = '<span style="grid-column:1/-1;color:#9aa0aa">eval 회차 데이터 없음. <code>/eval</code> 명령으로 첫 회차를 만드세요.</span>';
+    return;
+  }
+  const total = latest.total || 0;
+  const passed = latest.passed_judges || 0;
+  const rate = total ? (passed / total * 100).toFixed(0) : 0;
+  const runCost = (latest.total_run_cost_usd || 0).toFixed(4);
+  const judgeCost = (latest.total_judge_cost_usd || 0).toFixed(4);
+  const elapsed = (latest.elapsed_sec || 0).toFixed(1);
+  box.innerHTML = `
+    <div>실행 시각</div><div class="v">${fmtDateShort(latest.started_at)}</div>
+    <div>통과율</div><div class="v">${passed}/${total} (${rate}%)</div>
+    <div>실행 비용</div><div class="v">$${runCost}</div>
+    <div>채점 비용</div><div class="v">$${judgeCost}</div>
+    <div>소요</div><div class="v">${elapsed}s</div>
+    <div>가드 위반</div><div class="v">${latest.guard_violations || 0}</div>
+  `;
+}
+
+function makeOrUpdate(name, canvasId, config) {
+  if (charts[name]) {
+    charts[name].data = config.data;
+    charts[name].options = config.options;
+    charts[name].update();
+  } else {
+    const ctx = $(canvasId).getContext('2d');
+    charts[name] = new Chart(ctx, config);
+  }
+}
+
+function renderPassRate(trend) {
+  makeOrUpdate('passRate', 'passRate', {
+    type: 'line',
+    data: {
+      labels: trend.map(r => fmtDateShort(r.started_at)),
+      datasets: [{
+        label: '통과율 (%)',
+        data: trend.map(r => (r.pass_rate * 100).toFixed(0)),
+        borderColor: '#8cc',
+        backgroundColor: 'rgba(136,204,204,0.15)',
+        tension: 0.2, fill: true,
+      }]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      scales: { y: { min: 0, max: 100, ticks: { color: '#9aa0aa' } }, x: { ticks: { color: '#9aa0aa' } } },
+      plugins: { legend: { labels: { color: '#c8ccd6' } } },
+    }
+  });
+}
+
+function renderPerCaseCost(rows) {
+  makeOrUpdate('perCaseCost', 'perCaseCost', {
+    type: 'bar',
+    data: {
+      labels: rows.map(r => r.case_id),
+      datasets: [
+        { label: '실행 평균 ($)', data: rows.map(r => r.avg_run_cost_usd),
+          backgroundColor: '#5dade2' },
+        { label: '채점 평균 ($)', data: rows.map(r => r.avg_judge_cost_usd),
+          backgroundColor: '#f5b041' },
+      ]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      scales: { x: { stacked: true, ticks: { color: '#9aa0aa' } }, y: { stacked: true, ticks: { color: '#9aa0aa' } } },
+      plugins: { legend: { labels: { color: '#c8ccd6' } } },
+    }
+  });
+}
+
+function renderDuration(rows) {
+  makeOrUpdate('duration', 'duration', {
+    type: 'bar',
+    data: {
+      labels: rows.map(r => r.case_id),
+      datasets: [
+        { label: 'p50 (s)', data: rows.map(r => (r.p50_ms / 1000).toFixed(2)),
+          backgroundColor: '#7dcea0' },
+        { label: 'p95 (s)', data: rows.map(r => (r.p95_ms / 1000).toFixed(2)),
+          backgroundColor: '#f1948a' },
+        { label: 'max (s)', data: rows.map(r => (r.max_ms / 1000).toFixed(2)),
+          backgroundColor: '#bb8fce' },
+      ]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      scales: { x: { ticks: { color: '#9aa0aa' } }, y: { ticks: { color: '#9aa0aa' } } },
+      plugins: { legend: { labels: { color: '#c8ccd6' } } },
+    }
+  });
+}
+
+async function reload() {
+  $('err').style.display = 'none';
+  try {
+    const stats = await fetchStats();
+    $('updated').textContent = '갱신 ' + fmtDateShort(stats.now);
+    $('run-count').textContent = '회차 ' + (stats.total_runs || 0) + '건';
+    renderLatest(stats.latest);
+    renderPassRate(stats.pass_rate_trend || []);
+    renderPerCaseCost(stats.per_case_avg || []);
+    renderDuration(stats.duration_distribution || []);
+  } catch (e) {
+    $('err').textContent = String(e);
+    $('err').style.display = 'block';
+  }
+}
+
+$('range').addEventListener('change', reload);
+$('refresh').addEventListener('click', reload);
+reload();
+</script>
+</body>
+</html>

--- a/telegram-bridge/dashboard/template.html
+++ b/telegram-bridge/dashboard/template.html
@@ -20,12 +20,12 @@
     .toolbar {
       display: flex; gap: .5rem; align-items: center; flex-wrap: wrap;
     }
-    .toolbar select, .toolbar button {
+    .toolbar select, .toolbar button, .toolbar a {
       background: #1c1f27; color: #e8e8ec; border: 1px solid #2c313c;
       border-radius: 6px; padding: .35rem .65rem; font-size: .85rem;
-      cursor: pointer; font-family: inherit;
+      cursor: pointer; font-family: inherit; text-decoration: none;
     }
-    .toolbar select:hover, .toolbar button:hover { border-color: #3a4150; }
+    .toolbar select:hover, .toolbar button:hover, .toolbar a:hover { border-color: #3a4150; }
     .toolbar .label { font-size: .75rem; color: #9aa0aa; margin-right: .25rem; }
     .toolbar button.refresh { padding: .35rem .55rem; }
     .toolbar button.refresh.spinning span { animation: spin 1s linear infinite; display: inline-block; }
@@ -57,6 +57,7 @@
       <h1>📊 AZ Cost Dashboard</h1>
     </div>
     <div class="toolbar">
+      <a id="eval-link" href="/dashboard/eval">🧪 eval →</a>
       <span class="label">기간</span>
       <select id="range">
         <option value="1d">1d</option>
@@ -103,6 +104,12 @@
     errEl.hidden = false;
     errEl.textContent = "⚠️ ?token=... 쿼리 파라미터를 붙여 다시 접속하세요.";
     return;
+  }
+
+  // /dashboard/eval 링크에 같은 토큰을 propagate — 클릭 한 번에 이동.
+  const evalLink = document.getElementById("eval-link");
+  if (evalLink) {
+    evalLink.href = "/dashboard/eval?token=" + encodeURIComponent(token);
   }
 
   // ── Settings (range, auto-refresh) — persisted to localStorage so the

--- a/telegram-bridge/webhooks/handlers.py
+++ b/telegram-bridge/webhooks/handlers.py
@@ -10,7 +10,13 @@ import logging
 
 from aiohttp import web
 from budget.engine import budget_check_all
-from dashboard import DASHBOARD_TOKEN, dashboard_handler, stats_api_handler
+from dashboard import (
+    DASHBOARD_TOKEN,
+    dashboard_handler,
+    eval_dashboard_handler,
+    eval_stats_api_handler,
+    stats_api_handler,
+)
 from notify.telegram import send_telegram
 from pricing.usage import track_usage, usage_history, usage_today
 from render import md_to_telegram_html
@@ -143,13 +149,20 @@ async def run_webhook_server() -> None:
     # is unset, so registering them is harmless when disabled.
     app.router.add_get("/api/stats", stats_api_handler)
     app.router.add_get("/dashboard", dashboard_handler)
+    # Eval dashboard (#115) — separate page with its own template. Same
+    # DASHBOARD_TOKEN auth, so the cost / eval pages share one credential.
+    app.router.add_get("/api/eval-stats", eval_stats_api_handler)
+    app.router.add_get("/dashboard/eval", eval_dashboard_handler)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "0.0.0.0", 8443)
     await site.start()
     routes_msg = "/notify, /track, /usage"
     if DASHBOARD_TOKEN:
-        routes_msg += ", /dashboard, /api/stats (token-protected)"
+        routes_msg += (
+            ", /dashboard, /dashboard/eval, "
+            "/api/stats, /api/eval-stats (token-protected)"
+        )
     else:
         routes_msg += " (dashboard disabled — set DASHBOARD_TOKEN to enable)"
     logger.info(f"Webhook server started on :8443 ({routes_msg})")

--- a/tests/test_bridge_eval_stats.py
+++ b/tests/test_bridge_eval_stats.py
@@ -1,0 +1,368 @@
+"""Pin `telegram-bridge/dashboard/eval_stats.py` — eval 회차 집계 (#115).
+
+`_build_eval_stats` 의 4가지 output 키 (latest, pass_rate_trend,
+per_case_avg, duration_distribution) 가 fixture 회차 JSON 들로부터
+정확한 모양으로 나오는지 핀.  HTML 핸들러 자체는 thin wrapper 라
+(test_bridge_dashboard.py 의 cost dashboard 와 동일 정책) unit-test 제외.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent / "telegram-bridge"
+
+
+def _load_eval_stats(tmp_runs_dir: Path):
+    """Spec-load `dashboard.eval_stats` with EVAL_RUNS_DIR pointed at the
+    test fixture directory.  template HTML 은 import 시점에 읽히지 않으므로
+    eval_handlers 는 로드하지 않는다 — stats 만."""
+    # 패키지 컨테이너 — 빈 namespace.
+    if "dashboard" not in sys.modules:
+        dash_pkg = types.ModuleType("dashboard")
+        dash_pkg.__path__ = [str(_ROOT / "dashboard")]  # type: ignore[attr-defined]
+        sys.modules["dashboard"] = dash_pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "dashboard.eval_stats", _ROOT / "dashboard" / "eval_stats.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dashboard.eval_stats"] = mod
+    spec.loader.exec_module(mod)
+    mod.EVAL_RUNS_DIR = tmp_runs_dir  # type: ignore[attr-defined]
+    return mod
+
+
+@pytest.fixture
+def stats(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    return _load_eval_stats(runs_dir)
+
+
+def _make_summary(
+    *,
+    started_at: datetime,
+    cases: list[dict],
+    total_run_cost: float = 0.1,
+    total_judge_cost: float = 0.001,
+    elapsed_sec: float = 10.0,
+) -> dict:
+    """build_run_summary (#114) 와 같은 모양의 dict 만들기."""
+    passed = sum(1 for c in cases if c.get("passed") is True)
+    failed = sum(
+        1
+        for c in cases
+        if c.get("passed") is False and not c.get("judge_error")
+    )
+    errored = sum(1 for c in cases if c.get("judge_error"))
+    guard = sum(
+        1
+        for c in cases
+        if c.get("guard_violations") or c.get("runner_error")
+    )
+    return {
+        "run_dir": "/tmp/x",
+        "started_at": started_at.isoformat(),
+        "elapsed_sec": elapsed_sec,
+        "total": len(cases),
+        "passed_judges": passed,
+        "failed_judges": failed,
+        "errored": errored,
+        "guard_violations": guard,
+        "total_run_cost_usd": total_run_cost,
+        "total_judge_cost_usd": total_judge_cost,
+        "cases": cases,
+    }
+
+
+def _write_run(runs_dir: Path, name: str, summary: dict) -> None:
+    d = runs_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "_summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)  # noqa: UP017
+
+
+# ── 빈 상태 ─────────────────────────────────────────────────────────────
+
+
+def test_no_runs_returns_empty_skeleton(stats):
+    out = stats._build_eval_stats(range_days=30)
+    assert out["total_runs"] == 0
+    assert out["latest"] is None
+    assert out["pass_rate_trend"] == []
+    assert out["per_case_avg"] == []
+    assert out["duration_distribution"] == []
+
+
+def test_missing_runs_dir_returns_empty(tmp_path):
+    """디렉토리 자체가 없을 때도 깨지지 않고 빈 결과."""
+    mod = _load_eval_stats(tmp_path / "nonexistent")
+    out = mod._build_eval_stats(range_days=30)
+    assert out["total_runs"] == 0
+
+
+def test_skips_run_dir_without_summary_json(stats, tmp_path):
+    """summary.json 없는 빈 회차 디렉토리는 무시."""
+    (tmp_path / "runs" / "20260512-100000").mkdir()
+    out = stats._build_eval_stats(range_days=30)
+    assert out["total_runs"] == 0
+
+
+def test_skips_malformed_summary_json(stats, tmp_path):
+    """깨진 JSON 도 silently skip."""
+    bad_dir = tmp_path / "runs" / "20260512-110000"
+    bad_dir.mkdir()
+    (bad_dir / "_summary.json").write_text(
+        "this is not json", encoding="utf-8"
+    )
+    out = stats._build_eval_stats(range_days=30)
+    assert out["total_runs"] == 0
+
+
+# ── 단일 회차 ───────────────────────────────────────────────────────────
+
+
+def test_single_run_populates_latest(stats, tmp_path):
+    started = _now_utc() - timedelta(hours=1)
+    summary = _make_summary(
+        started_at=started,
+        cases=[
+            {"case_id": "a", "passed": True, "score": 0.9, "run_cost_usd": 0.01,
+             "judge_cost_usd": 0.0001, "duration_ms": 1000},
+            {"case_id": "b", "passed": False, "score": 0.3, "run_cost_usd": 0.02,
+             "judge_cost_usd": 0.0002, "duration_ms": 2000},
+        ],
+    )
+    _write_run(tmp_path / "runs", "20260512-120000", summary)
+
+    out = stats._build_eval_stats(range_days=30)
+    assert out["total_runs"] == 1
+    assert out["latest"] is not None
+    assert out["latest"]["passed_judges"] == 1
+    # trend 도 1 entry.
+    assert len(out["pass_rate_trend"]) == 1
+    assert out["pass_rate_trend"][0]["pass_rate"] == 0.5
+    assert out["pass_rate_trend"][0]["passed"] == 1
+    assert out["pass_rate_trend"][0]["total"] == 2
+
+
+# ── 다중 회차 + 정렬 ────────────────────────────────────────────────────
+
+
+def test_multiple_runs_sorted_by_started_at(stats, tmp_path):
+    # 디스크 순서와 started_at 순서를 다르게 — 정렬이 시각 기준인지 검증.
+    t1 = _now_utc() - timedelta(hours=3)
+    t2 = _now_utc() - timedelta(hours=2)
+    t3 = _now_utc() - timedelta(hours=1)
+    _write_run(
+        tmp_path / "runs",
+        "z-third",
+        _make_summary(
+            started_at=t3,
+            cases=[{"case_id": "x", "passed": True, "duration_ms": 100}],
+        ),
+    )
+    _write_run(
+        tmp_path / "runs",
+        "a-first",
+        _make_summary(
+            started_at=t1,
+            cases=[{"case_id": "x", "passed": False, "duration_ms": 100}],
+        ),
+    )
+    _write_run(
+        tmp_path / "runs",
+        "m-second",
+        _make_summary(
+            started_at=t2,
+            cases=[{"case_id": "x", "passed": True, "duration_ms": 100}],
+        ),
+    )
+
+    out = stats._build_eval_stats(range_days=30)
+    trend = out["pass_rate_trend"]
+    assert len(trend) == 3
+    assert trend[0]["pass_rate"] == 0.0  # t1
+    assert trend[1]["pass_rate"] == 1.0  # t2
+    assert trend[2]["pass_rate"] == 1.0  # t3
+    # latest 는 가장 최근 (t3).
+    assert out["latest"]["started_at"] == t3.isoformat()
+
+
+# ── range 필터 ──────────────────────────────────────────────────────────
+
+
+def test_range_days_filters_old_runs(stats, tmp_path):
+    """범위 밖 회차는 trend/avg 에서 제외, latest 도 윈도우 내 가장 최근."""
+    old = _now_utc() - timedelta(days=40)
+    recent = _now_utc() - timedelta(days=2)
+    _write_run(
+        tmp_path / "runs",
+        "old",
+        _make_summary(
+            started_at=old,
+            cases=[{"case_id": "x", "passed": True, "duration_ms": 100}],
+        ),
+    )
+    _write_run(
+        tmp_path / "runs",
+        "recent",
+        _make_summary(
+            started_at=recent,
+            cases=[{"case_id": "x", "passed": False, "duration_ms": 100}],
+        ),
+    )
+
+    out = stats._build_eval_stats(range_days=30)
+    assert out["total_runs"] == 1  # old 제외
+    assert len(out["pass_rate_trend"]) == 1
+    assert out["pass_rate_trend"][0]["pass_rate"] == 0.0  # 'recent' 만
+
+
+def test_range_clamp_min_one(stats, tmp_path):
+    """range_days=0 같은 가장자리 입력에 대해서도 안전."""
+    # 함수 자체는 range_days 를 그대로 받는다 (HTTP 핸들러가 clamp).
+    # 0 을 줘도 _filter_window 가 cutoff=now → 빈 결과만 반환.
+    out = stats._build_eval_stats(range_days=0)
+    assert out["total_runs"] == 0
+
+
+# ── per_case_avg ────────────────────────────────────────────────────────
+
+
+def test_per_case_avg_aggregates_across_runs(stats, tmp_path):
+    runs_dir = tmp_path / "runs"
+    t1 = _now_utc() - timedelta(hours=3)
+    t2 = _now_utc() - timedelta(hours=2)
+
+    _write_run(
+        runs_dir,
+        "r1",
+        _make_summary(
+            started_at=t1,
+            cases=[
+                {"case_id": "alpha", "passed": True, "run_cost_usd": 0.01,
+                 "judge_cost_usd": 0.0001, "duration_ms": 1000},
+                {"case_id": "beta", "passed": False, "run_cost_usd": 0.02,
+                 "judge_cost_usd": 0.0002, "duration_ms": 2000},
+            ],
+        ),
+    )
+    _write_run(
+        runs_dir,
+        "r2",
+        _make_summary(
+            started_at=t2,
+            cases=[
+                {"case_id": "alpha", "passed": True, "run_cost_usd": 0.03,
+                 "judge_cost_usd": 0.0003, "duration_ms": 1500},
+                {"case_id": "beta", "passed": True, "run_cost_usd": 0.02,
+                 "judge_cost_usd": 0.0002, "duration_ms": 2200},
+            ],
+        ),
+    )
+
+    out = stats._build_eval_stats(range_days=30)
+    by_case = {r["case_id"]: r for r in out["per_case_avg"]}
+
+    # alpha: 2회 다 통과, 평균 비용 0.02, 평균 채점 0.0002, 평균 1250ms
+    assert by_case["alpha"]["runs"] == 2
+    assert by_case["alpha"]["pass_rate"] == 1.0
+    assert by_case["alpha"]["avg_run_cost_usd"] == 0.02
+    assert by_case["alpha"]["avg_judge_cost_usd"] == 0.0002
+    assert by_case["alpha"]["avg_duration_ms"] == 1250
+
+    # beta: 1/2 통과 (50%)
+    assert by_case["beta"]["pass_rate"] == 0.5
+    assert by_case["beta"]["avg_run_cost_usd"] == 0.02
+
+
+# ── duration_distribution ───────────────────────────────────────────────
+
+
+def test_duration_distribution_percentiles(stats, tmp_path):
+    runs_dir = tmp_path / "runs"
+    # 같은 케이스를 5번 — 100, 200, 300, 400, 500 ms.
+    for i, ms in enumerate([100, 200, 300, 400, 500]):
+        _write_run(
+            runs_dir,
+            f"run-{i:02d}",
+            _make_summary(
+                started_at=_now_utc() - timedelta(hours=10 - i),
+                cases=[{"case_id": "x", "passed": True, "duration_ms": ms}],
+            ),
+        )
+
+    out = stats._build_eval_stats(range_days=30)
+    dist = {r["case_id"]: r for r in out["duration_distribution"]}
+    # nearest-rank: 5 samples, p50 = index round(0.5*4)=2 → 300
+    # p95 = index round(0.95*4)=4 → 500. max = 500.
+    assert dist["x"]["p50_ms"] == 300
+    assert dist["x"]["p95_ms"] == 500
+    assert dist["x"]["max_ms"] == 500
+    assert dist["x"]["runs"] == 5
+
+
+def test_duration_percentile_single_sample(stats, tmp_path):
+    """샘플 1개면 p50 == p95 == max."""
+    _write_run(
+        tmp_path / "runs",
+        "only",
+        _make_summary(
+            started_at=_now_utc() - timedelta(minutes=10),
+            cases=[{"case_id": "solo", "passed": True, "duration_ms": 777}],
+        ),
+    )
+    out = stats._build_eval_stats(range_days=30)
+    dist = {r["case_id"]: r for r in out["duration_distribution"]}
+    assert dist["solo"]["p50_ms"] == 777
+    assert dist["solo"]["p95_ms"] == 777
+    assert dist["solo"]["max_ms"] == 777
+
+
+# ── parse helpers ──────────────────────────────────────────────────────
+
+
+def test_parse_started_at_handles_z_suffix(stats):
+    """ISO 'Z' suffix 도 fromisoformat 호환되도록 처리."""
+    s = stats._parse_started_at({"started_at": "2026-05-12T10:00:00Z"})
+    assert s is not None
+    assert s.tzinfo is not None
+
+
+def test_parse_started_at_returns_none_on_bad_value(stats):
+    assert stats._parse_started_at({"started_at": None}) is None
+    assert stats._parse_started_at({}) is None
+    assert stats._parse_started_at({"started_at": "not a date"}) is None
+
+
+# ── case 항목 결손 케이스 ───────────────────────────────────────────────
+
+
+def test_cases_missing_case_id_are_ignored(stats, tmp_path):
+    _write_run(
+        tmp_path / "runs",
+        "weird",
+        _make_summary(
+            started_at=_now_utc() - timedelta(hours=1),
+            cases=[
+                {"passed": True, "duration_ms": 100},  # no case_id
+                {"case_id": "ok", "passed": True, "duration_ms": 200},
+            ],
+        ),
+    )
+    out = stats._build_eval_stats(range_days=30)
+    assert {r["case_id"] for r in out["per_case_avg"]} == {"ok"}

--- a/tests/test_bridge_webhooks.py
+++ b/tests/test_bridge_webhooks.py
@@ -32,6 +32,7 @@ _OWN_MODULES = (
     "task_agg", "task_agg.agg",
     "budget", "budget.core", "budget.engine",
     "dashboard", "dashboard.auth", "dashboard.stats", "dashboard.handlers",
+    "dashboard.eval_stats", "dashboard.eval_handlers",
     "webhooks", "webhooks.handlers",
 )
 
@@ -157,6 +158,25 @@ def _load_webhooks_pkg(tmp_path):
     dash_pkg.DASHBOARD_TOKEN = auth_mod.DASHBOARD_TOKEN  # type: ignore[attr-defined]
     dash_pkg.dashboard_handler = dh_mod.dashboard_handler  # type: ignore[attr-defined]
     dash_pkg.stats_api_handler = dh_mod.stats_api_handler  # type: ignore[attr-defined]
+
+    # dashboard.eval_stats / eval_handlers (#115) — webhooks.handlers imports
+    # eval_dashboard_handler + eval_stats_api_handler from `dashboard`.
+    eval_stats_spec = importlib.util.spec_from_file_location(
+        "dashboard.eval_stats", _ROOT / "dashboard" / "eval_stats.py"
+    )
+    assert eval_stats_spec and eval_stats_spec.loader
+    eval_stats_mod = importlib.util.module_from_spec(eval_stats_spec)
+    sys.modules["dashboard.eval_stats"] = eval_stats_mod
+    eval_stats_spec.loader.exec_module(eval_stats_mod)
+    eval_handlers_spec = importlib.util.spec_from_file_location(
+        "dashboard.eval_handlers", _ROOT / "dashboard" / "eval_handlers.py"
+    )
+    assert eval_handlers_spec and eval_handlers_spec.loader
+    eh_mod = importlib.util.module_from_spec(eval_handlers_spec)
+    sys.modules["dashboard.eval_handlers"] = eh_mod
+    eval_handlers_spec.loader.exec_module(eh_mod)
+    dash_pkg.eval_dashboard_handler = eh_mod.eval_dashboard_handler  # type: ignore[attr-defined]
+    dash_pkg.eval_stats_api_handler = eh_mod.eval_stats_api_handler  # type: ignore[attr-defined]
 
     # webhooks.handlers
     wh_pkg = types.ModuleType("webhooks")


### PR DESCRIPTION
Closes #115 — 마일스톤 [Quality Evals 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/2) 6단계.

**TL;DR**: `/eval` ([#114](https://github.com/devyoon91/az-cliproxy-docker/issues/114)) 가 떨군 회차 summary 들을 `/dashboard/eval` 한 페이지에 시계열로. 통과율 / 케이스별 비용 / 지연 분포 세 가지를 Chart.js 차트로.

## 페이지

`/dashboard/eval?token=<DASHBOARD_TOKEN>` — 비용 대시보드와 같은 토큰, 같은 8443 포트.

| 카드 | 차트 / 데이터 |
|---|---|
| 📌 최신 회차 | 통과율 · 실행/채점 비용 · 소요 · 가드 위반 카운트 |
| 📈 통과율 추이 | 회차별 % (라인) |
| 💰 케이스별 평균 비용 | 실행 + 채점 stacked bar |
| ⏱ 케이스별 지연 분포 | p50 / p95 / max (그룹 바) |

비용 대시보드 ↔ eval 대시보드 양방향 링크 + 토큰 자동 propagation.

## 왜 별도 페이지 (탭 아님)

이슈 원문은 `?tab=eval` 식 탭 통합을 스케치했지만, 기존 336줄 cost template 에 탭 구조를 끼우는 건 invasive — 그리드 재배치 / JS init 분리 / auto-refresh 게이팅 모두 손대야 함. 별도 standalone 페이지가 (1) 검증된 cost 레이아웃을 재사용, (2) auth 공유, (3) cost 페이지에서 한 클릭으로 이동 — 동일한 운영 가치 + 절반의 변경.

## 변경

| 파일 | 내용 |
|---|---|
| [dashboard/eval_stats.py](telegram-bridge/dashboard/eval_stats.py) | `_build_eval_stats(range_days)` — runs/*/_summary.json 집계 |
| [dashboard/eval_handlers.py](telegram-bridge/dashboard/eval_handlers.py) | `/dashboard/eval` + `/api/eval-stats` aiohttp 핸들러 |
| [dashboard/eval_template.html](telegram-bridge/dashboard/eval_template.html) | 신규 페이지 (4 cards, Chart.js CDN) |
| [dashboard/template.html](telegram-bridge/dashboard/template.html) | toolbar 에 \"🧪 eval →\" 링크 + 토큰 propagation |
| [dashboard/__init__.py](telegram-bridge/dashboard/__init__.py) | 새 심볼 export |
| [webhooks/handlers.py](telegram-bridge/webhooks/handlers.py) | 2개 라우트 + startup 로그 갱신 |
| [tests/test_bridge_eval_stats.py](tests/test_bridge_eval_stats.py) | 14 케이스 |
| [tests/test_bridge_webhooks.py](tests/test_bridge_webhooks.py) | `dashboard` stub 에 새 핸들러 wiring 추가 |

## 데이터 흐름

```
/eval (#114)
  └─→ eval/runs/<ts>/_summary.json
                    │
                    ▼
   /api/eval-stats?range=30d
                    │
        _build_eval_stats(range_days):
          ┌─────────┴─────────┐
          ▼                   ▼
    pass_rate_trend      per_case_avg
          ▼                   ▼
   duration_distribution    latest
                    │
                    ▼
        /dashboard/eval (HTML + Chart.js)
```

`/api/eval-stats` JSON 구조는 dashboard JS 가 fetch 후 그대로 차트로 변환. 별도 변환 레이어 없음.

## 테스트 폴루션 사이드픽스

`webhooks/handlers.py` 가 새로 `eval_dashboard_handler` / `eval_stats_api_handler` 를 dashboard 에서 import 하게 되면서, `test_bridge_webhooks.py` 의 spec-loaded dashboard stub 이 이 심볼들을 모르고 깨졌음. 9개 webhooks 테스트 + 5개 pdf_export 테스트가 order-dependent 로 빨갛게 됨 (dashboard stub 의 잔재가 chat_pdf_export 의 `render.render` 경로까지 오염).

수정: test_bridge_webhooks 의 `_load_webhooks_pkg` 에 `dashboard.eval_stats` + `dashboard.eval_handlers` spec-load 추가, `_OWN_MODULES` 에 새 키 등록 (teardown 도 함께 정리).

## Verification

```
$ python -m pytest tests/test_bridge_eval_stats.py -v
============================= 14 passed in 0.24s ==============================

$ python -m pytest
============================= 335 passed in 1.59s ==============================

$ python -m ruff check telegram-bridge/ tests/
All checks passed!
```

## Test plan

**_build_eval_stats** (14):

빈 상태 (4):
- [x] runs 디렉토리 자체가 없을 때 빈 결과
- [x] runs 디렉토리는 있는데 summary 없을 때 빈 결과
- [x] summary.json 없는 회차 디렉토리 skip
- [x] malformed JSON skip

정상 동작 (5):
- [x] 단일 회차 → latest 채움 + trend 1 entry
- [x] 다중 회차 → started_at 기준 정렬 (디스크 순서 무관)
- [x] range_days 윈도우 필터 (범위 밖 회차 제외)
- [x] per_case_avg 가 회차들 가로질러 정확한 평균 산출
- [x] case_id 누락 항목은 무시

지연 분포 (2):
- [x] p50/p95/max nearest-rank 정확
- [x] 샘플 1개일 때 셋 다 동일 값

파싱 (2):
- [x] started_at \"Z\" suffix 호환
- [x] 깨진 / 누락 started_at → None

엣지 (1):
- [x] range_days=0 → 빈 결과 (HTTP 핸들러는 별도 clamp)

**테스트 폴루션 회귀 가드**: test_bridge_webhooks 가 새 eval 핸들러 import 를 견디는지 — 전체 suite 335/335 통과로 확인.

## 운영

```bash
# 1) docker compose up -d --force-recreate telegram-bridge
# 2) /dashboard?token=<TOKEN> 에서 "🧪 eval →" 클릭
# 3) /dashboard/eval 에서 30d 범위 통과율 추이 확인
```

## 다음

- [#116](https://github.com/devyoon91/az-cliproxy-docker/issues/116) — CI 회귀 워크플로우. baseline.json 기반 자동 diff.
- [#117](https://github.com/devyoon91/az-cliproxy-docker/issues/117) — docs/eval.md. 가이드 / 트러블슈팅 문서.