### PR TITLE
[CI] eval 회귀 워크플로우 + baseline 비교 (#116)

### DIFF
--- a/.github/scripts/eval_compare.py
+++ b/.github/scripts/eval_compare.py
@@ -1,0 +1,229 @@
+"""Diff one eval-run summary against `eval/baseline.json` and write a
+markdown report.  CI 워크플로우(#116) 가 호출하는 stand-alone CLI.
+
+비교 대상:
+- 통과율 (pass rate, primary gate — threshold_pp 만큼 떨어지면 회귀)
+- 총 비용 (실행 + 채점, 변동률만 보고)
+- 케이스별 pass 상태 변화 (newly_failing / newly_passing)
+
+baseline 이 없는 경우(첫 main 머지 등) 는 정상 동료로 처리 — 빈 비교 리포트
+출력 후 exit 0.  그래서 baseline.json 이 없는 새 저장소에서도 워크플로우가
+지속적 실패하지 않는다.
+
+stdlib only — 같은 Python 으로 별도 의존성 설치 없이 동작한다.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _pass_rate(summary: dict[str, Any]) -> float:
+    total = int(summary.get("total", 0) or 0)
+    passed = int(summary.get("passed_judges", 0) or 0)
+    return (passed / total) if total else 0.0
+
+
+def _total_cost(summary: dict[str, Any]) -> float:
+    return float(
+        (summary.get("total_run_cost_usd", 0.0) or 0.0)
+        + (summary.get("total_judge_cost_usd", 0.0) or 0.0)
+    )
+
+
+def compare(
+    current: dict[str, Any],
+    baseline: dict[str, Any],
+    threshold_pp: float,
+) -> dict[str, Any]:
+    """비교 결과를 dict 로 반환.
+
+    `verdict` 가 "regression" 이면 호출자가 exit 1 처리, "ok" 면 통과.
+    `delta_pp` 가 음수이면 통과율 하락 — 그 절대값이 `threshold_pp` 보다
+    크면 회귀로 본다 (예: threshold_pp=10, delta_pp=-12 → 회귀).
+    """
+    cur_rate = _pass_rate(current)
+    base_rate = _pass_rate(baseline)
+    delta_pp = (cur_rate - base_rate) * 100
+
+    cur_cost = _total_cost(current)
+    base_cost = _total_cost(baseline)
+    cost_delta_pct = (
+        ((cur_cost - base_cost) / base_cost * 100) if base_cost else 0.0
+    )
+
+    cur_cases = {
+        c["case_id"]: c for c in current.get("cases", []) or [] if c.get("case_id")
+    }
+    base_cases = {
+        c["case_id"]: c
+        for c in baseline.get("cases", []) or []
+        if c.get("case_id")
+    }
+    newly_failing: list[str] = []
+    newly_passing: list[str] = []
+    for cid in cur_cases.keys() | base_cases.keys():
+        cur_p = bool(cur_cases.get(cid, {}).get("passed"))
+        base_p = bool(base_cases.get(cid, {}).get("passed"))
+        if base_p and not cur_p:
+            newly_failing.append(cid)
+        elif not base_p and cur_p:
+            newly_passing.append(cid)
+
+    is_regression = delta_pp < -threshold_pp
+
+    return {
+        "verdict": "regression" if is_regression else "ok",
+        "current": {
+            "pass_rate": round(cur_rate, 4),
+            "total": current.get("total", 0),
+            "passed_judges": current.get("passed_judges", 0),
+            "total_cost_usd": round(cur_cost, 6),
+        },
+        "baseline": {
+            "pass_rate": round(base_rate, 4),
+            "total": baseline.get("total", 0),
+            "passed_judges": baseline.get("passed_judges", 0),
+            "total_cost_usd": round(base_cost, 6),
+        },
+        "delta_pp": round(delta_pp, 2),
+        "cost_delta_pct": round(cost_delta_pct, 2),
+        "threshold_pp": threshold_pp,
+        "newly_failing": sorted(newly_failing),
+        "newly_passing": sorted(newly_passing),
+    }
+
+
+def format_markdown(result: dict[str, Any]) -> str:
+    """비교 결과를 PR comment / job summary 용 마크다운으로."""
+    icon = "❌" if result["verdict"] == "regression" else "✅"
+    title = (
+        "Eval Regression Detected"
+        if result["verdict"] == "regression"
+        else "Eval OK"
+    )
+    cur = result["current"]
+    base = result["baseline"]
+
+    lines = [
+        f"## {icon} {title}",
+        "",
+        "| | baseline | current | delta |",
+        "|---|---|---|---|",
+        (
+            f"| 통과율 | {base['pass_rate'] * 100:.0f}% "
+            f"({base['passed_judges']}/{base['total']}) | "
+            f"{cur['pass_rate'] * 100:.0f}% "
+            f"({cur['passed_judges']}/{cur['total']}) | "
+            f"{result['delta_pp']:+.1f}pp |"
+        ),
+        (
+            f"| 총 비용 | ${base['total_cost_usd']:.4f} | "
+            f"${cur['total_cost_usd']:.4f} | "
+            f"{result['cost_delta_pct']:+.1f}% |"
+        ),
+        "",
+        f"임계값: 통과율 -{result['threshold_pp']}pp 이상 하락 시 회귀.",
+    ]
+    if result["newly_failing"]:
+        lines.append("")
+        lines.append("### 🔴 새로 실패한 케이스")
+        for cid in result["newly_failing"]:
+            lines.append(f"- `{cid}`")
+    if result["newly_passing"]:
+        lines.append("")
+        lines.append("### 🟢 새로 통과한 케이스")
+        for cid in result["newly_passing"]:
+            lines.append(f"- `{cid}`")
+    return "\n".join(lines)
+
+
+def format_no_baseline_markdown() -> str:
+    """baseline.json 이 없을 때의 placeholder 리포트."""
+    return (
+        "## ℹ️ Eval Report (no baseline)\n\n"
+        "`eval/baseline.json` 이 없어 회귀 비교를 건너뜁니다. "
+        "Telegram `/eval baseline` 명령으로 기준선을 한 번 기록 후 "
+        "다시 워크플로우를 돌리면 비교가 활성화됩니다."
+    )
+
+
+def _load_summary(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_current_path(args: argparse.Namespace) -> Path:
+    if args.current:
+        return Path(args.current)
+    if args.run_dir:
+        return Path(args.run_dir) / "_summary.json"
+    raise SystemExit("error: --run-dir 또는 --current 중 하나 필수")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="eval_compare",
+        description="Compare an eval run to baseline; output markdown report.",
+    )
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument(
+        "--run-dir",
+        help="회차 디렉토리 (안에서 _summary.json 을 읽음)",
+    )
+    g.add_argument(
+        "--current",
+        help="현재 summary JSON 직접 경로 (run-dir 와 택1)",
+    )
+    p.add_argument(
+        "--baseline",
+        default="eval/baseline.json",
+        help="기준선 JSON 경로 (기본 eval/baseline.json)",
+    )
+    p.add_argument(
+        "--threshold-pp",
+        type=float,
+        default=10.0,
+        help="통과율 회귀 임계값 (percentage points, 기본 10)",
+    )
+    p.add_argument(
+        "--output",
+        help="결과 markdown 저장 경로 (없으면 stdout)",
+    )
+    args = p.parse_args(argv if argv is not None else sys.argv[1:])
+
+    current_path = _resolve_current_path(args)
+    if not current_path.is_file():
+        print(
+            f"error: current summary not found: {current_path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    baseline_path = Path(args.baseline)
+    if not baseline_path.is_file():
+        md = format_no_baseline_markdown()
+        if args.output:
+            Path(args.output).write_text(md, encoding="utf-8")
+        else:
+            print(md)
+        return 0  # 첫 회차/baseline 없음은 워크플로우 실패가 아님
+
+    current = _load_summary(current_path)
+    baseline = _load_summary(baseline_path)
+
+    result = compare(current, baseline, args.threshold_pp)
+    md = format_markdown(result)
+
+    if args.output:
+        Path(args.output).write_text(md, encoding="utf-8")
+    else:
+        print(md)
+
+    return 1 if result["verdict"] == "regression" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,198 @@
+name: Eval Regression
+
+# 골든셋 회귀 자동 감지 워크플로우 (#116).
+#
+# 트리거:
+#   - workflow_dispatch: 수동 실행 (기본/안전 경로 — 첫 검증용)
+#   - push to main: 메인 머지 직후 회귀 감지
+#   - pull_request labeled 'eval-required': 일부 PR 에서 옵트인
+#
+# 필수 secret:
+#   ANTHROPIC_API_KEY  — runner(메인 응답) + judge(채점) 모두 Anthropic
+#                        API 키 사용.  CLIProxy 트랙은 CI 에 적합하지
+#                        않아 (OAuth 토큰 필요) Direct API 만 지원.
+#
+# 비용 추정:
+#   골든셋 10개 케이스 풀 실행 = ~$0.50 (Sonnet 4.6 + Haiku 4.5 채점).
+#   메인 머지마다 트리거되므로 머지 빈도 × $0.50 = 월간 비용.
+
+on:
+  workflow_dispatch:
+    inputs:
+      threshold_pp:
+        description: "통과율 회귀 임계값 (percentage points)"
+        default: "10"
+        required: true
+
+  push:
+    branches: [main]
+    # 워크플로우 자체 또는 평가 인프라 변경에만 트리거.  cases/ 변경은
+    # baseline 갱신을 동반해야 하므로 트리거 — 그 외 무관한 파일 푸시로
+    # 비용을 발생시키지 않게 path 필터.
+    paths:
+      - "eval/**"
+      - ".github/scripts/eval_compare.py"
+      - ".github/workflows/eval.yml"
+      - "agent-zero/prompts/**"
+      - "agent-zero/settings.example.json"
+
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+
+jobs:
+  eval:
+    name: Run + Judge + Compare
+    # PR 트리거의 경우 'eval-required' 라벨이 있어야만 실행.
+    # 모든 PR 에 비용을 부담시키지 않기 위한 옵트인 게이트.
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'eval-required')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: write   # PR 코멘트용
+
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify ANTHROPIC_API_KEY secret
+        # Empty/unset secret 은 GitHub Actions 가 ANTHROPIC_API_KEY="" 로
+        # 평가해 buildArgs 단계 통과 후 런타임에 cryptic 401 로 떨어진다.
+        # 여기서 일찍 끊어서 \"왜 실패했지\" 디버깅 비용 절감.
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY}" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret 미설정. Settings → Secrets → Actions 에 추가하세요."
+            exit 1
+          fi
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          # runner: pyyaml(schema), aiohttp(AZ HTTP).  judge: anthropic SDK.
+          # 버전은 telegram-bridge/Dockerfile (#114) 과 일치 — drift 시
+          # 두 파일 모두 업데이트.
+          pip install pyyaml==6.0.2 aiohttp==3.10.* anthropic==0.40.*
+
+      - name: Prepare AZ minimal config
+        # CI 에서는 Direct API 트랙(Anthropic) 만 사용 — CLIProxy 컨테이너는
+        # 띄우지 않는다.  AZ settings.example.json 이 이미 anthropic provider
+        # 기본값을 가지므로 그대로 복사.
+        run: |
+          mkdir -p agent-zero/logs/tasks agent-zero/work_dir agent-zero/memory
+          cp agent-zero/settings.example.json agent-zero/settings.json
+          cat > .env <<EOF
+          ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+          BRANCH=main
+          GIT_USER_NAME=ci
+          GIT_USER_EMAIL=ci@github.local
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          DASHBOARD_TOKEN=
+          EOF
+
+      - name: Boot Agent Zero (no cliproxy)
+        # `--no-deps` 로 cliproxy 의존성 skip.  `--build` 로 image 빌드 (3-5분
+        # 소요).  포트 50001 매핑이 docker-compose.yml 에 이미 있어서 host 에서
+        # localhost:50001 로 접근 가능.
+        run: |
+          docker compose up -d --no-deps --build agent-zero
+          # 헬스체크 — / 가 200 응답 (AZ UI) 할 때까지 최대 5분.
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null -m 3 http://localhost:50001/; then
+              echo "Agent Zero ready ($i*5s)"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Agent Zero 5분 안에 ready 안 됨"
+          docker compose logs agent-zero | tail -100
+          exit 1
+
+      - name: Run eval (all cases)
+        env:
+          AZ_API_URL: "http://localhost:50001"
+          EVAL_TASKS_DIR: ${{ github.workspace }}/agent-zero/logs/tasks
+          EVAL_LOG_LEVEL: INFO
+        run: |
+          python -m eval.runner --all
+          # 회차 디렉토리는 eval/runs/<timestamp>/ 형태 — 가장 최근 것을
+          # GITHUB_ENV 로 다음 step 에 전달.
+          RUN_DIR=$(ls -dt eval/runs/*/ | head -1)
+          echo "RUN_DIR=${RUN_DIR%/}" >> "$GITHUB_ENV"
+          echo "Run directory: ${RUN_DIR%/}"
+
+      - name: Judge run
+        run: |
+          python -m eval.judge --run-dir "$RUN_DIR" --cases-dir eval/cases
+
+      - name: Compare to baseline
+        id: compare
+        # exit 0 = OK / no baseline, 1 = regression, 2 = error.
+        # `continue-on-error` 로 step 자체는 항상 통과시키고, 다음 단계에서
+        # comparison-result 를 보고 최종 job 결과를 결정.
+        continue-on-error: true
+        run: |
+          THRESHOLD="${{ inputs.threshold_pp || '10' }}"
+          python .github/scripts/eval_compare.py \
+            --run-dir "$RUN_DIR" \
+            --baseline eval/baseline.json \
+            --threshold-pp "$THRESHOLD" \
+            --output eval-report.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Append to job summary
+        if: always()
+        run: |
+          if [ -f eval-report.md ]; then
+            cat eval-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-run-${{ github.run_id }}
+          path: |
+            eval/runs/
+            eval-report.md
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Comment on PR
+        # 라벨로 트리거된 PR 일 때만 코멘트.
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('eval-report.md')) return;
+            const body = fs.readFileSync('eval-report.md', 'utf8');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });
+
+      - name: AZ logs on failure
+        if: failure()
+        run: docker compose logs agent-zero | tail -200
+
+      - name: Enforce regression gate
+        # compare step 의 exit code 가 1 (regression) 이면 워크플로우 실패.
+        # 0 (ok / no baseline) 이면 통과.
+        run: |
+          rc="${{ steps.compare.outputs.exit_code }}"
+          if [ "$rc" = "1" ]; then
+            echo "::error::Eval regression detected (pass-rate dropped beyond threshold)"
+            exit 1
+          fi
+          echo "Eval gate passed (rc=$rc)"

--- a/eval/README.md
+++ b/eval/README.md
@@ -121,6 +121,52 @@ git add eval/baseline.json && git commit -m "eval: record baseline (run <timesta
 목표 baseline 통과율: **≥ 70%** (Sonnet 4.6 기준). 미만이면 시스템 프롬프트나
 케이스 작성을 점검할 신호.
 
+또는 폰에서:
+
+```
+/eval baseline    # bridge 컨테이너 안의 baseline.json 갱신
+```
+
+bridge 가 마운트된 `./eval/baseline.json` 을 그대로 덮어쓰므로 그 후
+`git add eval/baseline.json && git commit` 로 PR 에 포함시키면 된다.
+
+## CI 회귀 자동 감지 (#116)
+
+[`.github/workflows/eval.yml`](../.github/workflows/eval.yml) 가 골든셋 회귀를
+자동으로 감지한다.
+
+| 트리거 | 동작 |
+|---|---|
+| `workflow_dispatch` (수동) | Actions 탭에서 \"Eval Regression\" 선택 후 Run. 임계값 입력 가능 |
+| `push` to `main` | `eval/**`, 워크플로우 자체, 또는 `agent-zero/prompts/**` 변경 시 머지 후 자동 실행 |
+| PR 라벨 `eval-required` | 해당 PR 에서만 실행, 결과를 PR 코멘트로 남김 |
+
+비교 결과:
+- 통과율이 `baseline.json` 대비 **임계값(기본 10pp) 이상 하락**하면 워크플로우 실패
+- `baseline.json` 이 없으면 \"no baseline\" 으로 처리 (실패 아님)
+- 통과/실패 여부 + 비용 변동 + 새로 실패한 케이스 목록을 job summary 와 (PR 인 경우) 코멘트로 출력
+
+### 필수 secret
+
+| 이름 | 용도 |
+|---|---|
+| `ANTHROPIC_API_KEY` | runner(메인 응답) + judge(채점) 모두 사용. CLIProxy 트랙은 CI 비호환 — Direct API 만 |
+
+Settings → Secrets and variables → Actions 에서 추가.
+
+### 비교 스크립트 단독 사용
+
+CI 외부에서도 두 회차 summary 를 비교할 수 있다 — 로컬 디버깅용:
+
+```bash
+python .github/scripts/eval_compare.py \
+  --run-dir eval/runs/20260512-093015 \
+  --baseline eval/baseline.json \
+  --threshold-pp 10 \
+  --output report.md
+echo "exit code: $?"   # 0=ok / no baseline, 1=regression, 2=error
+```
+
 ## 로드 검증
 
 ```python

--- a/tests/test_eval_compare.py
+++ b/tests/test_eval_compare.py
@@ -1,0 +1,352 @@
+""".github/scripts/eval_compare.py 검증.
+
+stand-alone CLI 이므로 dynamic import 로 로드.  비교 로직 (compare),
+markdown 포맷터 (format_markdown), main() 의 분기들을 모두 핀.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / ".github" / "scripts" / "eval_compare.py"
+
+
+def _load_compare_module():
+    """`.github/scripts/eval_compare.py` 를 모듈로 spec-load.
+
+    이름에 점이 없는 단일 파일 — 매번 새로 로드해서 sys.modules 오염 회피.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "eval_compare", _SCRIPT_PATH
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["eval_compare"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mod():
+    return _load_compare_module()
+
+
+def _summary(
+    *,
+    total: int = 10,
+    passed: int = 8,
+    cases: list[dict] | None = None,
+    run_cost: float = 0.4,
+    judge_cost: float = 0.004,
+) -> dict:
+    return {
+        "total": total,
+        "passed_judges": passed,
+        "total_run_cost_usd": run_cost,
+        "total_judge_cost_usd": judge_cost,
+        "cases": cases or [],
+    }
+
+
+# ── compare ─────────────────────────────────────────────────────────────
+
+
+def test_compare_no_change_is_ok(mod):
+    s = _summary(total=10, passed=8)
+    r = mod.compare(s, s, threshold_pp=10.0)
+    assert r["verdict"] == "ok"
+    assert r["delta_pp"] == 0.0
+
+
+def test_compare_pass_rate_improvement(mod):
+    base = _summary(total=10, passed=5)
+    cur = _summary(total=10, passed=9)
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    assert r["verdict"] == "ok"
+    assert r["delta_pp"] == 40.0  # 50% → 90%
+
+
+def test_compare_drop_below_threshold_is_ok(mod):
+    base = _summary(total=10, passed=10)
+    cur = _summary(total=10, passed=9)  # -10pp (정확히 임계값)
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    # `< -threshold_pp` 조건이므로 정확히 -10pp 는 아직 OK.
+    assert r["verdict"] == "ok"
+    assert r["delta_pp"] == -10.0
+
+
+def test_compare_drop_above_threshold_is_regression(mod):
+    base = _summary(total=10, passed=10)
+    cur = _summary(total=10, passed=8)  # -20pp
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    assert r["verdict"] == "regression"
+    assert r["delta_pp"] == -20.0
+
+
+def test_compare_custom_threshold_strict(mod):
+    """임계값을 5pp 로 좁히면 같은 변화도 회귀로 분류."""
+    base = _summary(total=10, passed=10)
+    cur = _summary(total=10, passed=9)  # -10pp
+    r = mod.compare(cur, base, threshold_pp=5.0)
+    assert r["verdict"] == "regression"
+
+
+def test_compare_zero_total_handled(mod):
+    """current 가 0건 (전부 fail/error) 이거나 baseline 이 0건이어도
+    ZeroDivisionError 안 난다."""
+    base = _summary(total=0, passed=0)
+    cur = _summary(total=10, passed=5)
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    # base rate = 0, cur rate = 0.5 → +50pp → ok
+    assert r["verdict"] == "ok"
+    assert r["delta_pp"] == 50.0
+    # 반대 방향 (base 정상, cur 비어있음).
+    r = mod.compare(_summary(total=0, passed=0), base, threshold_pp=10.0)
+    assert r["delta_pp"] == 0.0
+
+
+def test_compare_cost_delta_reported(mod):
+    base = _summary(run_cost=0.5, judge_cost=0.005)  # total 0.505
+    cur = _summary(run_cost=0.6, judge_cost=0.006)  # total 0.606
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    # +20%
+    assert r["cost_delta_pct"] == 20.0
+
+
+def test_compare_cost_delta_zero_base(mod):
+    """baseline 비용이 0 이어도 ZeroDivisionError 안 남."""
+    base = _summary(run_cost=0.0, judge_cost=0.0)
+    cur = _summary(run_cost=0.1, judge_cost=0.001)
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    assert r["cost_delta_pct"] == 0.0  # divide-by-zero fallback
+
+
+def test_compare_lists_newly_failing(mod):
+    base = _summary(
+        cases=[
+            {"case_id": "a", "passed": True},
+            {"case_id": "b", "passed": True},
+            {"case_id": "c", "passed": True},
+        ]
+    )
+    cur = _summary(
+        cases=[
+            {"case_id": "a", "passed": True},
+            {"case_id": "b", "passed": False},  # 새로 실패
+            {"case_id": "c", "passed": False},  # 새로 실패
+        ]
+    )
+    r = mod.compare(cur, base, threshold_pp=50.0)  # 임계 넉넉히
+    assert r["newly_failing"] == ["b", "c"]
+    assert r["newly_passing"] == []
+
+
+def test_compare_lists_newly_passing(mod):
+    base = _summary(
+        cases=[
+            {"case_id": "a", "passed": False},
+            {"case_id": "b", "passed": True},
+        ]
+    )
+    cur = _summary(
+        cases=[
+            {"case_id": "a", "passed": True},  # 새로 통과
+            {"case_id": "b", "passed": True},
+        ]
+    )
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    assert r["newly_passing"] == ["a"]
+    assert r["newly_failing"] == []
+
+
+def test_compare_handles_missing_case_in_one_side(mod):
+    """베이스라인엔 있는데 현재엔 빠진 케이스(또는 그 반대) 도 안전."""
+    base = _summary(cases=[{"case_id": "removed", "passed": True}])
+    cur = _summary(cases=[{"case_id": "added", "passed": False}])
+    r = mod.compare(cur, base, threshold_pp=50.0)
+    # 'removed' 는 base 에서 pass 였는데 cur 엔 없음 → cur_p=False → newly_failing
+    assert "removed" in r["newly_failing"]
+    # 'added' 는 base 에 없음 + cur 에서 fail → 양쪽 다 False → 변화 없음
+    assert r["newly_passing"] == []
+
+
+def test_compare_ignores_cases_without_id(mod):
+    """case_id 없는 항목은 비교 대상에서 빠진다 — baseline 의 dict
+    keying 단계에서 걸러져 newly_failing/passing 어느 쪽도 만들지 않는다."""
+    base = _summary(cases=[{"passed": True}])  # id 없음 — 비교 모집단 0건
+    cur = _summary(cases=[{"case_id": "x", "passed": True}])
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    # x 는 base 에 없으므로 base_p=False, cur_p=True → newly_passing.
+    # 이건 의도된 동작 (새로 추가된 케이스가 첫 회차에 통과한 상태).
+    assert r["newly_failing"] == []
+    assert r["newly_passing"] == ["x"]
+
+
+def test_compare_case_only_in_current_treated_as_newly_passing(mod):
+    """baseline 에 없는 케이스가 현재에서 통과 → newly_passing 으로 분류.
+
+    의미적으로: 새 케이스를 추가한 PR 에서 그 케이스가 통과한 상태 → 리포트에
+    '새로 통과' 로 보여 reviewer 가 한눈에 확인 가능.  실패라면 newly_failing.
+    """
+    base = _summary(cases=[])
+    cur = _summary(cases=[{"case_id": "new_case", "passed": True}])
+    r = mod.compare(cur, base, threshold_pp=10.0)
+    assert r["newly_passing"] == ["new_case"]
+
+
+def test_compare_case_only_in_baseline_treated_as_newly_failing(mod):
+    """baseline 엔 통과로 있던 케이스가 현재 회차엔 빠짐 → newly_failing.
+    누군가 케이스를 의도적으로 지웠을 때 reviewer 가 알아챌 수 있게."""
+    base = _summary(cases=[{"case_id": "removed", "passed": True}])
+    cur = _summary(cases=[])
+    r = mod.compare(cur, base, threshold_pp=50.0)
+    assert r["newly_failing"] == ["removed"]
+
+
+# ── format_markdown ─────────────────────────────────────────────────────
+
+
+def test_markdown_ok_path(mod):
+    r = mod.compare(_summary(passed=9), _summary(passed=9), 10.0)
+    md = mod.format_markdown(r)
+    assert "✅" in md
+    assert "Eval OK" in md
+    assert "통과율" in md
+
+
+def test_markdown_regression_path(mod):
+    base = _summary(total=10, passed=10)
+    cur = _summary(total=10, passed=6)  # -40pp
+    r = mod.compare(cur, base, 10.0)
+    md = mod.format_markdown(r)
+    assert "❌" in md
+    assert "Eval Regression Detected" in md
+    assert "-40.0pp" in md
+
+
+def test_markdown_lists_newly_failing_section(mod):
+    base = _summary(cases=[{"case_id": "alpha", "passed": True}])
+    cur = _summary(cases=[{"case_id": "alpha", "passed": False}])
+    r = mod.compare(cur, base, 10.0)
+    md = mod.format_markdown(r)
+    assert "새로 실패" in md
+    assert "`alpha`" in md
+
+
+def test_markdown_no_change_sections_omitted(mod):
+    r = mod.compare(_summary(), _summary(), 10.0)
+    md = mod.format_markdown(r)
+    assert "새로 실패" not in md
+    assert "새로 통과" not in md
+
+
+def test_markdown_no_baseline(mod):
+    md = mod.format_no_baseline_markdown()
+    assert "no baseline" in md.lower()
+    assert "/eval baseline" in md
+
+
+# ── main() / CLI ────────────────────────────────────────────────────────
+
+
+def _write_summary(path: Path, **kwargs):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_summary(**kwargs), ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def test_main_returns_0_when_no_baseline(mod, tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _write_summary(run_dir / "_summary.json")
+    out_path = tmp_path / "report.md"
+    rc = mod.main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--baseline",
+            str(tmp_path / "missing_baseline.json"),
+            "--output",
+            str(out_path),
+        ]
+    )
+    assert rc == 0
+    md = out_path.read_text(encoding="utf-8")
+    assert "no baseline" in md.lower()
+
+
+def test_main_returns_1_on_regression(mod, tmp_path):
+    run_dir = tmp_path / "run"
+    _write_summary(run_dir / "_summary.json", total=10, passed=5)
+    baseline = tmp_path / "baseline.json"
+    _write_summary(baseline, total=10, passed=10)
+    rc = mod.main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--baseline",
+            str(baseline),
+            "--threshold-pp",
+            "10",
+            "--output",
+            str(tmp_path / "report.md"),
+        ]
+    )
+    assert rc == 1
+
+
+def test_main_returns_0_on_ok(mod, tmp_path):
+    run_dir = tmp_path / "run"
+    _write_summary(run_dir / "_summary.json", total=10, passed=9)
+    baseline = tmp_path / "baseline.json"
+    _write_summary(baseline, total=10, passed=10)
+    rc = mod.main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--baseline",
+            str(baseline),
+            "--threshold-pp",
+            "20",
+        ]
+    )
+    assert rc == 0
+
+
+def test_main_returns_2_when_current_missing(mod, tmp_path):
+    rc = mod.main(
+        [
+            "--run-dir",
+            str(tmp_path / "no-such-dir"),
+            "--baseline",
+            str(tmp_path / "baseline.json"),
+        ]
+    )
+    assert rc == 2
+
+
+def test_main_requires_run_dir_or_current(mod):
+    with pytest.raises(SystemExit):
+        mod.main(["--baseline", "x"])
+
+
+def test_main_supports_current_arg(mod, tmp_path):
+    cur = tmp_path / "cur.json"
+    _write_summary(cur)
+    rc = mod.main(
+        [
+            "--current",
+            str(cur),
+            "--baseline",
+            str(tmp_path / "missing.json"),
+            "--output",
+            str(tmp_path / "out.md"),
+        ]
+    )
+    assert rc == 0


### PR DESCRIPTION
Closes #116 — 마일스톤 [Quality Evals 2026-05](https://github.com/devyoon91/az-cliproxy-docker/milestone/2) 7단계.

**TL;DR**: 골든셋 ([#113](https://github.com/devyoon91/az-cliproxy-docker/issues/113)) + runner ([#111](https://github.com/devyoon91/az-cliproxy-docker/issues/111)) + judge ([#112](https://github.com/devyoon91/az-cliproxy-docker/issues/112)) 를 CI 게이트로. `eval/baseline.json` 대비 통과율이 임계값(기본 10pp) 이상 하락하면 워크플로우 실패. 1회 ~$0.50, path-filtered + 라벨 옵트인으로 비용 통제.

## 트리거

| 트리거 | 동작 | 비용 통제 |
|---|---|---|
| `workflow_dispatch` (수동) | 임계값 입력 후 Run. **첫 검증/디버깅 경로** | 수동만 |
| `push` to `main` | 머지 직후 자동 — `eval/`, `agent-zero/prompts/`, settings example, 워크플로우 자체 변경 시에만 | path-filtered |
| PR `eval-required` 라벨 | 해당 PR 에서만 실행 + 결과 코멘트 | 라벨 옵트인 |

비용 추정: 풀 실행 1회 ≈ \$0.50 (Sonnet 4.6 응답 + Haiku 4.5 채점). 경로 필터 + 라벨 게이트로 \"매 PR 발생\" 방지.

## 변경

| 파일 | 내용 |
|---|---|
| [.github/scripts/eval_compare.py](.github/scripts/eval_compare.py) | stdlib-only CLI: 회차 _summary.json ↔ baseline.json diff → 마크다운 리포트 + exit code |
| [.github/workflows/eval.yml](.github/workflows/eval.yml) | 3 트리거, AZ 부팅(--no-deps --build), runner + judge + compare, PR 코멘트, artifact 업로드 |
| [eval/README.md](eval/README.md) | \"CI 회귀 자동 감지\" 섹션 추가 |
| [tests/test_eval_compare.py](tests/test_eval_compare.py) | 25 케이스 (비교 로직 + 포맷 + CLI) |

## 비교 스크립트 출력 예시

```markdown
## ❌ Eval Regression Detected

| | baseline | current | delta |
|---|---|---|---|
| 통과율 | 80% (8/10) | 60% (6/10) | -20.0pp |
| 총 비용 | \$0.4500 | \$0.4800 | +6.7% |

임계값: 통과율 -10pp 이상 하락 시 회귀.

### 🔴 새로 실패한 케이스
- `markdown_table_format`
- `pr_title_korean`
```

Exit code: 0=OK or no baseline, 1=regression, 2=error.

## 핵심 설계 결정

### 1. \"no baseline\" 은 회귀 아님

`eval/baseline.json` 이 아직 없는 fresh 저장소·fork 에서도 워크플로우가 영구 실패하지 않도록 \"no baseline\" 노티스만 출력하고 exit 0. 사용자가 `/eval baseline` 으로 한 번 기준선 기록할 때까지 머지를 막지 않음.

### 2. workflow_dispatch 가 primary

자동 트리거에 ANTHROPIC API 비용을 곧장 노출하지 않는다. 사용자가 한 번 수동으로 돌려 secret/AZ 부팅이 잘 됨을 확인한 뒤, 자동 트리거 신뢰. main-push 는 path-filtered 로 \"평가 의미 있는 변경\" 에만 발화.

### 3. PR 라벨 게이트

전체 PR 에 \$0.50 비용을 떠넘기지 않고, `eval-required` 라벨로 명시적 옵트인. 코드 리뷰어가 \"이 PR 은 품질 영향 가능성 있다\" 판단 시 라벨 부여.

### 4. AZ 부팅 — `--no-deps --build`

CI 에서는 Direct API 트랙(Anthropic) 만. CLIProxy 는 OAuth 가 필요해 CI 비호환. `--no-deps` 로 cliproxy 의존성 skip, `--build` 로 image 생성 (3-5분).

### 5. 새/제거 케이스 처리

- baseline 에 없고 current 에 통과 → `newly_passing` (새로 추가된 케이스)
- baseline 에 통과로 있고 current 에 없음 → `newly_failing` (제거된 케이스)

PR 에서 케이스를 의도적으로 추가/제거할 때 reviewer 가 한눈에 확인.

## Verification

```
$ python -m pytest tests/test_eval_compare.py -v
============================= 25 passed in 0.09s ==============================

$ python -m pytest
============================= 360 passed in 1.92s ==============================

$ python -m ruff check .github/scripts/eval_compare.py tests/test_eval_compare.py
All checks passed!

$ python -c \"import yaml; yaml.safe_load(open('.github/workflows/eval.yml'))\"
# (YAML valid)
```

## Test plan

**compare()** (12):
- [x] 변동 없음 → ok
- [x] 통과율 개선 → ok
- [x] 정확히 -임계값pp → ok (`< -threshold` 조건이므로 경계는 통과)
- [x] -임계값 초과 → regression
- [x] custom threshold 적용
- [x] total=0 / cost=0 안전
- [x] cost_delta_pct 계산 (정상 / zero base)
- [x] newly_failing / newly_passing 리스트 정확
- [x] base 에만 있는 케이스 → newly_failing
- [x] cur 에만 있는 케이스 (통과) → newly_passing
- [x] case_id 없는 항목은 비교 모집단에서 제외

**format_markdown()** (4):
- [x] OK / regression / 새로 실패 섹션 / 변경 없을 때 섹션 생략

**main()** CLI (8):
- [x] no baseline → exit 0, \"no baseline\" 메시지
- [x] regression → exit 1
- [x] ok → exit 0
- [x] current 누락 → exit 2
- [x] --run-dir / --current 둘 다 없으면 SystemExit
- [x] --current 직접 경로 지원

**no_baseline_markdown** (1):
- [x] /eval baseline 안내 포함

## 주의: 첫 머지 후 ANTHROPIC_API_KEY 필요

이 PR 머지 후 path 필터가 일치하므로 (이 PR 가 워크플로우 자체를 추가) main-push 트리거가 발화한다. **GitHub repo Settings → Secrets and variables → Actions** 에 `ANTHROPIC_API_KEY` 가 없으면 워크플로우는 \"::error:: ANTHROPIC_API_KEY secret 미설정\" 으로 빠르게 실패한다. 의도된 동작 — secret 추가 후 `workflow_dispatch` 로 재실행.

baseline.json 도 아직 커밋 안 됨 → 첫 실제 실행은 \"no baseline\" 노티스로 통과. `/eval baseline` 한 번 돌려서 `eval/baseline.json` 커밋 후 본격 회귀 감지 시작.

## 다음

- [#117](https://github.com/devyoon91/az-cliproxy-docker/issues/117) — `docs/eval.md` 가이드 (마지막).