### PR TITLE
feat: Agent Zero v1.13 → v1.18 업그레이드

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,6 +1,6 @@
 # Agent Zero + CLIProxy 구축 가이드
 
-> Agent Zero v1.13 | CLIProxy v6.9.18 | Telegram Bridge (custom)
+> Agent Zero v1.18 | CLIProxy v6.9.18 | Telegram Bridge (custom)
 
 이 문서는 [README.md](README.md) 를 읽었다는 가정 하에, 신규 사용자가 부팅까지
 실수 없이 도달하기 위한 **walkthrough** 입니다. README 가 "이 저장소가 무엇을

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ API 에 직접 연결하는 경로, **Track B (CLIProxy)** 는 공식 CLI 의 OA
 
 | Component | Version | Image / Detail |
 |-----------|---------|----------------|
-| Agent Zero | v1.13 | `agent0ai/agent-zero:v1.13` |
+| Agent Zero | v1.18 | `agent0ai/agent-zero:v1.18` |
 | CLIProxy | v6.9.18 | `eceasy/cli-proxy-api:v6.9.18` |
 | Telegram Bridge | custom | `python:3.12-slim` 기반 |
 | LiteLLM | 1.79.3 | Agent Zero 내장 |

--- a/agent-zero/Dockerfile
+++ b/agent-zero/Dockerfile
@@ -7,6 +7,6 @@
 # Bumping the base image: edit the FROM line and rebuild
 # (`docker compose build agent-zero`).
 
-FROM agent0ai/agent-zero:v1.13
+FROM agent0ai/agent-zero:v1.18
 
 RUN /opt/venv-a0/bin/pip install --no-cache-dir --disable-pip-version-check weasyprint

--- a/agent-zero/prompts/agent.system.skills.md
+++ b/agent-zero/prompts/agent.system.skills.md
@@ -1,3 +1,9 @@
 ## skills
-use `skills_tool:list` to discover skills when specialized instructions may help
-use `skills_tool:load` before following a skill
+use `skills_tool` action `search` when the user's wording sounds like a task, trigger phrase, or keyword match for a skill
+if the user asks to find/search a skill, search first before loading
+use `skills_tool` action `list` when you need a broader catalog view
+use `skills_tool` action `load` before following a skill
+loaded skills may document beta/specialized tools not in the always-on tool list; use them only after loading the skill
+
+available:
+{{skills}}

--- a/agent-zero/prompts/agent.system.skills.relevant.md
+++ b/agent-zero/prompts/agent.system.skills.relevant.md
@@ -1,10 +1,10 @@
 # Relevant Skills (auto-matched)
 
-**The following skills matched the user's current request via trigger patterns. You MUST load one of these via `skills_tool:load` before falling back to general tools (`browser_agent`, `search_engine`, `code_execution_tool`).**
+**The following skills matched the user's current request via trigger patterns. You MUST load one of these via `skills_tool` (action `load`, `skill_name=<name>`) before falling back to general tools (`browser_agent`, `search_engine`, `code_execution_tool`).**
 
 ## Rules
 
-1. **MUST**: If a skill is matched below, call `skills_tool:load` and follow its guidance.
+1. **MUST**: If a skill is matched below, call `skills_tool` with action `load` and follow its guidance.
 2. **MUST NOT**: Do not call `browser_agent` or `search_engine` standalone for Korean-domain queries (laws, public-company filings, HWP files, privacy policies, Korean company info, etc.) when a matching skill is listed below.
 3. **Priority**: When multiple skills match, evaluate in listed order (highest score first). Skip to the next only if the first is clearly inapplicable.
 4. **Exception**: General tools may be used only when (a) the matched skill is clearly a false-positive against the user's intent, or (b) the user explicitly requested a general tool.
@@ -21,4 +21,4 @@
 
 ✅ **Right**:
 > User: "Show me Samsung Electronics' 10 most recent disclosures."
-> Agent: `skills_tool:load(skill_name="k-dart")` → precise data via DART API
+> Agent: `skills_tool` (action `load`, `skill_name="k-dart"`) → precise data via DART API

--- a/agent-zero/prompts/agent.system.tool.scheduler.md
+++ b/agent-zero/prompts/agent.system.tool.scheduler.md
@@ -1,26 +1,28 @@
 ### scheduler
-manage saved tasks and schedules
-rules:
-- before `scheduler:create_*` or `scheduler:run_task`, inspect existing tasks with `scheduler:find_task_by_name` or `scheduler:list_tasks`
-- do not manually run a task just because it is scheduled or planned unless user asks to run now
-- do not create recursive task prompts that schedule more tasks
-methods:
-- `scheduler:list_tasks`: optional `state[]`, `type[]`, `next_run_within`, `next_run_after`
-- `scheduler:find_task_by_name`: `name`
-- `scheduler:show_task`: `uuid`
-- `scheduler:run_task`: `uuid`, optional `context`
-- `scheduler:delete_task`: `uuid`
-- `scheduler:create_scheduled_task`: `name`, `system_prompt`, `prompt`, optional `attachments[]`, `schedule{minute,hour,day,month,weekday}`, optional `dedicated_context`
-- `scheduler:create_adhoc_task`: `name`, `system_prompt`, `prompt`, optional `attachments[]`, optional `dedicated_context`
-- `scheduler:create_planned_task`: `name`, `system_prompt`, `prompt`, optional `attachments[]`, `plan[]` iso datetimes like `2025-04-29T18:25:00`, optional `dedicated_context`
-- `scheduler:wait_for_task`: `uuid`; works for dedicated-context tasks
+Manage saved tasks and schedules. For complex task work, load skill `scheduled-tasks`.
+
+Actions: `list_tasks`, `find_task_by_name`, `show_task`, `run_task`, `update_task`, `delete_task`, `create_scheduled_task`, `create_adhoc_task`, `create_planned_task`, `wait_for_task`.
+
+Common args: `action`, `name`, `uuid`, `system_prompt`, `prompt`, `attachments`, `schedule`, `timezone`, `plan`, `dedicated_context`.
+
+Rules:
+- Before `create_*`, `update_task`, `delete_task`, or `run_task`, inspect existing tasks with `find_task_by_name` or `list_tasks`.
+- Do not run scheduled/planned tasks unless the user asks to run now.
+- Do not create recursive task prompts that schedule more tasks.
+- New tasks use a dedicated context unless `dedicated_context` is `false`.
+- Use `create_scheduled_task` for recurring/cron tasks; `schedule` must be cron fields, not an ISO datetime.
+- For one planned date/time, use `create_planned_task` with `plan: ["YYYY-MM-DDTHH:MM:SS"]`.
+- Use IANA timezones like `Europe/Rome`; include timezone when the user names a timezone.
+- For "tomorrow at 9:15 Rome time", scheduled shape is `schedule: {"minute":"15","hour":"9","day":"11","month":"5","weekday":"*","timezone":"Europe/Rome"}`.
+
 example:
 ~~~json
 {
   "thoughts": ["I should check for an existing task before I create or run anything."],
   "headline": "Looking up scheduled task",
-  "tool_name": "scheduler:find_task_by_name",
+  "tool_name": "scheduler",
   "tool_args": {
+    "action": "find_task_by_name",
     "name": "daily backup"
   }
 }

--- a/agent-zero/prompts/agent.system.tool.skills.md
+++ b/agent-zero/prompts/agent.system.tool.skills.md
@@ -1,18 +1,25 @@
 ### skills_tool
 use skills only when relevant
+actions: list search load read_file
+common args: action skill_name query file_path
 workflow:
-- `skills_tool:list`: discover available skills
-- `skills_tool:load`: load one skill by `skill_name`
+- action `search`: find candidate skills by keywords or trigger phrases from the current task
+- action `list`: discover available skills
+- action `load`: load one skill by `skill_name`
+- action `read_file`: open one file inside a loaded skill directory
+if the user says "find/search a skill", call `search` before `load` even when the likely skill name seems obvious
+`read_file` requires both `skill_name` and `file_path`; load the skill first, then read `SKILL.md` or the named relative file
 after loading a skill, follow its instructions and use referenced files or scripts with other tools
 reload a skill if its instructions are no longer in context
 example:
 ~~~json
 {
-  "thoughts": ["A skill may already encode the workflow I need."],
-  "headline": "Loading relevant skill",
-  "tool_name": "skills_tool:load",
+  "thoughts": ["The user's request sounds like a skill trigger phrase, so I should search first."],
+  "headline": "Searching for relevant skill",
+  "tool_name": "skills_tool",
   "tool_args": {
-    "skill_name": "playwright"
+    "action": "search",
+    "query": "set up a0 cli connector"
   }
 }
 ~~~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,10 @@ services:
 
   # ── Agent Zero: AI Agent Framework ──
   agent-zero:
-    # Custom image: extends agent0ai/agent-zero:v1.13 with weasyprint for the
+    # Custom image: extends agent0ai/agent-zero:v1.18 with weasyprint for the
     # local chat_pdf_export plugin. See agent-zero/Dockerfile.
     build: ./agent-zero
-    image: az-cliproxy-docker-agent-zero:v1.13-pdf
+    image: az-cliproxy-docker-agent-zero:v1.18-pdf
     container_name: agent-zero
     ports:
       - "50001:80"


### PR DESCRIPTION
Refs #135

## TL;DR

Agent Zero **v1.13 → v1.18**. 실제 손볼 곳은 **도구 호출 형식**(skills_tool·scheduler) 하나뿐이었고, 가장 어려울 줄 알았던 비용 추적은 건드릴 필요가 없었다. 격리 컨테이너에서 비용 추적·스킬·출력 모두 정상 확인.

## 왜 올리나

- **보안**: v1.15에 마크다운 렌더링 **XSS 수정** 포함 — 업그레이드의 가장 큰 명분.
- **이득**: v1.16 model preset **deep-merge**가 우리 `_model_config`와 잘 맞는다.
- 5버전이나 뒤처져 있어 더 벌어지기 전에 따라잡는다.

## 무엇이 바뀌나

| 영역 | 변경 |
|---|---|
| **이미지** | `Dockerfile` FROM v1.13 → v1.18, 태그 `v1.18-pdf`. weasyprint 레이어 그대로 |
| **버전 표기** | README 스펙표 · GUIDE 헤더 |
| **skills_tool** | 콜론(`skills_tool:load`) → `tool_args.action`. v1.18 정식 프롬프트로 교체(+`read_file` 액션) |
| **scheduler** | 같은 정규화(`scheduler:create_*` → `action`) |
| **skills.relevant.md** | 한국어 도메인 강제 프롬프트 — 형식만 수술 패치, 내용 유지 |

도구 형식 정규화는 v1.14의 `tool_args.action` 계약 변경에서 왔다. 우리 프롬프트가 옛 콜론 예시를 박아둬서 v1.18이 못 알아듣던 것.

## 비용 추적은 왜 안 건드렸나

이슈 #135에서 \"v1.18이 비용 추적 훅을 제거했다\"고 봤는데 **오진이었다**. v1.18 `agent.py`가 `chat_model_call_after`·`util_model_call_after`를 **동일 시그니처로 여전히 호출**한다(L827·L783). 우리 확장은 그대로 동작 → 재배선 불필요. (당시 \"번들 확장 파일이 없다\"를 \"훅이 없다\"로 착각.)

## 검증

격리 테스트 컨테이너(`:50002`)에서 확인. 라이브(`:50001`)는 안 건드렸다.

**비용 추적 — 단일 메시지 클린 테스트가 결정적:**
\`\`\`
\"2+2 는?\" → 답변 \"4\"
task JSON: llm=2 (haiku+sonnet) · cost=$0.0219 · 정상 기록
\`\`\`

| 항목 | 결과 |
|---|---|
| 이미지 빌드 (weasyprint) | ✅ |
| 컨테이너 부팅 | ✅ HTTP 200 |
| 새 형식 프롬프트 로드 | ✅ 콜론 0 |
| 확장 로드 | ✅ probe가 litellm 래핑 |
| 비용 추적 end-to-end | ✅ (위 클린 테스트) |
| 스킬 recall / 모델 호출 훅 | ✅ 발화 확인 |
| 라이브 settings.json | ✅ 무변경 |

> golden eval **배치** 통과율은 신뢰하지 않았다 — 러너의 task_report 상관 버그(**#137**, v1.18과 무관)가 빈 리포트를 케이스에 잘못 붙인다. 그래서 단일 메시지로 직접 확인했다.

## 범위 밖 (별건)

- **#137** — eval 러너 배치 상관 버그. 이번에 발견, 별도 수정.
- `settings.example.json`의 `browser_model_*`(v1.18 제거) · `stt_*`(v1.16 플러그인 분리) 키는 코어가 무시 → 무해. 문서 정리는 후속.

## Test plan

- [ ] 머지 후 `docker compose build agent-zero && docker compose up -d --force-recreate agent-zero`
- [ ] 폰에서 \"삼성전자 공시\" → k-dart 스킬 로딩 (#67 시나리오)
- [ ] `/today` 비용 추적 정상
- [ ] PDF 추출(전체/메시지별) + 생성 알림(#134)
- [ ] scheduler 태스크 1건 생성 (`action` 형식)