### PR TITLE
feat: Agent Zero v1.18 → v1.20 업그레이드

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ agent-zero/logs/
 # Agent Zero runtime data
 agent-zero/work_dir/
 agent-zero/memory/
+# Upstream-generated DOX doc copied into the mounted prompts dir on boot
+# (v1.19+). Not our override — ignore so it doesn't pollute git status.
+agent-zero/prompts/AGENTS.md
 
 # Backups (contain secrets)
 backups/

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,6 +1,6 @@
 # Agent Zero + CLIProxy 구축 가이드
 
-> Agent Zero v1.18 | CLIProxy v6.9.18 | Telegram Bridge (custom)
+> Agent Zero v1.20 | CLIProxy v6.9.18 | Telegram Bridge (custom)
 
 이 문서는 [README.md](README.md) 를 읽었다는 가정 하에, 신규 사용자가 부팅까지
 실수 없이 도달하기 위한 **walkthrough** 입니다. README 가 "이 저장소가 무엇을

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ API 에 직접 연결하는 경로, **Track B (CLIProxy)** 는 공식 CLI 의 OA
 
 | Component | Version | Image / Detail |
 |-----------|---------|----------------|
-| Agent Zero | v1.18 | `agent0ai/agent-zero:v1.18` |
+| Agent Zero | v1.20 | `agent0ai/agent-zero:v1.20` |
 | CLIProxy | v6.9.18 | `eceasy/cli-proxy-api:v6.9.18` |
 | Telegram Bridge | custom | `python:3.12-slim` 기반 |
 | LiteLLM | 1.79.3 | Agent Zero 내장 |

--- a/agent-zero/Dockerfile
+++ b/agent-zero/Dockerfile
@@ -7,6 +7,6 @@
 # Bumping the base image: edit the FROM line and rebuild
 # (`docker compose build agent-zero`).
 
-FROM agent0ai/agent-zero:v1.18
+FROM agent0ai/agent-zero:v1.20
 
 RUN /opt/venv-a0/bin/pip install --no-cache-dir --disable-pip-version-check weasyprint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,10 @@ services:
 
   # ── Agent Zero: AI Agent Framework ──
   agent-zero:
-    # Custom image: extends agent0ai/agent-zero:v1.18 with weasyprint for the
+    # Custom image: extends agent0ai/agent-zero:v1.20 with weasyprint for the
     # local chat_pdf_export plugin. See agent-zero/Dockerfile.
     build: ./agent-zero
-    image: az-cliproxy-docker-agent-zero:v1.18-pdf
+    image: az-cliproxy-docker-agent-zero:v1.20-pdf
     container_name: agent-zero
     ports:
       - "50001:80"


### PR DESCRIPTION
업스트림 v1.18 → **v1.20**(v1.19 건너뜀). 변경의 무게중심(OAuth / Remote Control 대수술)은 우리가 안 쓰는 영역이고, 우리 커스텀 통합(task-report hook, skill-recall override, `_model_config` persist 마운트)은 라이브에서 전부 정상 동작 확인했다.

## Why

- v1.18에 올린 지 얼마 안 됐지만 그 사이 v1.19·v1.20 두 버전이 더 나옴
- 직전 업그레이드(#138, v1.13 → v1.18)와 동일 패턴

## 변경 사항

| 파일 | 변경 |
|---|---|
| `agent-zero/Dockerfile` | `FROM agent0ai/agent-zero` v1.18 → v1.20 |
| `docker-compose.yml` | 이미지 태그 `v1.18-pdf` → `v1.20-pdf` + 주석 |
| `README.md` / `GUIDE.md` | 버전 배너 |
| `.gitignore` | `agent-zero/prompts/AGENTS.md` 무시 (v1.19+ 업스트림 자동 생성 Prompts DOX, 부팅마다 재생성 — 우리 override 아님) |

## 영향범위 (사전 대조)

- **skill-recall override** (`_63_recall_relevant_skills.py`): 업스트림 SHA가 v1.18↔v1.20 동일 → 우리 override 베이스 그대로
- **usage 추적 hook**: `chat_model_call_after`·`util_model_call_after` 호출부 v1.20 `agent.py`에 여전히 존재
- **`_model_config` 폴백 오타**: v1.20 `default_config.yaml`에도 `claude-sonnet-4.6`(점) 오타 그대로 → `config.json` persist 마운트 여전히 필수
- **OAuth / Remote Control / document_query 분리**: 우리는 cliproxy + API key 방식, PDF는 별도 `chat_pdf_export` → 무관

## Verification

라이브 컨테이너 재생성 후 스모크 + end-to-end 1건 실행, 전부 통과.

| 항목 | 결과 |
|---|---|
| 이미지 빌드 | exit 0, `weasyprint 69.0` import OK |
| 모델 persist | override `claude-sonnet-4-6`(점 없음) → 404 폴백 회피 |
| skill recall | override 로드 + 220→400 truncate 패치 유지 |
| UI | 호스트 `:50001` HTTP 200, supervisor 전 프로세스 RUNNING |
| CSRF/origin | v1.20 강화된 origin 검증에도 브릿지 origin 정상 수용 (회귀 없음) |

end-to-end (`message_async` → `PONG` 응답 → task JSON 생성):

```
"llm_calls": [
  {"model": "claude-haiku-4-5",  "input_tokens": 343,   "output_tokens": 6,   "cost_usd": 0.000373},
  {"model": "claude-sonnet-4-6", "input_tokens": 26739, "output_tokens": 124, "cache_creation_tokens": 25631, "cost_usd": 0.1013}
]
"ended_reason": "completed", "final_response": "PONG"
```

→ util/chat hook 양쪽 캡처, cache 필드(`cache_creation_tokens`)·per-call `cost_usd` 정상.

## Test plan

- [x] `docker compose build agent-zero` 성공
- [x] v1.20 컨테이너 라이브 재생성 + 부팅 traceback 0
- [x] 모델 override / usage 추적 / PDF dep / skill recall 스모크
- [x] end-to-end 메시지 1건 → task JSON cost 캡처
- [ ] 머지 후 main 배포 dir: `git checkout -- docker-compose.yml && git pull` 로 임시 태그 편집 정리

## 비고

- `cliproxy`가 `unhealthy` 표시지만 `/v1/models` HTTP 200 — 헬스체크 false-negative(기존, 이번 변경 무관)
