### PR TITLE
fix: settings.example.json browser_model_name 오타 수정

### DIFF
--- a/agent-zero/settings.example.json
+++ b/agent-zero/settings.example.json
@@ -32,7 +32,7 @@
     "embed_model_rl_requests": 0,
     "embed_model_rl_input": 0,
     "browser_model_provider": "anthropic",
-    "browser_model_name": "claude-haiku-3.5-sonnet",
+    "browser_model_name": "claude-haiku-4-5",
     "browser_model_api_base": "",
     "browser_model_vision": true,
     "browser_model_kwargs": {


### PR DESCRIPTION
## TL;DR

`agent-zero/settings.example.json` 의 `browser_model_name` 이 존재하지 않는 식별자 `claude-haiku-3.5-sonnet` 으로 되어 있어, 사용자가 예제를 그대로 복사하면 browser 도구 첫 호출에서 실패. 동일 파일의 `util_model_name` 과 같은 `claude-haiku-4-5` 로 정정.

## Why

- `claude-haiku-3.5-sonnet` 은 Haiku 와 Sonnet 식별자를 섞은 잘못된 이름 (실제 모델 미존재).
- 예제 파일은 신규 사용자의 출발점 — 그대로 복사 시 browser 모델 초기화 단계에서 401/404 가능.

## What changed

| 파일 | 변경 |
|------|------|
| `agent-zero/settings.example.json:35` | `claude-haiku-3.5-sonnet` → `claude-haiku-4-5` |

## 선택 근거

- 같은 파일 `util_model_name` (line 18) 이 이미 `claude-haiku-4-5` — 일관성 유지.
- Haiku 4.5 는 vision 지원 → `browser_model_vision: true` (line 37) 와 호환.

## Verification

```bash
grep browser_model_name agent-zero/settings.example.json
#    "browser_model_name": "claude-haiku-4-5",
```

## Test plan

- [x] `grep` 으로 새 값 확인
- [ ] 예제 복사 → `agent-zero/settings.json` 로 시작 시 browser 도구 정상 호출 (수동 smoke)