### PR TITLE
build(telegram-bridge): pip 의존성 정확한 버전 핀

### DIFF
--- a/telegram-bridge/Dockerfile
+++ b/telegram-bridge/Dockerfile
@@ -3,12 +3,12 @@ FROM python:3.12-slim
 WORKDIR /app
 
 RUN pip install --no-cache-dir \
-    python-telegram-bot==21.* \
-    aiohttp==3.* \
-    httpx \
-    openai \
-    pyyaml==6.* \
-    anthropic==0.40.*
+    python-telegram-bot==21.11.1 \
+    aiohttp==3.13.5 \
+    httpx==0.28.1 \
+    openai==2.36.0 \
+    pyyaml==6.0.3 \
+    anthropic==0.40.0
 
 COPY bot.py .
 COPY pricing/ ./pricing/


### PR DESCRIPTION
## TL;DR

`telegram-bridge/Dockerfile` 의 pip 핀이 느슨해서 (`==21.*`, `==3.*`, `openai` 는 완전 unpinned 등) 같은 Dockerfile 이 빌드 시점마다 다른 버전을 설치 → 재현성·CVE 추적성 저하. 현재 빌드 산출물의 `pip freeze` 결과를 그대로 정확한 버전으로 고정.

## Why

| 문제 | 영향 |
|------|------|
| `==21.*`, `==3.*`, `==6.*` 등 와일드카드 | minor/patch 업스트림 변경 시 같은 Dockerfile → 다른 산출물 |
| `httpx`, `openai` 완전 unpinned | 메이저 버전까지 자유 → 빌드 깨질 가능성 |
| 모두 정확 핀 부재 | 알려진 CVE 발견 시 "어느 버전인지" 추적 불가 |

## What changed

`telegram-bridge/Dockerfile:5-11` — 와일드카드 핀 + unpinned 를 정확한 버전 핀으로 교체:

| 패키지 | Before | After |
|--------|--------|-------|
| python-telegram-bot | `==21.*` | `==21.11.1` |
| aiohttp | `==3.*` | `==3.13.5` |
| httpx | (unpinned) | `==0.28.1` |
| openai | (unpinned) | `==2.36.0` |
| pyyaml | `==6.*` | `==6.0.3` |
| anthropic | `==0.40.*` | `==0.40.0` |

핀 값은 **현재 main 빌드의 `pip freeze` 결과 그대로** — 즉시 동작 보장.

## Verification

```text
$ docker compose build --no-cache telegram-bridge
... DONE 30.8s (성공)

$ docker run --rm --entrypoint pip <image> freeze | grep -iE "python-telegram-bot|aiohttp|httpx|^openai|pyyaml|anthropic"
aiohttp==3.13.5
anthropic==0.40.0
httpx==0.28.1
openai==2.36.0
python-telegram-bot==21.11.1
PyYAML==6.0.3

$ docker run --rm --entrypoint python <image> -c "import bot; print('import ok')"
import ok
```

## Test plan

- [x] `docker compose build --no-cache telegram-bridge` 성공
- [x] 6개 패키지 모두 정확 버전으로 설치 확인 (`pip freeze`)
- [x] `bot.py` import smoke 통과
- [ ] CI (`.github/workflows/ci.yml`) 통과 확인
- [ ] 실제 텔레그램 봇 기동 후 webhook/usage 기본 동작 1회 확인 (수동)

## 다음 단계 (별도 PR 권장)

- 의존성 정기 점검 루틴 (Dependabot/Renovate) 도입 검토 — 이 PR 은 "현재 시점 핀" 만 정리하고, 자동 업데이트 흐름은 별도 의사결정 필요.