### PR TITLE
[Config] settings.example.json temperature kwargs 제거 — Fable 5 / Opus 4.7+ 호환 (#143)

### DIFF
--- a/agent-zero/settings.example.json
+++ b/agent-zero/settings.example.json
@@ -1,13 +1,12 @@
 {
     "_comment_provider": "프로바이더 선택: anthropic (권장, 프롬프트 캐싱 지원), openai, other (CLIProxy 등)",
+    "_comment_kwargs": "*_model_kwargs는 비워둘 것 — Fable 5/Opus 4.7+는 sampling 파라미터(temperature, top_p, top_k)를 400으로 거부한다 (#143). 구모델도 temperature 생략 시 기본값으로 동작.",
 
     "version": "v0.9.3",
     "chat_model_provider": "anthropic",
     "chat_model_name": "claude-sonnet-4-6",
     "chat_model_api_base": "",
-    "chat_model_kwargs": {
-        "temperature": "0"
-    },
+    "chat_model_kwargs": {},
     "chat_model_ctx_length": 50000,
     "chat_model_ctx_history": 0.5,
     "chat_model_vision": true,
@@ -19,9 +18,7 @@
     "util_model_api_base": "",
     "util_model_ctx_length": 100000,
     "util_model_ctx_input": 0.7,
-    "util_model_kwargs": {
-        "temperature": "0"
-    },
+    "util_model_kwargs": {},
     "util_model_rl_requests": 0,
     "util_model_rl_input": 0,
     "util_model_rl_output": 0,
@@ -35,9 +32,7 @@
     "browser_model_name": "claude-haiku-4-5",
     "browser_model_api_base": "",
     "browser_model_vision": true,
-    "browser_model_kwargs": {
-        "temperature": "0"
-    },
+    "browser_model_kwargs": {},
     "memory_recall_enabled": true,
     "memory_recall_interval": 5,
     "memory_recall_history_len": 10000,


### PR DESCRIPTION
Closes #143

**TL;DR**: `settings.example.json` 템플릿 3곳(chat/util/browser)의 `"temperature": "0"` kwargs 제거. Fable 5 / Opus 4.7+는 sampling 파라미터를 400으로 거부하므로, 이 템플릿으로 부트스트랩한 환경에서 모델 전환 시 터지는 footgun 제거.

## Why

- **Fable 5 / Opus 4.7+** 는 `temperature`/`top_p`/`top_k`를 받으면 400 에러 (Anthropic API breaking change)
- 라이브 런타임(`usr-plugins/_model_config/config.json`)은 이미 `kwargs: {}`라 **현재 운영 영향 없음** — 신규 셋업·템플릿 복원 경로만 해당
- 구모델(Sonnet 4.6 등)도 temperature 생략 시 provider 기본값으로 동작 → 제거 무해

## What changed

- `agent-zero/settings.example.json`: `chat_model_kwargs` / `util_model_kwargs` / `browser_model_kwargs` → `{}`
- 템플릿 상단에 `_comment_kwargs` 한 줄 추가 — 향후 편집 시 제약이 살아남도록

## Verification

```
python -c "import json; json.load(open('agent-zero/settings.example.json'))"  # valid json
python -m pytest tests -q   # 375 passed
```

## Test plan

- [ ] CI 통과
