### PR TITLE
fix(telegram-bridge): 일일 리포트가 '어제'일 때만 발송 (#131)

### DIFF
--- a/telegram-bridge/bot.py
+++ b/telegram-bridge/bot.py
@@ -129,6 +129,7 @@ from pricing.cost import (
     calc_cost,
 )
 from pricing.usage import (
+    build_daily_report_lines,
     track_usage,
     usage_history,
     usage_today,
@@ -785,7 +786,13 @@ from webhooks.handlers import (  # noqa: E402, F401
 
 # ── 일일 사용량 리포트 스케줄러 ──
 async def daily_usage_reporter():
-    """매일 자정에 일일 사용량 리포트를 Telegram으로 전송"""
+    """매일 KST 00:01 에 어제 사용량 리포트를 Telegram 으로 전송.
+
+    `usage_today` 가 \"어제 일자\" 데이터를 들고 있을 때만 발송한다.
+    `/track` 이벤트만 bucket 을 회전시키므로 idle 인 날에는 stale 한
+    이전 활성일 데이터가 남아있는데, 이걸 매일 같은 라벨로 반복 발송하지
+    않도록 발송 단계에서 일자 매칭 가드를 둔다 (issue #131).
+    """
     logger.info("Daily usage reporter started")
 
     while True:
@@ -798,25 +805,10 @@ async def daily_usage_reporter():
             wait_seconds += 86400
         await asyncio.sleep(wait_seconds)
 
-        # 어제 사용량 리포트
-        if usage_today["requests"] > 0:
-            lines = [
-                f"📊 일일 사용량 리포트 ({usage_today['date']})\n",
-                f"총 요청: {usage_today['requests']}건",
-                f"총 입력: {usage_today['input_tokens']:,} 토큰",
-                f"총 출력: {usage_today['output_tokens']:,} 토큰",
-                f"총 비용: ${usage_today['cost_usd']:.4f}",
-            ]
-            by_model = usage_today.get("by_model", {})
-            if by_model:
-                lines.append("\n🤖 모델별 내역:")
-                for model, stats in sorted(by_model.items(), key=lambda x: x[1]["cost_usd"], reverse=True):
-                    lines.append(
-                        f"  {model}\n"
-                        f"    {stats['requests']}건 | "
-                        f"in:{stats['input_tokens']:,} out:{stats['output_tokens']:,} | "
-                        f"${stats['cost_usd']:.4f}"
-                    )
+        # KST 기준 어제 일자 — usage_today.date 와 일치할 때만 발송
+        yesterday_str = (_kst_now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        lines = build_daily_report_lines(usage_today, yesterday_str)
+        if lines:
             await send_telegram("\n".join(lines))
 
 

--- a/telegram-bridge/pricing/usage.py
+++ b/telegram-bridge/pricing/usage.py
@@ -78,6 +78,47 @@ def _rotate_if_new_day(today_str: str) -> None:
     usage_today.update(_empty_today_bucket(today_str))
 
 
+def build_daily_report_lines(today_bucket: dict, yesterday_str: str) -> list[str] | None:
+    """Render the lines for the daily usage report — yesterday's totals only.
+
+    Returns None if there is nothing to send:
+    - `today_bucket["date"]` does not match `yesterday_str` (stale bucket
+      from an earlier active day — idle days must stay silent so the
+      reporter doesn't re-send the same numbers night after night), or
+    - `today_bucket["requests"] <= 0` (the bucket is for yesterday but
+      nothing was logged).
+
+    Caller passes `yesterday_str` because the time source belongs to the
+    reporter — keeping this helper a pure function is what makes it
+    testable without async / scheduler machinery. See issue #131.
+    """
+    if today_bucket["date"] != yesterday_str:
+        return None
+    if today_bucket["requests"] <= 0:
+        return None
+
+    lines = [
+        f"📊 일일 사용량 리포트 ({today_bucket['date']})\n",
+        f"총 요청: {today_bucket['requests']}건",
+        f"총 입력: {today_bucket['input_tokens']:,} 토큰",
+        f"총 출력: {today_bucket['output_tokens']:,} 토큰",
+        f"총 비용: ${today_bucket['cost_usd']:.4f}",
+    ]
+    by_model = today_bucket.get("by_model", {})
+    if by_model:
+        lines.append("\n🤖 모델별 내역:")
+        for model, stats in sorted(
+            by_model.items(), key=lambda x: x[1]["cost_usd"], reverse=True
+        ):
+            lines.append(
+                f"  {model}\n"
+                f"    {stats['requests']}건 | "
+                f"in:{stats['input_tokens']:,} out:{stats['output_tokens']:,} | "
+                f"${stats['cost_usd']:.4f}"
+            )
+    return lines
+
+
 def track_usage(
     model: str,
     input_tokens: int,

--- a/tests/test_bridge_usage.py
+++ b/tests/test_bridge_usage.py
@@ -193,3 +193,50 @@ def test_bindings_survive_rollover(usage, monkeypatch):
     assert captured is usage.usage_today
     assert captured["date"] == "2026-05-09"
     assert captured["requests"] == 1
+
+
+# ── build_daily_report_lines (issue #131) ──────────────────────────
+
+
+def test_daily_report_sends_when_bucket_matches_yesterday(usage):
+    """Happy path — usage_today.date == yesterday and requests > 0 → lines."""
+    usage.track_usage("claude-fake", 1_000, 100)
+    # The fixture pins today to 2026-05-08; on 5/09 00:01 the report
+    # should label 5/08 as yesterday and emit lines.
+    lines = usage.build_daily_report_lines(usage.usage_today, "2026-05-08")
+    assert lines is not None
+    assert any("2026-05-08" in line for line in lines)
+    assert any("총 요청: 1건" in line for line in lines)
+    assert any("claude-fake" in line for line in lines)
+
+
+def test_daily_report_skips_when_bucket_is_stale(usage):
+    """Regression for issue #131 — if usage_today is from a day earlier
+    than 'yesterday' (idle days in between), the reporter must NOT send
+    that stale data repeatedly.
+    """
+    usage.track_usage("claude-fake", 1_000, 100)  # date == 2026-05-08
+    # Two idle days have passed; reporter fires on 5/11 → yesterday is 5/10.
+    lines = usage.build_daily_report_lines(usage.usage_today, "2026-05-10")
+    assert lines is None
+
+
+def test_daily_report_skips_when_no_requests(usage):
+    """Bucket is for yesterday but logged zero requests → silent."""
+    # Manually set the bucket to yesterday's date with no activity.
+    usage.usage_today.clear()
+    usage.usage_today.update(usage._empty_today_bucket("2026-05-08"))
+    lines = usage.build_daily_report_lines(usage.usage_today, "2026-05-08")
+    assert lines is None
+
+
+def test_daily_report_includes_by_model_breakdown(usage):
+    """Lines should carry the by_model section sorted by cost desc."""
+    usage.track_usage("claude-fake-cheap", 100, 10)        # tiny cost
+    usage.track_usage("claude-fake-expensive", 10_000, 5_000)  # bigger cost
+    lines = usage.build_daily_report_lines(usage.usage_today, "2026-05-08")
+    assert lines is not None
+    text = "\n".join(lines)
+    assert "🤖 모델별 내역:" in text
+    # Expensive model should appear before cheap one in the rendered output.
+    assert text.index("claude-fake-expensive") < text.index("claude-fake-cheap")


### PR DESCRIPTION
Closes #131

## TL;DR

일일 사용량 리포트가 stale `usage_today` 를 그대로 발송하던 버그 수정.
이제 `usage_today.date` 가 **어제 (KST)** 일자와 일치할 때만 발송하고,
idle 인 날은 침묵합니다.

## Why

[`daily_usage_reporter`](telegram-bridge/bot.py) 가 매일 KST 00:01 에 보내는
\"📊 일일 사용량 리포트\" 가 **이름·주석상 \"어제\"** 지만 실제로는
`usage_today` 에 남아 있는 **\"마지막 사용한 날\"** 데이터를 라벨까지 그대로
발송했습니다.

| 시점 | usage_today | 00:01 리포트 | 기대 |
|---|---|---|---|
| 5/24 사용 → 5/25 00:01 | date=5/24 | \"5/24\" | ✓ |
| 5/25 idle → 5/26 00:01 | **여전히 date=5/24** | **\"5/24\" 재발송** | 침묵 |
| 5/26 idle → 5/27 00:01 | 여전히 date=5/24 | **\"5/24\" 또 발송** | 침묵 |

원인: `usage_today` 회전은 [`pricing/usage.py:_rotate_if_new_day`](telegram-bridge/pricing/usage.py)
가 담당하는데 **`track_usage()` 안에서만** 호출됨. idle 인 날엔 `/track`
이벤트가 없어 bucket 이 stale 한 채로 매일 같은 데이터가 발송됨.

## 무엇을 했나

**Option A — 어제 매칭 가드** (이슈 #131 의 옵션 비교 참조):

- `pricing/usage.py` 에 **순수 함수** `build_daily_report_lines(today_bucket, yesterday_str) -> list[str] | None` 추가
  - `today_bucket[\"date\"] != yesterday_str` → `None` (stale)
  - `today_bucket[\"requests\"] <= 0` → `None` (어제 사용 없음)
  - 그 외엔 기존과 동일한 라인 구성을 반환
- `bot.py:daily_usage_reporter` 가 KST 어제 일자를 계산해 helper 에 위임. 반환이 `None` 이면 침묵.
- 비교 검토했지만 채택 안 한 대안:
  - **B. idle 알림**: \"📊 어제 사용 없음\" 메시지 — 매일 0원 알림 노이즈.
  - **C. 강제 rotate**: 00:01 에 무조건 회전 — `usage_history` 에 빈 bucket 누적 사이드이펙트.

## Verification

\`\`\`
$ pytest tests/test_bridge_usage.py -v
...
test_daily_report_sends_when_bucket_matches_yesterday   PASSED
test_daily_report_skips_when_bucket_is_stale            PASSED
test_daily_report_skips_when_no_requests                PASSED
test_daily_report_includes_by_model_breakdown           PASSED
============================= 11 passed in 0.06s ==============================

$ pytest -q
364 passed in 3.16s
\`\`\`

## Test plan

- [ ] 컨테이너 재기동 후 `usage_today.date` 가 어제일 때 KST 00:01 직후 리포트 1건 도착
- [ ] idle 인 날 KST 00:01 직후 리포트 미도착 (그 동안 송신되던 stale 데이터가 더 이상 안 오는지)
- [ ] 정상 활성 다음날 리포트가 평소처럼 도착