### PR TITLE
[Bug] AZ 학습 메모리 영속화 — 메모리 마운트를 /a0/usr/memory로 교정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,10 @@ services:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
     volumes:
       - ./agent-zero/work_dir:/a0/work_dir
-      - ./agent-zero/memory:/a0/memory
+      # AZ v1.x writes memory/index to /a0/usr/memory (usr-area split, ~v1.13),
+      # not /a0/memory. Mounting the old path left learned memory in the
+      # container-local layer → wiped on every recreate/upgrade (issue #146).
+      - ./agent-zero/memory:/a0/usr/memory
       - ./agent-zero/logs:/a0/logs
       - ./agent-zero/prompts:/a0/prompts
       - ./agent-zero/git-init.sh:/a0/git-init.sh:ro


### PR DESCRIPTION
AZ 학습 메모리가 컨테이너 재생성마다 휘발되던 문제를 마운트 경로 교정으로 해결한다. 원인·근거는 #146 참고.

## Why

Agent Zero v1.x는 메모리 + 벡터 색인을 **`/a0/usr/memory`**(`/a0/usr/` 사용자 영역 분리, ~v1.13)에 쓰는데, compose 마운트는 옛 경로 `/a0/memory`를 가리키고 있었다. 그래서:

- 호스트에 연결된 `/a0/memory`는 **항상 비어 있고**, 실데이터는 컨테이너 로컬 `/a0/usr/memory`에 쌓임
- `--force-recreate` / 이미지 업그레이드마다 그 데이터가 **소실**
- 지식 색인은 파일에서 재빌드되니 무해하지만, `memorize_fragments`/`memorize_solutions`로 자동 저장되는 **학습 메모리(기본 활성)는 영구 손실**
- 지식베이스는 멀쩡해 보이고 메모리 손실은 조용해서 그동안 안 드러남

## What changed

`docker-compose.yml` 마운트 한 줄 (컨테이너 측 타겟만 변경):

```diff
- ./agent-zero/memory:/a0/memory
+ ./agent-zero/memory:/a0/usr/memory
```

**호스트 경로(`agent-zero/memory`)는 그대로**라 `.gitignore` / `scripts/backup.sh` / eval 워크플로는 변경 없이 그대로 동작한다 (오히려 이제 실데이터를 잡게 됨).

## Verification

배포 환경에서 실제 영속 검증:

```
# 1) 새 마운트로 recreate → 마운트 정상
host\agent-zero\memory  ->  /a0/usr/memory   ✅

# 2) 컨테이너 안에 sentinel 기록 → 호스트에 즉시 반영 (양방향 bind)
$ docker exec agent-zero sh -c 'echo ... > /a0/usr/memory/PERSIST_TEST.txt'
$ cat agent-zero/memory/PERSIST_TEST.txt   # 호스트에서 보임 ✅

# 3) docker compose up -d --force-recreate (버그 재현 지점)
# 4) 재생성 후 sentinel 확인
persist-test-146 ...   ✅ 재생성 넘어 영속됨
```

수정 전이었다면 3)에서 사라졌을 데이터다.

## Test plan

- [x] 새 마운트로 `--force-recreate` 후 UI HTTP 200 정상 기동
- [x] 호스트 `agent-zero/memory/` ↔ 컨테이너 `/a0/usr/memory` 양방향 bind 확인
- [x] sentinel이 `--force-recreate` 넘어 영속됨 (핵심)
- [x] 테스트 잔여물 정리

Fixes #146
