### PR TITLE
[Pricing] Claude 모델 라인업 대응 — stale alias 제거 + family-aware fallback (#141)

### DIFF
--- a/agent-zero/lib/pricing.py
+++ b/agent-zero/lib/pricing.py
@@ -43,19 +43,26 @@ _FALLBACK = {
     "cache_creation_input_token_cost": 0.00000375,  # $3.75 / 1M (25% premium)
 }
 
-# Common model-name aliases → canonical LiteLLM key. AZ sometimes prefixes
-# with "anthropic/" or uses shorthand like "claude-sonnet-4-6" when the
-# LiteLLM key is "claude-sonnet-4-20250929". Extend as needed.
-_ALIASES = {
-    "anthropic/claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
-    "claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
-    "anthropic/claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
-    "claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
-    "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
-    "claude-haiku-4-5": "claude-haiku-4-5-20251001",
-    "anthropic/claude-opus-4-5": "claude-opus-4-5-20250929",
-    "claude-opus-4-5": "claude-opus-4-5-20250929",
+# Anthropic family rates (input, output) per token, used when the LiteLLM
+# table is unavailable but the model name still tells us the tier (#141).
+# Without this, a table-load failure prices Opus 4.x at the flat $3/$15
+# fallback — a ~1.7x undercount ($5/$25 actual), and Fable 5 at ~3.3x off
+# ($10/$50 actual). Cache rates derive from input: read 0.1x, write 1.25x.
+_FAMILY_FALLBACK = {
+    "claude-fable": (0.00001, 0.00005),    # $10 / $50 per 1M
+    "claude-opus": (0.000005, 0.000025),   # $5 / $25
+    "claude-sonnet": (0.000003, 0.000015),  # $3 / $15
+    "claude-haiku": (0.000001, 0.000005),  # $1 / $5
 }
+
+# Model-name aliases → canonical LiteLLM key. Only needed when the LiteLLM
+# key differs from the AZ-side name after stripping the "anthropic/" prefix.
+# LiteLLM now keys every model AZ uses natively — bare names for the whole
+# lineup including claude-sonnet-4-6, claude-opus-4-6/7/8, claude-fable-5 —
+# so exact match + prefix strip covers everything. The old entries mapped
+# claude-sonnet-4-6 onto the dated 4-5 snapshot key, shadowing the native
+# key for prefixed forms (#141). Extend only for genuine key mismatches.
+_ALIASES: dict[str, str] = {}
 
 _PRICE_TABLE: dict = {}
 _LOADED = False
@@ -121,13 +128,29 @@ def _resolve_key(model: str | None) -> str | None:
     return None
 
 
+def _family_rates(model: str | None) -> dict | None:
+    """Tier-accurate rates from the model name when the table has no entry."""
+    if not model:
+        return None
+    name = model.split("/", 1)[1] if model.startswith("anthropic/") else model
+    for prefix, (in_rate, out_rate) in _FAMILY_FALLBACK.items():
+        if name.startswith(prefix):
+            return {
+                "input_cost_per_token": in_rate,
+                "output_cost_per_token": out_rate,
+                "cache_read_input_token_cost": in_rate * 0.10,
+                "cache_creation_input_token_cost": in_rate * 1.25,
+            }
+    return None
+
+
 def get_rates(model: str | None) -> dict:
     """Return the 4-rate dict for a model, falling back to `_FALLBACK`."""
     _ensure_loaded()
     key = _resolve_key(model)
     info = _PRICE_TABLE.get(key) if key else None
     if info is None:
-        return dict(_FALLBACK)
+        return _family_rates(model) or dict(_FALLBACK)
     # Anthropic entries may omit cache fields for models without prompt caching.
     # Default creation to input*1.25, read to input*0.1 per Anthropic's schedule.
     in_rate = info.get("input_cost_per_token", _FALLBACK["input_cost_per_token"])

--- a/docs/prompt-caching.md
+++ b/docs/prompt-caching.md
@@ -145,11 +145,11 @@ ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
     "chat_model_api_base": "",
 
     "util_model_provider": "anthropic",
-    "util_model_name": "claude-haiku-3.5-sonnet",
+    "util_model_name": "claude-haiku-4-5",
     "util_model_api_base": "",
 
     "browser_model_provider": "anthropic",
-    "browser_model_name": "claude-haiku-3.5-sonnet",
+    "browser_model_name": "claude-haiku-4-5",
     "browser_model_api_base": ""
 }
 ```

--- a/telegram-bridge/pricing/cost.py
+++ b/telegram-bridge/pricing/cost.py
@@ -70,27 +70,43 @@ def _load_model_cost_map() -> None:
     logger.warning("[Cost] Using fallback cost estimation")
 
 
+# Anthropic family rates (input, output) per token, used when the LiteLLM
+# table is unavailable but the model name still tells us the tier (#141).
+# Mirrors agent-zero/lib/pricing.py:_FAMILY_FALLBACK — keep in sync.
+_FAMILY_FALLBACK = {
+    "claude-fable": (0.00001, 0.00005),    # $10 / $50 per 1M
+    "claude-opus": (0.000005, 0.000025),   # $5 / $25
+    "claude-sonnet": (0.000003, 0.000015),  # $3 / $15
+    "claude-haiku": (0.000001, 0.000005),  # $1 / $5
+}
+
+
 def _model_info(model: str) -> dict:
     """Resolve a model name against the LiteLLM price map with AZ aliasing.
 
-    AZ tags streaming calls as "anthropic/claude-sonnet-4-6" but LiteLLM
-    keys them as "claude-sonnet-4-5-20250929". Try the exact key first,
-    then a few known aliases, then strip the `anthropic/` prefix.
+    LiteLLM carries native keys for the current Anthropic lineup
+    (claude-sonnet-4-6, claude-opus-4-6/7/8, claude-fable-5) as well as
+    bare legacy names, so exact match plus `anthropic/` prefix-strip
+    covers everything AZ emits. The old alias dict mapped
+    claude-sonnet-4-6 onto the dated 4-5 snapshot key, shadowing the
+    native key (#141).
     """
     if model in _model_cost_map:
         return _model_cost_map[model]
-    aliases = {
-        "anthropic/claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
-        "claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
-        "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
-    }
-    if model in aliases and aliases[model] in _model_cost_map:
-        return _model_cost_map[aliases[model]]
     if model.startswith("anthropic/"):
         tail = model.split("/", 1)[1]
         if tail in _model_cost_map:
             return _model_cost_map[tail]
     return {}
+
+
+def _family_rates(model: str) -> tuple[float, float] | None:
+    """Tier-accurate (input, output) rates from the model name alone."""
+    name = model.split("/", 1)[1] if model.startswith("anthropic/") else model
+    for prefix, rates in _FAMILY_FALLBACK.items():
+        if name.startswith(prefix):
+            return rates
+    return None
 
 
 def calc_cost(
@@ -118,8 +134,10 @@ def calc_cost(
     Same fix lives in agent-zero/lib/pricing.py:compute_cost.
     """
     info = _model_info(model)
-    in_rate = info.get("input_cost_per_token", 0.000003)  # $3 / 1M fallback
-    out_rate = info.get("output_cost_per_token", 0.000015)  # $15 / 1M
+    family = _family_rates(model) if not info else None
+    fb_in, fb_out = family or (0.000003, 0.000015)  # generic $3/$15 last resort
+    in_rate = info.get("input_cost_per_token", fb_in)
+    out_rate = info.get("output_cost_per_token", fb_out)
     read_rate = info.get("cache_read_input_token_cost", in_rate * 0.10)
     create_rate = info.get("cache_creation_input_token_cost", in_rate * 1.25)
     inp = max(0, int(input_tokens))

--- a/telegram-bridge/pricing/snapshot.py
+++ b/telegram-bridge/pricing/snapshot.py
@@ -62,14 +62,12 @@ def _resolve_litellm_key(model: str) -> str | None:
         return None
     if model in _model_cost_map:
         return model
-    aliases = {
-        "anthropic/claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
-        "claude-sonnet-4-6": "claude-sonnet-4-5-20250929",
-        "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
-        "claude-haiku-4-5": "claude-haiku-4-5-20251001",
-    }
-    if model in aliases and aliases[model] in _model_cost_map:
-        return aliases[model]
+    # LiteLLM now keys the whole lineup natively (claude-sonnet-4-6,
+    # claude-opus-4-6/7/8, claude-fable-5, bare legacy names) — exact
+    # match + prefix strip resolves every AZ form to ONE canonical key.
+    # The old alias dict sent prefixed forms to dated snapshot keys while
+    # bare forms exact-matched native keys, splitting one model across
+    # two snapshot identifiers (#141).
     if model.startswith("anthropic/"):
         tail = model.split("/", 1)[1]
         if tail in _model_cost_map:
@@ -236,7 +234,7 @@ def _format_pricing_diff(changes: list[dict], prev_date: str, curr_date: str) ->
 
     Shape:
       💱 가격 변동 감지 (2026-04-27 → 2026-04-28)
-        claude-sonnet-4-5-20250929 (claude-sonnet-4-6)
+        claude-sonnet-4-6 (anthropic/claude-sonnet-4-6)
           input_cost_per_token: $3.00 → $2.50 / 1M (-16.7%)
     """
     def fmt_rate(v) -> str:

--- a/tests/test_bridge_cost.py
+++ b/tests/test_bridge_cost.py
@@ -91,3 +91,42 @@ def test_normalize_model_strips_anthropic_prefix(cost):
     assert cost._normalize_model("claude-sonnet-4-6") == "claude-sonnet-4-6"
     assert cost._normalize_model("") == ""
     assert cost._normalize_model(None) is None  # type: ignore[arg-type]
+
+
+# ── family-aware fallback (#141) ────────────────────────────────────
+# With the LiteLLM map empty (fetch failed / not yet loaded), Anthropic
+# models price by family tier instead of the flat $3/$15 fallback —
+# which undercounted Opus ~1.7x ($5/$25 actual) and Fable 5 ~3.3x
+# ($10/$50 actual).
+
+
+def test_family_fallback_opus(cost):
+    cost._model_cost_map.clear()
+    c = cost.calc_cost("claude-opus-4-8", 1_000_000, 1_000_000)
+    assert c == pytest.approx(5.0 + 25.0, rel=1e-9)
+
+
+def test_family_fallback_fable_with_prefix(cost):
+    cost._model_cost_map.clear()
+    c = cost.calc_cost("anthropic/claude-fable-5", 1_000_000, 1_000_000)
+    assert c == pytest.approx(10.0 + 50.0, rel=1e-9)
+
+
+def test_family_fallback_cache_rates_derive_from_input(cost):
+    """Cache rates derive from the family input rate: read 0.1x, write 1.25x."""
+    cost._model_cost_map.clear()
+    c = cost.calc_cost(
+        "claude-opus-4-8",
+        input_tokens=2_000_000,
+        output_tokens=0,
+        cache_read_tokens=1_000_000,
+        cache_creation_tokens=1_000_000,
+    )
+    # regular = 0; read 1M * $0.50/1M + write 1M * $6.25/1M
+    assert c == pytest.approx(0.5 + 6.25, rel=1e-9)
+
+
+def test_family_fallback_not_applied_to_unknown_models(cost):
+    cost._model_cost_map.clear()
+    c = cost.calc_cost(FALLBACK_MODEL, 1_000_000, 1_000_000)
+    assert c == pytest.approx(3.0 + 15.0, rel=1e-9)  # generic fallback intact

--- a/tests/test_bridge_pricing_snapshot.py
+++ b/tests/test_bridge_pricing_snapshot.py
@@ -84,18 +84,20 @@ def snap(tmp_path):
 # ── _resolve_litellm_key ────────────────────────────────────────────
 
 
-def test_resolve_litellm_key_known_alias(snap):
-    """When the canonical key exists in the cost map, alias maps to it."""
+def test_resolve_litellm_key_native_key(snap):
+    """Both AZ forms resolve to the ONE native LiteLLM key (#141).
+
+    The old alias map sent prefixed forms to the dated 4-5 snapshot key
+    while bare forms exact-matched the native key, splitting one model
+    across two snapshot identifiers.
+    """
     snap._model_cost_map.clear()
-    snap._model_cost_map.update({"claude-sonnet-4-5-20250929": {}})
+    snap._model_cost_map.update({"claude-sonnet-4-6": {}})
     assert (
         snap._resolve_litellm_key("anthropic/claude-sonnet-4-6")
-        == "claude-sonnet-4-5-20250929"
+        == "claude-sonnet-4-6"
     )
-    assert (
-        snap._resolve_litellm_key("claude-sonnet-4-6")
-        == "claude-sonnet-4-5-20250929"
-    )
+    assert snap._resolve_litellm_key("claude-sonnet-4-6") == "claude-sonnet-4-6"
 
 
 def test_resolve_litellm_key_strip_anthropic_prefix(snap):
@@ -299,7 +301,7 @@ def test_interested_models_from_task_jsons(snap, tmp_path):
     """End-to-end of the task→model rollup. Writes fake task JSON,
     reads it through `_load_task_jsons`, expects a {key: aliases} map."""
     snap._model_cost_map.clear()
-    snap._model_cost_map.update({"claude-sonnet-4-5-20250929": {}})
+    snap._model_cost_map.update({"claude-sonnet-4-6": {}})
 
     # Set up task dir matching `agg_mod.TASKS_DIR`.
     from datetime import datetime, timedelta, timezone
@@ -321,9 +323,10 @@ def test_interested_models_from_task_jsons(snap, tmp_path):
     (tasks_dir / "t1.json").write_text(json.dumps(payload), encoding="utf-8")
 
     out = snap._interested_models(window_days=7)
-    # Only the resolvable model surfaces; both aliases (sorted) are kept.
-    assert list(out.keys()) == ["claude-sonnet-4-5-20250929"]
-    assert out["claude-sonnet-4-5-20250929"] == [
+    # Only the resolvable model surfaces; both aliases (sorted) are kept
+    # under the ONE native LiteLLM key (#141).
+    assert list(out.keys()) == ["claude-sonnet-4-6"]
+    assert out["claude-sonnet-4-6"] == [
         "anthropic/claude-sonnet-4-6",
         "claude-sonnet-4-6",
     ]

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -104,3 +104,34 @@ def test_format_usd_breakpoints(pricing):
     assert pricing.format_usd(1.2345) == "$1.2345"          # >= 0.01 → 4dp
     assert pricing.format_usd(0.001234) == "$0.001234"      # >= 0.0001 → 6dp
     assert pricing.format_usd(0.000005) == "$5.00e-06"      # otherwise scientific
+
+
+# ── family-aware fallback (#141) ────────────────────────────────────
+
+
+def _load_pricing_offline():
+    """Fresh module with the price table forced empty — exercises the
+    fallback paths deterministically, no network."""
+    mod = _load_pricing()
+    mod._LOADED = True  # skip remote/bundled load; _PRICE_TABLE stays {}
+    return mod
+
+
+def test_family_fallback_rates_offline():
+    """With no price table, Anthropic models price by family tier instead
+    of the flat $3/$15 fallback (Opus would be ~1.7x under, Fable ~3.3x)."""
+    pricing = _load_pricing_offline()
+    opus = pricing.get_rates("claude-opus-4-8")
+    assert opus["input_cost_per_token"] == pytest.approx(5e-6)
+    assert opus["output_cost_per_token"] == pytest.approx(25e-6)
+    fable = pricing.get_rates("anthropic/claude-fable-5")  # prefix stripped
+    assert fable["input_cost_per_token"] == pytest.approx(10e-6)
+    assert fable["output_cost_per_token"] == pytest.approx(50e-6)
+    # Cache rates derive from family input rate: read 0.1x, write 1.25x.
+    assert fable["cache_read_input_token_cost"] == pytest.approx(1e-6)
+    assert fable["cache_creation_input_token_cost"] == pytest.approx(12.5e-6)
+
+
+def test_family_fallback_not_applied_to_unknown_models():
+    pricing = _load_pricing_offline()
+    assert pricing.get_rates("model-that-does-not-exist-xyz") == pricing._FALLBACK


### PR DESCRIPTION
Closes #141

**TL;DR**: Claude 신모델 라인업(Opus 4.6/4.7/4.8, Fable 5) 대응 — stale alias 3곳 제거 + 테이블 미적재 시 모델 패밀리별 fallback 요율 적용. 동작 변경은 가격 계산/스냅샷 키 경로에 한정.

## Why

- LiteLLM 가격 테이블에 현행 라인업 **네이티브 키가 모두 등재**됨 (`claude-sonnet-4-6`, `claude-opus-4-6/7/8`, `claude-fable-5` — 2026-06-10 확인). 기존 alias는 `claude-sonnet-4-6`을 구키 `claude-sonnet-4-5-20250929`로 강제 매핑해 prefixed 형태가 네이티브 키를 못 타고, 스냅샷 canonical key가 형태별로 분열
- LiteLLM 페치 실패 시 **flat $3/$15 fallback** — Opus 4.x($5/$25)는 ~1.7배, Fable 5($10/$50)는 ~3.3배 과소계산

## What changed

| 파일 | 변경 |
|---|---|
| `agent-zero/lib/pricing.py` | **alias 맵 비움** (exact match + prefix-strip으로 전부 해석됨) + `_FAMILY_FALLBACK` 추가 |
| `telegram-bridge/pricing/cost.py` | 동일 — alias 제거 + family fallback (`/track`·`/today` 경로) |
| `telegram-bridge/pricing/snapshot.py` | alias 제거 — 스냅샷 키가 모델당 1개로 통일 |
| `docs/prompt-caching.md` | 존재하지 않는 `claude-haiku-3.5-sonnet` → `claude-haiku-4-5` |
| tests 3개 | alias 테스트를 네이티브 키 기준으로 갱신 + family fallback 테스트 9건 추가 |

- **Family fallback 요율** (per 1M, input/output): fable $10/$50 · opus $5/$25 · sonnet $3/$15 · haiku $1/$5, cache read 0.1×·write 1.25× 파생. 비-Anthropic 모델은 기존 $3/$15 유지
- 부수 발견: 기존 opus-4-5 alias가 존재하지 않는 키(`claude-opus-4-5-20250929`)를 가리키고 있었음 — alias 제거로 함께 해소

## Verification

```
python -m pytest tests -q          # 375 passed
python -m ruff check <변경 파일>    # All checks passed
```

## 참고

- 스냅샷 canonical key가 dated → 네이티브로 바뀌므로, 다음 가격 드리프트 스냅샷에서 구키 항목은 자연 소멸하고 신키로 새로 쌓임 (가격 비교는 동일 키끼리만 수행되어 오탐 없음)

## Test plan

- [ ] CI 통과
- [ ] 배포 후 `/today` 비용이 Anthropic Console과 일치하는지 확인
- [ ] LiteLLM 페치 실패 로그 발생 시 Opus/Fable 비용이 family 요율로 잡히는지 확인
