### PR TITLE
feat(chat_pdf_export): PDF 생성 중/완료 알림 추가 (#133)

### DIFF
--- a/agent-zero/usr-plugins/chat_pdf_export/api/export_pdf.py
+++ b/agent-zero/usr-plugins/chat_pdf_export/api/export_pdf.py
@@ -29,6 +29,49 @@ if str(_PLUGIN_ROOT) not in sys.path:
 
 from render.render import render_chat_to_pdf  # noqa: E402
 
+# Progress notifications are best-effort: a missing or changed Agent Zero
+# notification API must never break the actual export. See issue #133.
+try:
+    from helpers.notification import (  # noqa: E402
+        NotificationManager,
+        NotificationPriority,
+        NotificationType,
+    )
+    _NOTIFY_AVAILABLE = True
+except Exception:  # pragma: no cover - depends on agent-zero version
+    _NOTIFY_AVAILABLE = False
+
+
+def _notify(notif_id: str, kind: str, title: str, message: str, display_time: int) -> None:
+    """Best-effort toast via Agent Zero's NotificationManager.
+
+    `kind` is one of "progress" | "success" | "error". Reusing the same
+    `notif_id` makes the manager update the existing toast in place, so a
+    single notification transitions 생성 중 → 완료/실패 rather than stacking.
+    Swallows every error — the PDF export must succeed even when the
+    notification layer doesn't.
+    """
+    if not _NOTIFY_AVAILABLE:
+        return
+    try:
+        type_map = {
+            "progress": NotificationType.PROGRESS,
+            "success": NotificationType.SUCCESS,
+            "error": NotificationType.ERROR,
+        }
+        NotificationManager.send_notification(
+            type=type_map.get(kind, NotificationType.INFO),
+            priority=NotificationPriority.NORMAL,
+            message=message,
+            title=title,
+            id=notif_id,
+            group="chat-pdf-export",
+            display_time=display_time,
+        )
+    except Exception:  # pragma: no cover - defensive; never break export
+        pass
+
+
 # LogItem.type → our normalized role. Types we don't surface in the PDF
 # (progress/info/hint/etc.) map to None and get skipped.
 _TYPE_MAP: dict[str, str | None] = {
@@ -173,14 +216,36 @@ class ExportPdf(ApiHandler):
                 )
             return Response("Chat has no exportable messages", 400)
 
+        # Bracket the slow WeasyPrint render with a progress → done toast so
+        # the user knows the PDF is being generated (issue #133). Stable id
+        # per (context, log_no) so re-clicks update one toast, not a stack.
+        notif_id = f"chat-pdf-export-{ctxid}-{log_no if log_no is not None else 'full'}"
+        _notify(
+            notif_id,
+            "progress",
+            "PDF 추출",
+            "PDF 생성 중…" if log_no is None else f"메시지 #{log_no} PDF 생성 중…",
+            display_time=120,  # keep visible through a long render
+        )
+
         try:
             pdf_bytes = render_chat_to_pdf(chat)
         except ImportError as e:
+            _notify(
+                notif_id,
+                "error",
+                "PDF 추출 실패",
+                "PDF 렌더링 의존성이 없습니다 (weasyprint).",
+                display_time=10,
+            )
             return Response(
                 f"PDF rendering dependency missing: {e}. "
                 f"Install via `pip install weasyprint` inside the agent-zero container.",
                 500,
             )
+        except Exception as e:
+            _notify(notif_id, "error", "PDF 추출 실패", str(e)[:200], display_time=10)
+            raise
 
         # Korean-safe filename (RFC 5987). Browsers prefer the filename* form
         # for non-ASCII, but we also send a sanitized ASCII fallback for
@@ -193,6 +258,8 @@ class ExportPdf(ApiHandler):
             f'attachment; filename="{ascii_fallback}"; '
             f"filename*=UTF-8''{quote(utf8_name)}"
         )
+
+        _notify(notif_id, "success", "PDF 추출 완료", utf8_name, display_time=4)
 
         return Response(
             response=pdf_bytes,

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -57,6 +57,35 @@ def _stub_helpers() -> None:
     api_mod.Request = object
     helpers.api = api_mod  # type: ignore[attr-defined]
 
+    # `helpers.notification` — chat_pdf_export emits PDF-generation progress
+    # toasts via NotificationManager (issue #133). Record every send so tests
+    # can assert the progress → success/error transitions.
+    notif_mod = _ensure_module("helpers.notification")
+
+    class _NotificationType:
+        INFO = "info"
+        SUCCESS = "success"
+        WARNING = "warning"
+        ERROR = "error"
+        PROGRESS = "progress"
+
+    class _NotificationPriority:
+        NORMAL = 10
+        HIGH = 20
+
+    class _NotificationManager:
+        sent: list = []
+
+        @staticmethod
+        def send_notification(**kwargs):
+            _NotificationManager.sent.append(kwargs)
+            return kwargs
+
+    notif_mod.NotificationType = _NotificationType
+    notif_mod.NotificationPriority = _NotificationPriority
+    notif_mod.NotificationManager = _NotificationManager
+    helpers.notification = notif_mod  # type: ignore[attr-defined]
+
 
 def _stub_agent() -> None:
     """`agent.AgentContext`, `agent.LoopData`."""

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -124,3 +124,109 @@ def test_noise_types_filtered_out(export_pdf):
     # Whatever role the response maps to, info/progress should be gone.
     assert len(chat["messages"]) == 2
     assert all(t not in {"info", "progress"} for t in types)
+
+
+# ── progress notifications (issue #133) ──────────────────────────────
+#
+# The slow WeasyPrint render is bracketed by a progress → success/error
+# toast so the user knows a PDF is being generated. The handler is async
+# and returns a Flask Response; we drive it with a fresh event loop the
+# same way test_bridge_webhooks.py exercises aiohttp handlers.
+
+import agent as _agent  # noqa: E402  (stub installed by conftest)
+import helpers.notification as _notif  # noqa: E402  (stub installed by conftest)
+
+
+def _run(coro):
+    import asyncio
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def notif_sink():
+    _notif.NotificationManager.sent.clear()
+    yield _notif.NotificationManager.sent
+    _notif.NotificationManager.sent.clear()
+
+
+def test_export_emits_progress_then_success(export_pdf, notif_sink):
+    ctx = _FakeContext("현대차 시세", [
+        _FakeLogItem(0, "user", "사용자", "현대차 오늘 시세 알려줘"),
+        _FakeLogItem(1, "response", "응답", "**현대차** 616,000원"),
+    ])
+    _agent.AgentContext._store["ctx-ok"] = ctx
+    resp = _run(export_pdf.ExportPdf().process({"context": "ctx-ok"}, None))
+
+    kinds = [n["type"] for n in notif_sink]
+    assert kinds == ["progress", "success"]
+    # Same id on both → the toast updates in place rather than stacking.
+    assert notif_sink[0]["id"] == notif_sink[1]["id"]
+    assert notif_sink[0]["group"] == "chat-pdf-export"
+    # Success carries the generated filename.
+    assert notif_sink[1]["message"].endswith(".pdf")
+    # The export itself still succeeded (PDF bytes returned).
+    assert 200 in resp.kwargs.values() or 200 in getattr(resp, "args", ())
+
+
+def test_export_per_message_progress_mentions_log_no(export_pdf, notif_sink):
+    ctx = _FakeContext("Hyundai", [
+        _FakeLogItem(0, "user", "u", "Q"),
+        _FakeLogItem(1, "response", "r", "ANSWER"),
+    ])
+    _agent.AgentContext._store["ctx-msg"] = ctx
+    _run(export_pdf.ExportPdf().process({"context": "ctx-msg", "log_no": 1}, None))
+
+    assert notif_sink[0]["type"] == "progress"
+    assert "#1" in notif_sink[0]["message"]
+    # Per-message id is distinct from the full-chat id for the same context.
+    assert notif_sink[0]["id"].endswith("-1")
+
+
+def test_export_emits_error_on_render_failure(export_pdf, notif_sink, monkeypatch):
+    ctx = _FakeContext("boom", [
+        _FakeLogItem(0, "user", "u", "Q"),
+        _FakeLogItem(1, "response", "r", "A"),
+    ])
+    _agent.AgentContext._store["ctx-err"] = ctx
+
+    def _boom(_chat):
+        raise RuntimeError("weasyprint exploded")
+
+    monkeypatch.setattr(export_pdf, "render_chat_to_pdf", _boom)
+    with pytest.raises(RuntimeError, match="exploded"):
+        _run(export_pdf.ExportPdf().process({"context": "ctx-err"}, None))
+
+    kinds = [n["type"] for n in notif_sink]
+    assert kinds == ["progress", "error"]
+    assert notif_sink[1]["id"] == notif_sink[0]["id"]
+
+
+def test_export_importerror_returns_500_and_error_toast(export_pdf, notif_sink, monkeypatch):
+    ctx = _FakeContext("noweasy", [
+        _FakeLogItem(0, "user", "u", "Q"),
+        _FakeLogItem(1, "response", "r", "A"),
+    ])
+    _agent.AgentContext._store["ctx-noweasy"] = ctx
+
+    def _no_weasy(_chat):
+        raise ImportError("No module named 'weasyprint'")
+
+    monkeypatch.setattr(export_pdf, "render_chat_to_pdf", _no_weasy)
+    resp = _run(export_pdf.ExportPdf().process({"context": "ctx-noweasy"}, None))
+
+    # Graceful 500 (not a raise) so the frontend shows a useful message.
+    assert 500 in getattr(resp, "args", ())
+    assert [n["type"] for n in notif_sink] == ["progress", "error"]
+
+
+def test_export_no_toast_when_chat_empty(export_pdf, notif_sink):
+    """Empty-chat validation returns before the render bracket, so no
+    progress toast — the frontend surfaces the 4xx immediately."""
+    ctx = _FakeContext("empty", [])
+    _agent.AgentContext._store["ctx-empty"] = ctx
+    _run(export_pdf.ExportPdf().process({"context": "ctx-empty"}, None))
+    assert notif_sink == []


### PR DESCRIPTION
Closes #133

## TL;DR

PDF 추출 시 \"생성 중 → 완료/실패\" 토스트를 Agent Zero `NotificationManager` 로 띄움. 긴 채팅에서 WeasyPrint 가 수십 초 걸려도 사용자가 진행 상태를 알 수 있음. 전체/메시지별 두 버튼 모두 적용. 백엔드 한 파일만 변경, 프론트 무수정.

## Why

[chat_pdf_export](agent-zero/usr-plugins/chat_pdf_export/) 의 export 는 동기 호출이라 긴 채팅이면 수십 초 멈춰 있는데, 피드백이 버튼 라벨 `\"PDF\" → \"PDF…\"` 가 전부였음. 사용자는 \"진행 중인지 죽었는지\" 알 수 없었음.

## 무엇을 했나

`api/export_pdf.py` 의 render 구간을 알림으로 감쌈:

| 시점 | 알림 |
|---|---|
| render 직전 | `PROGRESS` — \"PDF 생성 중…\" (메시지별이면 \"메시지 #N PDF 생성 중…\") |
| 성공 | `SUCCESS` — 생성된 파일명 |
| `ImportError` (weasyprint 없음) | `ERROR` + 기존 500 응답 유지 |
| 기타 예외 | `ERROR` + 재던짐 (기존 propagation 보존) |

- **stable id** `chat-pdf-export-{ctxid}-{log_no|full}` → 같은 토스트를 in-place 업데이트 (스택 안 쌓임). 전체/메시지별 버튼이 자연히 분리됨.
- **best-effort**: 알림 import·전송 모두 `try/except` 로 감쌈 — 알림 API 가 없거나 바뀌어도 export 자체는 절대 안 깨짐.
- **빠른 검증 실패** (빈 채팅 등) 는 render 구간 전에 return 하므로 토스트 안 뜸 (프론트가 4xx 즉시 표시).
- 동기 핸들러여도 `send_notification` 내부 `mark_dirty_all` 이 다음 `/poll` 에서 토스트를 push → 응답 전 화면에 \"생성 중\" 표시됨.

## Verification

\`\`\`
$ pytest tests/test_pdf_export.py -v
... 10 passed

$ pytest -q
369 passed in 3.67s

$ ruff check (changed files)
All checks passed!
\`\`\`

라이브 컨테이너 (force-recreate 후):
\`\`\`
helpers.notification OK: NotificationType.PROGRESS SUCCESS ERROR
plugin import OK; _NOTIFY_AVAILABLE = True
\`\`\`

신규 테스트 5건: progress→success / 메시지별 id / progress→error / ImportError→500+toast / 빈 채팅 무토스트. `tests/stubs.py` 에 호출 기록용 `helpers.notification` stub 추가.

## Out of scope

- WeasyPrint 내부 단계별 progress (라이브러리 미제공). \"수집 중 / HTML 렌더 / PDF 변환\" 까지 쪼개려면 백엔드를 async/streaming 으로 바꿔야 해서 별도.
- 프론트 store 의 기존 `alert()` 실패 표시 — 토스트와 일부 중복되지만 무해, 별도.

## Test plan

- [ ] 긴 채팅에서 전체 PDF 버튼 클릭 → \"PDF 생성 중…\" 토스트 → 완료 시 파일명 토스트
- [ ] 메시지별 PDF 버튼 → \"메시지 #N PDF 생성 중…\" 토스트
- [ ] weasyprint 제거 환경에서 실패 토스트 + 기존 에러 동작